### PR TITLE
adds skip_waiting_for_build_processing to upload_to_testflight

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,6 +48,8 @@ platform :ios do
     )
 
     build_app(scheme: "AppStore")
-    upload_to_testflight
+    upload_to_testflight(
+      skip_waiting_for_build_processing: true
+    )
   end
 end


### PR DESCRIPTION
adds skip_waiting_for_build_processing to upload_to_testflight to avoid Circle CI job failures due to timeout waiting for the app store to process the build