### PR TITLE
Adding predictive text foundation

### DIFF
--- a/EyeSpeak.xcodeproj/project.pbxproj
+++ b/EyeSpeak.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		A92FFB8F23ECD6F200AF2D0B /* HotCorners.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A92FFB8E23ECD6F200AF2D0B /* HotCorners.storyboard */; };
 		A98E8A2323F1DBDF00BF1F22 /* SettingsFooterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98E8A2223F1DBDF00BF1F22 /* SettingsFooterCollectionViewCell.swift */; };
 		A98E8A2523F1DBF200BF1F22 /* SettingsFooterCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A98E8A2423F1DBF200BF1F22 /* SettingsFooterCollectionViewCell.xib */; };
+		A9DE16FE23F48FD30094DB64 /* TextPredictionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DE16FD23F48FD30094DB64 /* TextPredictionController.swift */; };
+		A9DE170023F4900C0094DB64 /* TextExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DE16FF23F4900C0094DB64 /* TextExpression.swift */; };
 		A9DF00FA23E38DB00072C7E1 /* PageControlReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF00F923E38DB00072C7E1 /* PageControlReusableView.swift */; };
 		B879831123E0CEC300DC1A81 /* PresetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B879831023E0CEC300DC1A81 /* PresetsViewController.swift */; };
 		B879831523E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */; };
@@ -93,6 +95,8 @@
 		A92FFB8E23ECD6F200AF2D0B /* HotCorners.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = HotCorners.storyboard; sourceTree = "<group>"; };
 		A98E8A2223F1DBDF00BF1F22 /* SettingsFooterCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFooterCollectionViewCell.swift; sourceTree = "<group>"; };
 		A98E8A2423F1DBF200BF1F22 /* SettingsFooterCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsFooterCollectionViewCell.xib; sourceTree = "<group>"; };
+		A9DE16FD23F48FD30094DB64 /* TextPredictionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPredictionController.swift; sourceTree = "<group>"; };
+		A9DE16FF23F4900C0094DB64 /* TextExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextExpression.swift; sourceTree = "<group>"; };
 		A9DF00F923E38DB00072C7E1 /* PageControlReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageControlReusableView.swift; sourceTree = "<group>"; };
 		B879831023E0CEC300DC1A81 /* PresetsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresetsViewController.swift; sourceTree = "<group>"; };
 		B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetItemCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -210,6 +214,8 @@
 			children = (
 				6B17CD7B23E9DFD50050BCB8 /* AVSpeechSynthesizer+Shared.swift */,
 				B8DA9DF323F30BD200FEBE19 /* VectorUtils.swift */,
+				A9DE16FD23F48FD30094DB64 /* TextPredictionController.swift */,
+				A9DE16FF23F4900C0094DB64 /* TextExpression.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -445,6 +451,7 @@
 				B8DA9DEC23EB8FB900FEBE19 /* CategorySectionBackground.swift in Sources */,
 				6B9DFA7623E8D59A0037673E /* UICollectionView+Gaze.swift in Sources */,
 				6B9DFA7023E88A630037673E /* InterpolableValues.swift in Sources */,
+				A9DE16FE23F48FD30094DB64 /* TextPredictionController.swift in Sources */,
 				6B9DFA5D23E889DB0037673E /* UIHeadGaze.swift in Sources */,
 				6B9DFA6F23E88A610037673E /* Interpolation.swift in Sources */,
 				130C00B820D2AD2A007C3163 /* AppDelegate.swift in Sources */,
@@ -454,6 +461,7 @@
 				A92FFB8D23ECCB5400AF2D0B /* SettingsViewController.swift in Sources */,
 				B879831523E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift in Sources */,
 				6B9DFA5F23E889DB0037673E /* UIHeadGazeEvent.swift in Sources */,
+				A9DE170023F4900C0094DB64 /* TextExpression.swift in Sources */,
 				6B9DFA5B23E889DB0037673E /* UIHeadGazeViewController.swift in Sources */,
 				A98E8A2323F1DBDF00BF1F22 /* SettingsFooterCollectionViewCell.swift in Sources */,
 				6B9DFA6223E889DB0037673E /* UIVirtualCursorView.swift in Sources */,

--- a/EyeSpeak.xcodeproj/project.pbxproj
+++ b/EyeSpeak.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		A98E8A2523F1DBF200BF1F22 /* SettingsFooterCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A98E8A2423F1DBF200BF1F22 /* SettingsFooterCollectionViewCell.xib */; };
 		A9DE16FE23F48FD30094DB64 /* TextPredictionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DE16FD23F48FD30094DB64 /* TextPredictionController.swift */; };
 		A9DE170023F4900C0094DB64 /* TextExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DE16FF23F4900C0094DB64 /* TextExpression.swift */; };
+		A9DE170223F492B20094DB64 /* Array+Split.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DE170123F492B20094DB64 /* Array+Split.swift */; };
+		A9DE170623F4C0AF0094DB64 /* TextPrediction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DE170523F4C0AF0094DB64 /* TextPrediction.swift */; };
 		A9DF00FA23E38DB00072C7E1 /* PageControlReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF00F923E38DB00072C7E1 /* PageControlReusableView.swift */; };
 		B879831123E0CEC300DC1A81 /* PresetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B879831023E0CEC300DC1A81 /* PresetsViewController.swift */; };
 		B879831523E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */; };
@@ -97,6 +99,8 @@
 		A98E8A2423F1DBF200BF1F22 /* SettingsFooterCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsFooterCollectionViewCell.xib; sourceTree = "<group>"; };
 		A9DE16FD23F48FD30094DB64 /* TextPredictionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPredictionController.swift; sourceTree = "<group>"; };
 		A9DE16FF23F4900C0094DB64 /* TextExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextExpression.swift; sourceTree = "<group>"; };
+		A9DE170123F492B20094DB64 /* Array+Split.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Split.swift"; sourceTree = "<group>"; };
+		A9DE170523F4C0AF0094DB64 /* TextPrediction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPrediction.swift; sourceTree = "<group>"; };
 		A9DF00F923E38DB00072C7E1 /* PageControlReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageControlReusableView.swift; sourceTree = "<group>"; };
 		B879831023E0CEC300DC1A81 /* PresetsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresetsViewController.swift; sourceTree = "<group>"; };
 		B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetItemCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -216,6 +220,7 @@
 				B8DA9DF323F30BD200FEBE19 /* VectorUtils.swift */,
 				A9DE16FD23F48FD30094DB64 /* TextPredictionController.swift */,
 				A9DE16FF23F4900C0094DB64 /* TextExpression.swift */,
+				A9DE170123F492B20094DB64 /* Array+Split.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -299,6 +304,7 @@
 			children = (
 				B8DA9DFD23F3407000FEBE19 /* TextPresets.swift */,
 				B8B779E823F34A7B00FEE660 /* KeyboardKeyGroup.swift */,
+				A9DE170523F4C0AF0094DB64 /* TextPrediction.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -446,12 +452,14 @@
 				6B9DFA6E23E88A5F0037673E /* LowPassInterpolator.swift in Sources */,
 				6B9DFA7423E8D1270037673E /* TrackingContainerViewController.swift in Sources */,
 				6B17CD7E23E9F85F0050BCB8 /* HotCornerOverlayViewController.swift in Sources */,
+				A9DE170623F4C0AF0094DB64 /* TextPrediction.swift in Sources */,
 				B8DA9DF023EDECEE00FEBE19 /* AppConfig.swift in Sources */,
 				B8B779E923F34A7B00FEE660 /* KeyboardKeyGroup.swift in Sources */,
 				B8DA9DEC23EB8FB900FEBE19 /* CategorySectionBackground.swift in Sources */,
 				6B9DFA7623E8D59A0037673E /* UICollectionView+Gaze.swift in Sources */,
 				6B9DFA7023E88A630037673E /* InterpolableValues.swift in Sources */,
 				A9DE16FE23F48FD30094DB64 /* TextPredictionController.swift in Sources */,
+				A9DE170223F492B20094DB64 /* Array+Split.swift in Sources */,
 				6B9DFA5D23E889DB0037673E /* UIHeadGaze.swift in Sources */,
 				6B9DFA6F23E88A610037673E /* Interpolation.swift in Sources */,
 				130C00B820D2AD2A007C3163 /* AppDelegate.swift in Sources */,

--- a/EyeSpeak/Features/Presets/Models/TextPrediction.swift
+++ b/EyeSpeak/Features/Presets/Models/TextPrediction.swift
@@ -1,0 +1,14 @@
+//
+//  PredictiveText.swift
+//  EyeSpeak
+//
+//  Created by Jesse Morgan on 2/12/20.
+//  Copyright © 2020 WillowTree. All rights reserved.
+//
+
+import Foundation
+
+struct TextPrediction: Hashable {
+    let text: String
+    let id = UUID()
+}

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -105,7 +105,7 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
     }
     
     static func predictiveTextSectionLayout() -> NSCollectionLayoutSection {
-        let numOfItems = CGFloat(5)
+        let numOfItems = CGFloat(4)
         
         let predictiveTextItem = NSCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1 / numOfItems),

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -26,7 +26,7 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
         attr?.transform = CGAffineTransform(translationX: 0, y: 500.0)
         return attr
     }
-    
+
     override func finalLayoutAttributesForDisappearingItem(at itemIndexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
         let attr = super.finalLayoutAttributesForDisappearingItem(at: itemIndexPath)
         // Make animation only happen for preset items
@@ -83,25 +83,38 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
     }
     
     static func categoriesSectionLayout() -> NSCollectionLayoutSection {
-        let category1Item = NSCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(262.0 / 1048.0),
-                                               heightDimension: .fractionalHeight(1.0)))
-        let category2Item = NSCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(262.0 / 1048.0),
-                                               heightDimension: .fractionalHeight(1.0)))
-        let category3Item = NSCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(262.0 / 1048.0),
-                                               heightDimension: .fractionalHeight(1.0)))
-        let category4Item = NSCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(262.0 / 1048.0),
-                                               heightDimension: .fractionalHeight(1.0)))
+        let numOfItems = CGFloat(4)
         
-        let subitems = [category1Item, category2Item, category3Item, category4Item]
+        let categoryItem = NSCollectionLayoutItem(
+            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1 / numOfItems),
+                                               heightDimension: .fractionalHeight(1.0)))
         
         let containerGroup = NSCollectionLayoutGroup.horizontal(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                heightDimension: .fractionalHeight(137.0 / totalHeight)),
-            subitems: subitems)
+            subitem: categoryItem, count: Int(numOfItems))
+        containerGroup.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
+        let section = NSCollectionLayoutSection(group: containerGroup)
+        
+        let backgroundDecoration = NSCollectionLayoutDecorationItem.background(elementKind: "CategorySectionBackground")
+        backgroundDecoration.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 32, bottom: 16, trailing: 32)
+        
+        section.decorationItems = [backgroundDecoration]
+        section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 32, bottom: 16, trailing: 32)
+        return section
+    }
+    
+    static func predictiveTextSectionLayout() -> NSCollectionLayoutSection {
+        let numOfItems = CGFloat(5)
+        
+        let predictiveTextItem = NSCollectionLayoutItem(
+            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1 / numOfItems),
+                                               heightDimension: .fractionalHeight(1.0)))
+        
+        let containerGroup = NSCollectionLayoutGroup.horizontal(
+            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                               heightDimension: .fractionalHeight(137.0 / totalHeight)),
+            subitem: predictiveTextItem, count: Int(numOfItems))
         containerGroup.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
         let section = NSCollectionLayoutSection(group: containerGroup)
         

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -83,16 +83,16 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
     }
     
     static func categoriesSectionLayout() -> NSCollectionLayoutSection {
-        let numOfItems = CGFloat(4)
+        let itemCount = CGFloat(4)
         
         let categoryItem = NSCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1 / numOfItems),
+            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1 / itemCount),
                                                heightDimension: .fractionalHeight(1.0)))
         
         let containerGroup = NSCollectionLayoutGroup.horizontal(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                heightDimension: .fractionalHeight(137.0 / totalHeight)),
-            subitem: categoryItem, count: Int(numOfItems))
+            subitem: categoryItem, count: Int(itemCount))
         containerGroup.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
         let section = NSCollectionLayoutSection(group: containerGroup)
         
@@ -105,16 +105,16 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
     }
     
     static func predictiveTextSectionLayout() -> NSCollectionLayoutSection {
-        let numOfItems = CGFloat(4)
+        let itemCount = CGFloat(4)
         
         let predictiveTextItem = NSCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1 / numOfItems),
+            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1 / itemCount),
                                                heightDimension: .fractionalHeight(1.0)))
         
         let containerGroup = NSCollectionLayoutGroup.horizontal(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                heightDimension: .fractionalHeight(137.0 / totalHeight)),
-            subitem: predictiveTextItem, count: Int(numOfItems))
+            subitem: predictiveTextItem, count: Int(itemCount))
         containerGroup.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
         let section = NSCollectionLayoutSection(group: containerGroup)
         

--- a/EyeSpeak/Features/Presets/PresetsViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsViewController.swift
@@ -39,6 +39,8 @@ class PresetsViewController: UICollectionViewController {
         }
     }
     
+    let textExpression = TextExpression()
+    
     enum Section: Int, CaseIterable {
         case topBar
         case textField
@@ -52,7 +54,7 @@ class PresetsViewController: UICollectionViewController {
         case textField(String)
         case topBarButton(TopBarButton)
         case category(PresetCategory)
-        case predictiveText(String)
+        case predictiveText(TextPrediction)
         case presetItem(String)
         case keyGroup(KeyGroup)
     }
@@ -78,6 +80,10 @@ class PresetsViewController: UICollectionViewController {
             self.updateSnapshot()
         }
     }
+    
+    // TODO: Hook this up with the TextExpression predict() function when the user updates
+    // the text in the text field
+    let predictions: [TextPrediction?] = []
     
     override var prefersHomeIndicatorAutoHidden: Bool {
         return true
@@ -146,8 +152,8 @@ class PresetsViewController: UICollectionViewController {
                 return cell
             case .category(let category):
                 return self.setupCell(reuseIdentifier: CategoryItemCollectionViewCell.reuseIdentifier, indexPath: indexPath, title: category.description)
-            case .predictiveText(let text):
-                return self.setupCell(reuseIdentifier: CategoryItemCollectionViewCell.reuseIdentifier, indexPath: indexPath, title: text)
+            case .predictiveText(let predictiveText):
+                return self.setupCell(reuseIdentifier: CategoryItemCollectionViewCell.reuseIdentifier, indexPath: indexPath, title: predictiveText.text)
             case .presetItem(let preset):
                 return self.setupCell(reuseIdentifier: PresetItemCollectionViewCell.reuseIdentifier, indexPath: indexPath, title: preset)
             case .keyGroup(let keyGroup):
@@ -174,7 +180,17 @@ class PresetsViewController: UICollectionViewController {
         
         if showKeyboard {
             snapshot.appendSections([.predictiveText])
-            snapshot.appendItems([.predictiveText(""), .predictiveText(""), .predictiveText(""), .predictiveText(""), .predictiveText("")])
+            if predictions.isEmpty {
+                 snapshot.appendItems([.predictiveText(TextPrediction(text: "")),
+                                       .predictiveText(TextPrediction(text: "")),
+                                       .predictiveText(TextPrediction(text: "")),
+                                       .predictiveText(TextPrediction(text: ""))])
+            } else {
+                snapshot.appendItems([.predictiveText(TextPrediction(text: predictions[0]?.text ?? "")),
+                                      .predictiveText(TextPrediction(text: predictions[1]?.text ?? "")),
+                                      .predictiveText(TextPrediction(text: predictions[2]?.text ?? "")),
+                                      .predictiveText(TextPrediction(text: predictions[3]?.text ?? ""))])
+            }
             
             snapshot.appendSections([.keyboard])
             snapshot.appendItems(KeyGroup.QWERTYKeyboardGroups.map { .keyGroup($0) })

--- a/EyeSpeak/Features/Presets/PresetsViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsViewController.swift
@@ -83,7 +83,7 @@ class PresetsViewController: UICollectionViewController {
     
     // TODO: Hook this up with the TextExpression predict() function when the user updates
     // the text in the text field
-    let predictions: [TextPrediction?] = []
+    let predictions: [TextPrediction] = []
     
     override var prefersHomeIndicatorAutoHidden: Bool {
         return true
@@ -100,7 +100,7 @@ class PresetsViewController: UICollectionViewController {
     
     private func setupCollectionView() {
         collectionView.delaysContentTouches = false
-//        collectionView.isScrollEnabled = false
+        collectionView.isScrollEnabled = false
         collectionView.register(UINib(nibName: "TextFieldCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "TextFieldCollectionViewCell")
         collectionView.register(UINib(nibName: "CategoryItemCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "CategoryItemCollectionViewCell")
         collectionView.register(UINib(nibName: "PresetItemCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "PresetItemCollectionViewCell")
@@ -186,10 +186,10 @@ class PresetsViewController: UICollectionViewController {
                                        .predictiveText(TextPrediction(text: "")),
                                        .predictiveText(TextPrediction(text: ""))])
             } else {
-                snapshot.appendItems([.predictiveText(TextPrediction(text: predictions[0]?.text ?? "")),
-                                      .predictiveText(TextPrediction(text: predictions[1]?.text ?? "")),
-                                      .predictiveText(TextPrediction(text: predictions[2]?.text ?? "")),
-                                      .predictiveText(TextPrediction(text: predictions[3]?.text ?? ""))])
+                snapshot.appendItems([.predictiveText(TextPrediction(text: predictions[safe: 0]?.text ?? "")),
+                                      .predictiveText(TextPrediction(text: predictions[safe: 1]?.text ?? "")),
+                                      .predictiveText(TextPrediction(text: predictions[safe: 2]?.text ?? "")),
+                                      .predictiveText(TextPrediction(text: predictions[safe: 3]?.text ?? ""))])
             }
             
             snapshot.appendSections([.keyboard])

--- a/EyeSpeak/Features/Presets/PresetsViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsViewController.swift
@@ -43,6 +43,7 @@ class PresetsViewController: UICollectionViewController {
         case topBar
         case textField
         case categories
+        case predictiveText
         case presets
         case keyboard
     }
@@ -51,6 +52,7 @@ class PresetsViewController: UICollectionViewController {
         case textField(String)
         case topBarButton(TopBarButton)
         case category(PresetCategory)
+        case predictiveText(String)
         case presetItem(String)
         case keyGroup(KeyGroup)
     }
@@ -92,7 +94,7 @@ class PresetsViewController: UICollectionViewController {
     
     private func setupCollectionView() {
         collectionView.delaysContentTouches = false
-        collectionView.isScrollEnabled = false
+//        collectionView.isScrollEnabled = false
         collectionView.register(UINib(nibName: "TextFieldCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "TextFieldCollectionViewCell")
         collectionView.register(UINib(nibName: "CategoryItemCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "CategoryItemCollectionViewCell")
         collectionView.register(UINib(nibName: "PresetItemCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "PresetItemCollectionViewCell")
@@ -108,7 +110,7 @@ class PresetsViewController: UICollectionViewController {
     
     private func createLayout() -> UICollectionViewLayout {
         let layout = PresetUICollectionViewCompositionalLayout { (sectionIndex: Int, _: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
-            let sectionKind = Section.allCases[sectionIndex]
+            let sectionKind = self.dataSource.snapshot().sectionIdentifiers[sectionIndex]
             
             switch sectionKind {
             case .topBar:
@@ -117,6 +119,8 @@ class PresetsViewController: UICollectionViewController {
                 return PresetUICollectionViewCompositionalLayout.textFieldSectionLayout()
             case .categories:
                 return PresetUICollectionViewCompositionalLayout.categoriesSectionLayout()
+            case .predictiveText:
+                return PresetUICollectionViewCompositionalLayout.predictiveTextSectionLayout()
             case .presets:
                 guard !self.showKeyboard else {
                     return nil
@@ -142,6 +146,8 @@ class PresetsViewController: UICollectionViewController {
                 return cell
             case .category(let category):
                 return self.setupCell(reuseIdentifier: CategoryItemCollectionViewCell.reuseIdentifier, indexPath: indexPath, title: category.description)
+            case .predictiveText(let text):
+                return self.setupCell(reuseIdentifier: CategoryItemCollectionViewCell.reuseIdentifier, indexPath: indexPath, title: text)
             case .presetItem(let preset):
                 return self.setupCell(reuseIdentifier: PresetItemCollectionViewCell.reuseIdentifier, indexPath: indexPath, title: preset)
             case .keyGroup(let keyGroup):
@@ -166,19 +172,18 @@ class PresetsViewController: UICollectionViewController {
         snapshot.appendSections([.textField])
         snapshot.appendItems([.textField(currentSpeechText)])
         
-        snapshot.appendSections([.categories])
-        snapshot.appendItems([.category(.category1), .category(.category2), .category(.category3), .category(.category4)])
-    
-        snapshot.appendSections([.presets])
-        
-        if !showKeyboard {
-            snapshot.appendItems(categoryPresets[selectedCategory]!)
-        }
-        
-        snapshot.appendSections([.keyboard])
-        
         if showKeyboard {
+            snapshot.appendSections([.predictiveText])
+            snapshot.appendItems([.predictiveText(""), .predictiveText(""), .predictiveText(""), .predictiveText(""), .predictiveText("")])
+            
+            snapshot.appendSections([.keyboard])
             snapshot.appendItems(KeyGroup.QWERTYKeyboardGroups.map { .keyGroup($0) })
+        } else {
+            snapshot.appendSections([.categories])
+            snapshot.appendItems([.category(.category1), .category(.category2), .category(.category3), .category(.category4)])
+            
+            snapshot.appendSections([.presets])
+            snapshot.appendItems(categoryPresets[selectedCategory]!)
         }
         
         dataSource.supplementaryViewProvider = { [weak self] (collectionView: UICollectionView, kind: String, indexPath: IndexPath) -> UICollectionReusableView? in
@@ -202,7 +207,7 @@ class PresetsViewController: UICollectionViewController {
         switch item {
         case .textField:
             return false
-        case .category, .presetItem, .topBarButton, .keyGroup:
+        case .category, .presetItem, .topBarButton, .keyGroup, .predictiveText:
             return true
         }
     }
@@ -213,7 +218,7 @@ class PresetsViewController: UICollectionViewController {
         switch item {
         case .textField:
             return false
-        case .category, .presetItem, .topBarButton, .keyGroup:
+        case .category, .presetItem, .topBarButton, .keyGroup, .predictiveText:
             return true
         }
     }
@@ -271,7 +276,7 @@ class PresetsViewController: UICollectionViewController {
         switch item {
         case .presetItem, .topBarButton:
             return true
-        case .category, .textField, .keyGroup:
+        case .category, .textField, .keyGroup, .predictiveText:
             return false
         }
     }

--- a/EyeSpeak/Utilities/Array+Split.swift
+++ b/EyeSpeak/Utilities/Array+Split.swift
@@ -1,0 +1,25 @@
+//
+//  Array+Split.swift
+//  EyeSpeak
+//
+//  Created by Duncan Lewis on 11/6/18.
+//  Copyright © 2018 WillowTree. All rights reserved.
+//
+
+import Foundation
+
+extension Array {
+    func splitBy(subSize: Int) -> [[Element]] {
+        return stride(from: 0, to: self.count, by: subSize).map {
+            Array(self[$0..<Swift.min($0 + subSize, self.count)])
+        }
+    }
+}
+
+extension Collection {
+
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript(safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/EyeSpeak/Utilities/TextExpression.swift
+++ b/EyeSpeak/Utilities/TextExpression.swift
@@ -1,0 +1,82 @@
+//
+//  TextExpression.swift
+//  EyeSpeak
+//
+//  Created by Kyle Ohanian on 4/16/19.
+//  Copyright © 2019 WillowTree. All rights reserved.
+//
+import Foundation
+
+protocol TextExpressionDelegate: class {
+    func textExpression(_ expression: TextExpression, valueChanged value: String)
+}
+
+class TextExpression {
+    private(set) var value: String = ""
+
+    weak var delegate: TextExpressionDelegate?
+
+    var wordCount: Int {
+        return value.split(separator: " ").count
+    }
+
+    var splitExpression: [String] {
+        let trimmedExpression = self.value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedExpression.split(separator: " ").map { String($0) }
+    }
+
+    func add(word: String) {
+        let trimmedExpression = self.value.trimmingCharacters(in: .whitespacesAndNewlines)
+        var newSplitExpression = trimmedExpression.split(separator: " ").map { String($0) }
+        newSplitExpression.append(word)
+        self.value = newSplitExpression.joined(separator: " ")
+        self.delegate?.textExpression(self, valueChanged: self.value)
+    }
+
+    func replaceWord(at index: Int, with newWord: String) {
+        var newSplitExpression = self.splitExpression
+        if newSplitExpression.count > index && index >= 0 {
+            newSplitExpression[index] = newWord
+        }
+        self.value = newSplitExpression.joined(separator: " ")
+        self.delegate?.textExpression(self, valueChanged: self.value)
+    }
+
+    func replaceLastWord(with newWord: String) {
+        self.replaceWord(at: self.splitExpression.count - 1, with: newWord)
+    }
+
+    func word(at index: Int) -> String? {
+        if self.splitExpression.count > index && index >= 0 {
+            return self.splitExpression[index]
+        } else {
+            return nil
+        }
+    }
+
+    func lastWord() -> String? {
+        return word(at: self.splitExpression.count - 1)
+    }
+
+    func backspace() {
+        if !self.value.isEmpty {
+            _ = self.value.removeLast()
+        }
+        self.delegate?.textExpression(self, valueChanged: self.value)
+    }
+
+    func append(text: String) {
+        self.value.append(text)
+        self.delegate?.textExpression(self, valueChanged: self.value)
+    }
+
+    func clear() {
+        self.value = ""
+        self.delegate?.textExpression(self, valueChanged: self.value)
+    }
+
+    func space() {
+        self.value.append(" ")
+        self.delegate?.textExpression(self, valueChanged: self.value)
+    }
+}

--- a/EyeSpeak/Utilities/TextExpression.swift
+++ b/EyeSpeak/Utilities/TextExpression.swift
@@ -41,11 +41,7 @@ class TextExpression {
     }
 
     func word(at index: Int) -> String? {
-        if self.splitExpression.count > index && index >= 0 {
-            return self.splitExpression[index]
-        } else {
-            return nil
-        }
+        return self.splitExpression[safe: index]
     }
 
     func lastWord() -> String? {

--- a/EyeSpeak/Utilities/TextExpression.swift
+++ b/EyeSpeak/Utilities/TextExpression.swift
@@ -7,14 +7,10 @@
 //
 import Foundation
 
-protocol TextExpressionDelegate: class {
-    func textExpression(_ expression: TextExpression, valueChanged value: String)
-}
-
 class TextExpression {
     private(set) var value: String = ""
-
-    weak var delegate: TextExpressionDelegate?
+    
+    private let textPredictionController = TextPredictionController()
 
     var wordCount: Int {
         return value.split(separator: " ").count
@@ -30,7 +26,6 @@ class TextExpression {
         var newSplitExpression = trimmedExpression.split(separator: " ").map { String($0) }
         newSplitExpression.append(word)
         self.value = newSplitExpression.joined(separator: " ")
-        self.delegate?.textExpression(self, valueChanged: self.value)
     }
 
     func replaceWord(at index: Int, with newWord: String) {
@@ -39,7 +34,6 @@ class TextExpression {
             newSplitExpression[index] = newWord
         }
         self.value = newSplitExpression.joined(separator: " ")
-        self.delegate?.textExpression(self, valueChanged: self.value)
     }
 
     func replaceLastWord(with newWord: String) {
@@ -62,21 +56,21 @@ class TextExpression {
         if !self.value.isEmpty {
             _ = self.value.removeLast()
         }
-        self.delegate?.textExpression(self, valueChanged: self.value)
     }
 
     func append(text: String) {
         self.value.append(text)
-        self.delegate?.textExpression(self, valueChanged: self.value)
     }
 
     func clear() {
         self.value = ""
-        self.delegate?.textExpression(self, valueChanged: self.value)
     }
 
     func space() {
         self.value.append(" ")
-        self.delegate?.textExpression(self, valueChanged: self.value)
+    }
+    
+    func predictions() -> [String] {
+        return textPredictionController.predictions(for: self)
     }
 }

--- a/EyeSpeak/Utilities/TextPredictionController.swift
+++ b/EyeSpeak/Utilities/TextPredictionController.swift
@@ -7,79 +7,20 @@
 //
 import UIKit
 
-protocol TextPredictionControllerDelegate: class {
-    func textPredictionController(_ controller: TextPredictionController, didUpdatePrediction value: String, at index: Int)
-}
-
-enum TextPredictionControllerState {
-    case idle
-    case matchByPhrase
-    case matchByWord
-}
-
 class TextPredictionController {
-    var prediction1: String = ""
-    var prediction2: String = ""
-    var prediction3: String = ""
-    var prediction4: String = ""
-    var prediction5: String = ""
-    var prediction6: String = ""
-
-    weak var delegate: TextPredictionControllerDelegate?
-    var state: TextPredictionControllerState = .idle
-    private var expression = TextExpression()
+    
     private let checker = UITextChecker()
 
-    func updateState(withTextExpression expression: TextExpression) {
-        self.expression = expression
-        let completions = self.completions()
-        self.prediction1 = ""
-        self.prediction2 = ""
-        self.prediction3 = ""
-        self.prediction4 = ""
-        self.prediction5 = ""
-        self.prediction6 = ""
-        if let prediction1 = completions[safe: 0] {
-            self.prediction1 = prediction1
-        }
-        if let prediction2 = completions[safe: 1] {
-            self.prediction2 = prediction2
-        }
-        if let prediction3 = completions[safe: 2] {
-            self.prediction3 = prediction3
-        }
-        if let prediction4 = completions[safe: 3] {
-            self.prediction4 = prediction4
-        }
-        if let prediction5 = completions[safe: 4] {
-            self.prediction5 = prediction5
-        }
-        if let prediction6 = completions[safe: 5] {
-            self.prediction6 = prediction6
-        }
-        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction1, at: 0)
-        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction2, at: 1)
-        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction3, at: 2)
-        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction4, at: 3)
-        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction5, at: 4)
-        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction6, at: 5)
+    func predictions(for expression: TextExpression) -> [String] {
+        return expression.value.hasExtraWhitespace ? matchesByPhrase(expression: expression) : matchesByWord(expression: expression)
     }
 
-    private func completions() -> [String] {
-        self.state = self.expression.value.hasExtraWhitespace ? .matchByPhrase : .matchByWord
-        return self.matches()
+    private func matchesByPhrase(expression: TextExpression) -> [String] {
+        return phraseCompletions(expression: expression, neededCompletions: 5)
     }
 
-    private func matches() -> [String] {
-        return self.state == .matchByPhrase ? matchesByPhrase() : matchesByWord()
-    }
-
-    private func matchesByPhrase() -> [String] {
-        return phraseCompletions(neededCompletions: 6)
-    }
-
-    private func phraseCompletions(neededCompletions: Int) -> [String] {
-        var splitExpression = self.expression.splitExpression
+    private func phraseCompletions(expression: TextExpression, neededCompletions: Int) -> [String] {
+        var splitExpression = expression.splitExpression
         var completions: [String] = []
         while !splitExpression.isEmpty && completions.count < neededCompletions {
             let phrase = splitExpression.joined(separator: " ")
@@ -92,9 +33,9 @@ class TextPredictionController {
         return completions
     }
 
-    private func matchesByWord() -> [String] {
-        let fullExpression = self.expression.value
-        let lastWord = self.expression.lastWord() ?? ""
+    private func matchesByWord(expression: TextExpression) -> [String] {
+        let fullExpression = expression.value
+        let lastWord = expression.lastWord() ?? ""
         let range = NSRange(location: (fullExpression as NSString).length - (lastWord as NSString).length, length: (lastWord as NSString).length)
         var joinedArray: [String] = []
         let guesses = checker.guesses(forWordRange: range, in: fullExpression, language: "en_US") ?? []
@@ -102,36 +43,6 @@ class TextPredictionController {
         joinedArray.append(contentsOf: completions)
         joinedArray.append(contentsOf: guesses)
         return joinedArray
-    }
-
-    func updateExpression(withPredictionAt index: Int) {
-        let lastWord = self.prediction(index: index)
-        guard !lastWord.isEmpty else { return }
-        if self.state == .matchByPhrase {
-            self.expression.add(word: lastWord)
-        } else {
-            self.expression.replaceLastWord(with: lastWord)
-        }
-        self.expression.space()
-    }
-
-    private func prediction(index: Int) -> String {
-        switch index {
-        case 0:
-            return self.prediction1
-        case 1:
-            return self.prediction2
-        case 2:
-            return self.prediction3
-        case 3:
-            return self.prediction4
-        case 4:
-            return self.prediction5
-        case 5:
-            return self.prediction6
-        default:
-            return ""
-        }
     }
 }
 

--- a/EyeSpeak/Utilities/TextPredictionController.swift
+++ b/EyeSpeak/Utilities/TextPredictionController.swift
@@ -1,0 +1,142 @@
+//
+//  TextPredictionController.swift
+//  EyeSpeak
+//
+//  Created by Kyle Ohanian on 4/15/19.
+//  Copyright © 2019 WillowTree. All rights reserved.
+//
+import UIKit
+
+protocol TextPredictionControllerDelegate: class {
+    func textPredictionController(_ controller: TextPredictionController, didUpdatePrediction value: String, at index: Int)
+}
+
+enum TextPredictionControllerState {
+    case idle
+    case matchByPhrase
+    case matchByWord
+}
+
+class TextPredictionController {
+    var prediction1: String = ""
+    var prediction2: String = ""
+    var prediction3: String = ""
+    var prediction4: String = ""
+    var prediction5: String = ""
+    var prediction6: String = ""
+
+    weak var delegate: TextPredictionControllerDelegate?
+    var state: TextPredictionControllerState = .idle
+    private var expression = TextExpression()
+    private let checker = UITextChecker()
+
+    func updateState(withTextExpression expression: TextExpression) {
+        self.expression = expression
+        let completions = self.completions()
+        self.prediction1 = ""
+        self.prediction2 = ""
+        self.prediction3 = ""
+        self.prediction4 = ""
+        self.prediction5 = ""
+        self.prediction6 = ""
+        if let prediction1 = completions[safe: 0] {
+            self.prediction1 = prediction1
+        }
+        if let prediction2 = completions[safe: 1] {
+            self.prediction2 = prediction2
+        }
+        if let prediction3 = completions[safe: 2] {
+            self.prediction3 = prediction3
+        }
+        if let prediction4 = completions[safe: 3] {
+            self.prediction4 = prediction4
+        }
+        if let prediction5 = completions[safe: 4] {
+            self.prediction5 = prediction5
+        }
+        if let prediction6 = completions[safe: 5] {
+            self.prediction6 = prediction6
+        }
+        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction1, at: 0)
+        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction2, at: 1)
+        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction3, at: 2)
+        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction4, at: 3)
+        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction5, at: 4)
+        self.delegate?.textPredictionController(self, didUpdatePrediction: self.prediction6, at: 5)
+    }
+
+    private func completions() -> [String] {
+        self.state = self.expression.value.hasExtraWhitespace ? .matchByPhrase : .matchByWord
+        return self.matches()
+    }
+
+    private func matches() -> [String] {
+        return self.state == .matchByPhrase ? matchesByPhrase() : matchesByWord()
+    }
+
+    private func matchesByPhrase() -> [String] {
+        return phraseCompletions(neededCompletions: 6)
+    }
+
+    private func phraseCompletions(neededCompletions: Int) -> [String] {
+        var splitExpression = self.expression.splitExpression
+        var completions: [String] = []
+        while !splitExpression.isEmpty && completions.count < neededCompletions {
+            let phrase = splitExpression.joined(separator: " ")
+            let augmentedString = phrase + " *"
+            let range = NSRange(location: (phrase as NSString).length, length: -1)
+            let phraseCompletions = checker.completions(forPartialWordRange: range, in: augmentedString, language: "en_US") ?? []
+            completions.append(contentsOf: phraseCompletions)
+            splitExpression.removeFirst()
+        }
+        return completions
+    }
+
+    private func matchesByWord() -> [String] {
+        let fullExpression = self.expression.value
+        let lastWord = self.expression.lastWord() ?? ""
+        let range = NSRange(location: (fullExpression as NSString).length - (lastWord as NSString).length, length: (lastWord as NSString).length)
+        var joinedArray: [String] = []
+        let guesses = checker.guesses(forWordRange: range, in: fullExpression, language: "en_US") ?? []
+        let completions = checker.completions(forPartialWordRange: range, in: fullExpression, language: "en_US") ?? []
+        joinedArray.append(contentsOf: completions)
+        joinedArray.append(contentsOf: guesses)
+        return joinedArray
+    }
+
+    func updateExpression(withPredictionAt index: Int) {
+        let lastWord = self.prediction(index: index)
+        guard !lastWord.isEmpty else { return }
+        if self.state == .matchByPhrase {
+            self.expression.add(word: lastWord)
+        } else {
+            self.expression.replaceLastWord(with: lastWord)
+        }
+        self.expression.space()
+    }
+
+    private func prediction(index: Int) -> String {
+        switch index {
+        case 0:
+            return self.prediction1
+        case 1:
+            return self.prediction2
+        case 2:
+            return self.prediction3
+        case 3:
+            return self.prediction4
+        case 4:
+            return self.prediction5
+        case 5:
+            return self.prediction6
+        default:
+            return ""
+        }
+    }
+}
+
+extension String {
+    var hasExtraWhitespace: Bool {
+        return self.count != self.trimmingCharacters(in: .whitespacesAndNewlines).count
+    }
+}


### PR DESCRIPTION
Changes included:
- Implemented transition between category row & predictive text row when switching to keyboard mode
- Brought back old EyeSpeak code that provided an array of strings of predictive words
- Refactored the code so that all prediction calls are within the TextExpression object by calling predict(). There will be an instance of TextExpression contained within the PresetsViewController that can append() or add() new words when needed