### PR TITLE
Presets size classes support

### DIFF
--- a/EyeSpeak.xcodeproj/project.pbxproj
+++ b/EyeSpeak.xcodeproj/project.pbxproj
@@ -872,7 +872,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.willowtreeapps.eyespeakaac";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -896,7 +896,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc com.willowtreeapps.eyespeakaac";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = RELEASE;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -1020,7 +1020,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.willowtreeapps.eyespeakaac";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = RELEASE;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 2;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = AppStore;
 		};

--- a/EyeSpeak/Base.lproj/Main.storyboard
+++ b/EyeSpeak/Base.lproj/Main.storyboard
@@ -42,6 +42,12 @@
                         </constraints>
                         <edgeInsets key="layoutMargins" top="32" left="32" bottom="32" right="32"/>
                         <viewLayoutGuide key="safeArea" id="N6F-RO-WaJ"/>
+                        <variation key="heightClass=compact">
+                            <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
+                        </variation>
+                        <variation key="widthClass=compact">
+                            <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
+                        </variation>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9OF-pV-I9m" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/EyeSpeak/Features/Presets/Categories/CategoriesPageViewController.swift
+++ b/EyeSpeak/Features/Presets/Categories/CategoriesPageViewController.swift
@@ -11,7 +11,13 @@ import CoreData
 
 class CategoriesPageViewController: UIPageViewController, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
     
-    private let itemsPerPage = 4
+    private var itemsPerPage: Int {
+        if case .regular = traitCollection.horizontalSizeClass {
+            return 4
+        }
+        
+        return 1
+    }
     private lazy var pages: [UIViewController] = categoryViewModels.chunked(into: itemsPerPage).map { viewModels in
         let collectionViewController = CategoryPageCollectionViewController(collectionViewLayout: CategoryPageCollectionViewController.createLayout(with: viewModels.count))
                 collectionViewController.items = viewModels

--- a/EyeSpeak/Features/Presets/Categories/CategoriesPageViewController.swift
+++ b/EyeSpeak/Features/Presets/Categories/CategoriesPageViewController.swift
@@ -20,8 +20,8 @@ class CategoriesPageViewController: UIPageViewController, UIPageViewControllerDa
     }
     private lazy var pages: [UIViewController] = categoryViewModels.chunked(into: itemsPerPage).map { viewModels in
         let collectionViewController = CategoryPageCollectionViewController(collectionViewLayout: CategoryPageCollectionViewController.createLayout(with: viewModels.count))
-                collectionViewController.items = viewModels
-                return collectionViewController
+        collectionViewController.items = viewModels
+        return collectionViewController
     }
     
     private lazy var categoryViewModels: [CategoryViewModel] =
@@ -33,9 +33,17 @@ class CategoriesPageViewController: UIPageViewController, UIPageViewControllerDa
         super.viewDidLoad()
         delegate = self
         dataSource = self
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         
-        if let firstViewController = pages.first {
-            setViewControllers([firstViewController], direction: .forward, animated: true)
+        let viewControllerToSelect = pages.first(where: {
+            (($0 as? CategoryPageCollectionViewController)?.items.contains(ItemSelection.categoryValueSubject.value) ?? false)
+        })
+        
+        if let viewController = viewControllerToSelect {
+            setViewControllers([viewController], direction: .forward, animated: true)
         }
     }
     

--- a/EyeSpeak/Features/Presets/Categories/CategoryItemCollectionViewCell.xib
+++ b/EyeSpeak/Features/Presets/Categories/CategoryItemCollectionViewCell.xib
@@ -16,7 +16,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="269" height="218"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qn0-yK-CCv">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.45000000000000001" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qn0-yK-CCv">
                         <rect key="frame" x="16" y="44" width="237" height="174"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                         <nil key="textColor"/>

--- a/EyeSpeak/Features/Presets/Pagination/Containers/PresetPaginationContainerCollectionViewCell.xib
+++ b/EyeSpeak/Features/Presets/Pagination/Containers/PresetPaginationContainerCollectionViewCell.xib
@@ -16,6 +16,7 @@
             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ldk-6n-dPb">
                 <rect key="frame" x="0.0" y="0.0" width="524" height="366"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
             </collectionViewCellContentView>
             <color key="backgroundColor" name="Background"/>
             <size key="customSize" width="524" height="366"/>

--- a/EyeSpeak/Features/Presets/Pagination/PageIndicatorCollectionViewCell.swift
+++ b/EyeSpeak/Features/Presets/Pagination/PageIndicatorCollectionViewCell.swift
@@ -17,7 +17,7 @@ class PageIndicatorCollectionViewCell: VocableCollectionViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         fillColor = .collectionViewBackgroundColor
-        pageLabel.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        pageLabel.adjustsFontSizeToFitWidth = true
         
         ItemSelection.presetsPageIndicatorPublisher.sink(receiveValue: { pageInfo in
             self.pageLabel.text = pageInfo

--- a/EyeSpeak/Features/Presets/Pagination/PageIndicatorCollectionViewCell.xib
+++ b/EyeSpeak/Features/Presets/Pagination/PageIndicatorCollectionViewCell.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,21 +16,21 @@
                 <rect key="frame" x="0.0" y="0.0" width="264" height="193"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Page 1 of X" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xmC-gl-HaJ">
-                        <rect key="frame" x="16" y="44" width="232" height="149"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Page 1 of X" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.29999999999999999" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xmC-gl-HaJ">
+                        <rect key="frame" x="0.0" y="0.0" width="264" height="193"/>
+                        <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                         <color key="textColor" name="DefaultFontColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
             </view>
             <constraints>
-                <constraint firstItem="xmC-gl-HaJ" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="topMargin" id="ORn-TK-Aaw"/>
-                <constraint firstItem="xmC-gl-HaJ" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leadingMargin" id="f2V-97-vmy"/>
-                <constraint firstAttribute="trailingMargin" secondItem="xmC-gl-HaJ" secondAttribute="trailing" id="n1Y-X4-BLX"/>
-                <constraint firstAttribute="bottomMargin" secondItem="xmC-gl-HaJ" secondAttribute="bottom" id="o63-F1-0B0"/>
+                <constraint firstItem="xmC-gl-HaJ" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="51f-am-cTg"/>
+                <constraint firstItem="xmC-gl-HaJ" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="Ggf-2o-7ze"/>
+                <constraint firstAttribute="bottom" secondItem="xmC-gl-HaJ" secondAttribute="bottom" id="Yop-WD-fFX"/>
+                <constraint firstAttribute="trailing" secondItem="xmC-gl-HaJ" secondAttribute="trailing" id="wEA-jI-O7b"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
+            <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
             <size key="customSize" width="264" height="193"/>
             <connections>
                 <outlet property="pageLabel" destination="xmC-gl-HaJ" id="LMl-WO-3qD"/>

--- a/EyeSpeak/Features/Presets/Pagination/PaginationCollectionViewCell.xib
+++ b/EyeSpeak/Features/Presets/Pagination/PaginationCollectionViewCell.xib
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="269" height="218"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qn0-yK-CCv">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.29999999999999999" translatesAutoresizingMaskIntoConstraints="NO" id="qn0-yK-CCv">
                         <rect key="frame" x="16" y="44" width="237" height="174"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                         <color key="textColor" name="DefaultFontColor"/>

--- a/EyeSpeak/Features/Presets/PresetItemCollectionViewCell.xib
+++ b/EyeSpeak/Features/Presets/PresetItemCollectionViewCell.xib
@@ -16,7 +16,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="269" height="218"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qn0-yK-CCv">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qn0-yK-CCv">
                         <rect key="frame" x="16" y="44" width="237" height="174"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                         <nil key="textColor"/>

--- a/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
@@ -136,6 +136,8 @@ class PresetPageCollectionViewController: UICollectionViewController {
                     return (3, 3)
                 case (.regular, .compact), (.compact, .compact):
                     return (2, 3)
+                case (.compact, .regular):
+                    return (3, 2)
                 default:
                     return (2, 3)
                 }

--- a/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
@@ -130,25 +130,27 @@ class PresetPageCollectionViewController: UICollectionViewController {
             let presetItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0 / 3.0),
                                                                                        heightDimension: .fractionalHeight(1.0)))
             
-            var itemsPerRow: Int {
+            var rowInfo: (numberOfRows: Int, itemsPerRow: Int) {
                 switch (traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass) {
-                case (.regular, .regular), (.regular, .compact):
-                    return 3
+                case (.regular, .regular):
+                    return (3, 3)
+                case (.regular, .compact), (.compact, .compact):
+                    return (2, 3)
                 default:
-                    return 2
+                    return (2, 3)
                 }
             }
             
             let rowGroup = NSCollectionLayoutGroup.horizontal(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                    heightDimension: .fractionalHeight(1.0)),
-                subitem: presetItem, count: itemsPerRow)
+                subitem: presetItem, count: rowInfo.itemsPerRow)
             rowGroup.interItemSpacing = .fixed(8)
             
             let containerGroup = NSCollectionLayoutGroup.vertical(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                    heightDimension: .fractionalHeight(1)),
-                subitem: rowGroup, count: 3)
+                subitem: rowGroup, count: rowInfo.numberOfRows)
             containerGroup.interItemSpacing = .fixed(8)
             containerGroup.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
             

--- a/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
@@ -32,6 +32,7 @@ class PresetPageCollectionViewController: UICollectionViewController {
         super.viewDidLoad()
         clearsSelectionOnViewWillAppear = false
     }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -117,22 +118,31 @@ class PresetPageCollectionViewController: UICollectionViewController {
         // Intended for use in computing the fractional-size dimensions of collection layout items rather than hard-coding width/height values
         private static let totalHeight: CGFloat = 834.0
         
-        init(with itemCount: Int) {
-            super.init(section: CompositionalLayout.presetsSectionLayout())
+        init(traitCollection: UITraitCollection) {
+            super.init(section: CompositionalLayout.presetsSectionLayout(for: traitCollection))
         }
         
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
         
-        private static func presetsSectionLayout() -> NSCollectionLayoutSection {
+        private static func presetsSectionLayout(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
             let presetItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0 / 3.0),
                                                                                        heightDimension: .fractionalHeight(1.0)))
+            
+            var itemsPerRow: Int {
+                switch (traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass) {
+                case (.regular, .regular), (.regular, .compact):
+                    return 3
+                default:
+                    return 2
+                }
+            }
             
             let rowGroup = NSCollectionLayoutGroup.horizontal(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                    heightDimension: .fractionalHeight(1.0)),
-                subitem: presetItem, count: 3)
+                subitem: presetItem, count: itemsPerRow)
             rowGroup.interItemSpacing = .fixed(8)
             
             let containerGroup = NSCollectionLayoutGroup.vertical(

--- a/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
@@ -132,9 +132,9 @@ class PresetPageCollectionViewController: UICollectionViewController {
             
             var rowInfo: (numberOfRows: Int, itemsPerRow: Int) {
                 switch (traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass) {
-                case (.regular, .regular):
+                case (.regular, .regular), (.regular, .compact):
                     return (3, 3)
-                case (.regular, .compact), (.compact, .compact):
+                case (.compact, .compact):
                     return (2, 3)
                 case (.compact, .regular):
                     return (3, 2)

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -164,32 +164,63 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
     }
         
     static func presetsSectionLayout(with environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
-        let flexibleSpacing = (environment.container.contentSize.width / 10.0) * 2.0
         
-        let presetPageItem = NSCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                               heightDimension: .fractionalHeight(504.0 / totalSize.height)))
+        var regularWidthPresetGroup: NSCollectionLayoutGroup {
+            let flexibleSpacing = (environment.container.contentSize.width / 10.0) * 2.0
+            
+            let presetPageItem = NSCollectionLayoutItem(
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                                   heightDimension: .fractionalHeight(504.0 / totalSize.height)))
+            
+            let leadingPaginationItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(146.0 / totalSize.width), heightDimension: .fractionalHeight(1)))
+            leadingPaginationItem.edgeSpacing = .init(leading: .flexible(flexibleSpacing), top: nil, trailing: nil, bottom: nil)
+            
+            let pageIndicatorItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(228.0 / totalSize.width), heightDimension: .fractionalHeight(1)))
+            
+            let trailingPaginationItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(146.0 / totalSize.width), heightDimension: .fractionalHeight(1)))
+            trailingPaginationItem.edgeSpacing = .init(leading: nil, top: nil, trailing: .flexible(flexibleSpacing), bottom: nil)
+            
+            let paginationGroup = NSCollectionLayoutGroup.horizontal(
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                                   heightDimension: .fractionalHeight(99.0 / totalSize.height)),
+                subitems: [leadingPaginationItem, pageIndicatorItem, trailingPaginationItem])
+            paginationGroup.interItemSpacing = .fixed(0)
+            
+            let containerGroup = NSCollectionLayoutGroup.vertical(
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(800.0 / totalSize.height)),
+                subitems: [presetPageItem, paginationGroup])
+            return containerGroup
+        }
         
-        let leadingPaginationItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(146.0 / totalSize.width), heightDimension: .fractionalHeight(1)))
-        leadingPaginationItem.edgeSpacing = .init(leading: .flexible(flexibleSpacing), top: nil, trailing: nil, bottom: nil)
+        var compactWidthPresetGroup: NSCollectionLayoutGroup {
+            let presetPageItem = NSCollectionLayoutItem(
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                                   heightDimension: .fractionalHeight(504.0 / totalSize.height)))
+            
+            let paginationItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0 / 4.0), heightDimension: .fractionalHeight(1)))
+            
+            let pageIndicatorItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(2.0 / 4.0), heightDimension: .fractionalHeight(1)))
+            
+            let paginationGroup = NSCollectionLayoutGroup.horizontal(
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                                   heightDimension: .fractionalHeight(99.0 / totalSize.height)),
+                subitems: [paginationItem, pageIndicatorItem, paginationItem])
+            paginationGroup.interItemSpacing = .fixed(0)
+            
+            let containerGroup = NSCollectionLayoutGroup.vertical(
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(4.0 / 5.0)),
+                subitems: [presetPageItem, paginationGroup])
+            
+            return containerGroup
+        }
         
-        let pageIndicatorItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(228.0 / totalSize.width), heightDimension: .fractionalHeight(1)))
+        let containerGroup = environment.traitCollection.horizontalSizeClass == .regular ? regularWidthPresetGroup : compactWidthPresetGroup
+        containerGroup.interItemSpacing = .fixed(8)
+    
+        let section = NSCollectionLayoutSection(group: containerGroup)
+        section.contentInsets = .init(top: 8, leading: 0, bottom: 8, trailing: 0)
         
-        let trailingPaginationItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(146.0 / totalSize.width), heightDimension: .fractionalHeight(1)))
-        trailingPaginationItem.edgeSpacing = .init(leading: nil, top: nil, trailing: .flexible(flexibleSpacing), bottom: nil)
-
-        let paginationGroup = NSCollectionLayoutGroup.horizontal(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                               heightDimension: .fractionalHeight(99.0 / totalSize.height)),
-            subitems: [leadingPaginationItem, pageIndicatorItem, trailingPaginationItem])
-        paginationGroup.interItemSpacing = .fixed(0)
-        
-        let containerGroup = NSCollectionLayoutGroup.vertical(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(800.0 / totalSize.height)),
-            subitems: [presetPageItem, paginationGroup])
-        containerGroup.interItemSpacing = .fixed(0)
-        
-        return NSCollectionLayoutSection(group: containerGroup)
+        return section
     }
     
     // MARK: Keyboard Layout

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -70,6 +70,8 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
                 subitems: subitems)
         }
         
+        var compactHeightContainerGroupLayout = regularWidthContainerGroupLayout
+        
         var compactWidthContainerGroupLayout: NSCollectionLayoutGroup {
             let textFieldItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.5)))
             
@@ -87,8 +89,13 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0 / 4.0)),
                 subitems: [textFieldItem, functionItemGroup])
         }
-        
-        let containerGroup = environment.traitCollection.horizontalSizeClass == .regular ? regularWidthContainerGroupLayout : compactWidthContainerGroupLayout
+    
+        let containerGroup: NSCollectionLayoutGroup
+        if case .compact = environment.traitCollection.verticalSizeClass {
+            containerGroup = compactHeightContainerGroupLayout
+        } else {
+            containerGroup = environment.traitCollection.horizontalSizeClass == .regular ? regularWidthContainerGroupLayout : compactWidthContainerGroupLayout
+        }
         
         let section = NSCollectionLayoutSection(group: containerGroup)
         
@@ -200,6 +207,8 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
             return containerGroup
         }
         
+        var compactHeightPresetGroup = regularWidthPresetGroup
+        
         var compactWidthPresetGroup: NSCollectionLayoutGroup {
             let presetPageItem = NSCollectionLayoutItem(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
@@ -222,7 +231,13 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
             return containerGroup
         }
         
-        let containerGroup = environment.traitCollection.horizontalSizeClass == .regular ? regularWidthPresetGroup : compactWidthPresetGroup
+        let containerGroup: NSCollectionLayoutGroup
+        if case .compact = environment.traitCollection.verticalSizeClass {
+            containerGroup = compactHeightPresetGroup
+        } else {
+            containerGroup = environment.traitCollection.horizontalSizeClass == .regular ? regularWidthPresetGroup : compactWidthPresetGroup
+        }
+        
         containerGroup.interItemSpacing = .fixed(8)
     
         let section = NSCollectionLayoutSection(group: containerGroup)

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -55,18 +55,39 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
     // MARK: - Section Layouts
     
     static func textFieldSectionLayout(with environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
-        let textFieldItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.7), heightDimension: .fractionalHeight(1.0)))
-        textFieldItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 4)
+        var regularWidthContainerGroupLayout: NSCollectionLayoutGroup {
+            let textFieldItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.7), heightDimension: .fractionalHeight(1.0)))
+            textFieldItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 4)
+            
+            let functionItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.1), heightDimension: .fractionalHeight(1.0)))
+            functionItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 4)
+            
+            let subitems = [textFieldItem, functionItem, functionItem, functionItem]
+            
+            return NSCollectionLayoutGroup.horizontal(
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                                   heightDimension: .fractionalHeight(100.0 / totalSize.height)),
+                subitems: subitems)
+        }
         
-        let functionItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.1), heightDimension: .fractionalHeight(1.0)))
-        functionItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 4)
+        var compactWidthContainerGroupLayout: NSCollectionLayoutGroup {
+            let textFieldItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.5)))
+            textFieldItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 4)
+            
+            let functionItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0)))
+            functionItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 4)
+            
+            let functionItemGroup = NSCollectionLayoutGroup.horizontal(
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                                   heightDimension: .fractionalHeight(0.5)),
+                subitems: [functionItem, functionItem])
+            
+            return NSCollectionLayoutGroup.vertical(
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0 / 4.0)),
+                subitems: [textFieldItem, functionItemGroup])
+        }
         
-        let subitems = [textFieldItem, functionItem, functionItem, functionItem]
-        
-        let containerGroup = NSCollectionLayoutGroup.horizontal(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                               heightDimension: .fractionalHeight(100.0 / totalSize.height)),
-            subitems: subitems)
+        let containerGroup = environment.traitCollection.horizontalSizeClass == .regular ? regularWidthContainerGroupLayout : compactWidthContainerGroupLayout
         
         let section = NSCollectionLayoutSection(group: containerGroup)
         

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -186,8 +186,16 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
                 subitems: [leadingPaginationItem, pageIndicatorItem, trailingPaginationItem])
             paginationGroup.interItemSpacing = .fixed(0)
             
+            var containerGroupFractionalWidth: NSCollectionLayoutDimension {
+                if case .compact = environment.traitCollection.verticalSizeClass {
+                    return .fractionalHeight(750.0 / totalSize.height)
+                }
+                
+                return .fractionalHeight(800.0 / totalSize.height)
+            }
+            
             let containerGroup = NSCollectionLayoutGroup.vertical(
-                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(800.0 / totalSize.height)),
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: containerGroupFractionalWidth),
                 subitems: [presetPageItem, paginationGroup])
             return containerGroup
         }
@@ -208,7 +216,7 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
             paginationGroup.interItemSpacing = .fixed(0)
             
             let containerGroup = NSCollectionLayoutGroup.vertical(
-                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(4.0 / 5.0)),
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(3.75 / 5.0)),
                 subitems: [presetPageItem, paginationGroup])
             
             return containerGroup

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -72,15 +72,16 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
         
         var compactWidthContainerGroupLayout: NSCollectionLayoutGroup {
             let textFieldItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.5)))
-            textFieldItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 4)
             
-            let functionItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0)))
-            functionItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 4)
-            
+            let leadingFunctionItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0)))
+            leadingFunctionItem.contentInsets = .init(top: 4, leading: 0, bottom: 0, trailing: 4)
+            let trailingFunctionItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0)))
+            trailingFunctionItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 0)
+
             let functionItemGroup = NSCollectionLayoutGroup.horizontal(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                    heightDimension: .fractionalHeight(0.5)),
-                subitems: [functionItem, functionItem])
+                subitems: [leadingFunctionItem, trailingFunctionItem])
             
             return NSCollectionLayoutGroup.vertical(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0 / 4.0)),
@@ -96,17 +97,38 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
     
     static func categoriesSectionLayout(with environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
         let totalSectionWidth: CGFloat = 1130.0
+        let traitCollection = environment.traitCollection
         
         let categoryItem = NSCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                heightDimension: .fractionalHeight(1)))
+        if case .compact = environment.traitCollection.horizontalSizeClass {
+            categoryItem.contentInsets = .init(top: 0, leading: 8, bottom: 0, trailing: 8)
+        }
+        
+        var categoryGroupFractionalWidth: NSCollectionLayoutDimension {
+            if case .regular = traitCollection.horizontalSizeClass {
+                return .fractionalWidth(906.0 / totalSectionWidth)
+            }
+            
+            return .fractionalWidth(3.0 / 5.0)
+        }
+        
         let categoriesGroup = NSCollectionLayoutGroup.horizontal(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(906.0 / totalSectionWidth),
+            layoutSize: NSCollectionLayoutSize(widthDimension: categoryGroupFractionalWidth,
                                                heightDimension: .fractionalHeight(1)),
             subitems: [categoryItem])
         
+        var paginationItemFractionalWidth: NSCollectionLayoutDimension {
+            if case .regular = traitCollection.horizontalSizeClass {
+                return .fractionalWidth(104.0 / totalSectionWidth)
+            }
+            
+            return .fractionalWidth(1.0 / 5.0)
+        }
+        
         let paginationItem = NSCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(104.0 / totalSectionWidth),
+            layoutSize: NSCollectionLayoutSize(widthDimension: paginationItemFractionalWidth,
                                                heightDimension: .fractionalHeight(1)))
         
         let containerGroup = NSCollectionLayoutGroup.horizontal(
@@ -115,7 +137,7 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
         containerGroup.interItemSpacing = .flexible(0)
         
         let section = NSCollectionLayoutSection(group: containerGroup)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 0, bottom: 0, trailing: 0)
+        section.contentInsets = NSDirectionalEdgeInsets(top: traitCollection.horizontalSizeClass == .regular ? 16 : 8, leading: 0, bottom: 0, trailing: 0)
         return section
     }
     

--- a/EyeSpeak/Features/Presets/PresetsPageViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsPageViewController.swift
@@ -14,14 +14,21 @@ class PresetsPageViewController: UIPageViewController, UIPageViewControllerDataS
     
     var selectedItem: PhraseViewModel?
     
-    private let itemsPerPage = 9
+    private var itemsPerPage: Int {
+        switch (traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass) {
+        case (.regular, .regular), (.regular, .compact):
+            return 9
+        default:
+            return 6
+        }
+    }
 
     private lazy var pages: [UIViewController] = {
         presetViewModels.chunked(into: itemsPerPage).map { viewModels in
-            let collectionViewController = PresetPageCollectionViewController(collectionViewLayout: PresetPageCollectionViewController.CompositionalLayout(with: viewModels.count))
+            let collectionViewController = PresetPageCollectionViewController(collectionViewLayout: PresetPageCollectionViewController.CompositionalLayout(traitCollection: traitCollection))
             collectionViewController.items = viewModels
             return collectionViewController
-            }
+        }
     }()
     
     private var presetViewModels: [PhraseViewModel] =

--- a/EyeSpeak/Features/Presets/PresetsViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsViewController.swift
@@ -333,7 +333,7 @@ class PresetsViewController: UICollectionViewController {
             let childContainerView = cell.contentView
             
             addChild(childViewController)
-            childViewController.view.frame = childContainerView.frame.inset(by: childContainerView.layoutMargins)
+            childViewController.view.frame = childContainerView.frame
             childContainerView.addSubview(childViewController.view)
             childViewController.didMove(toParent: self)
         }

--- a/EyeSpeak/Features/Presets/PresetsViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsViewController.swift
@@ -333,7 +333,7 @@ class PresetsViewController: UICollectionViewController {
             let childContainerView = cell.contentView
             
             addChild(childViewController)
-            childViewController.view.frame = childContainerView.frame
+            childViewController.view.frame = childContainerView.frame.inset(by: childContainerView.layoutMargins)
             childContainerView.addSubview(childViewController.view)
             childViewController.didMove(toParent: self)
         }

--- a/EyeSpeak/Features/Presets/PresetsViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsViewController.swift
@@ -107,7 +107,19 @@ class PresetsViewController: UICollectionViewController {
     override var prefersHomeIndicatorAutoHidden: Bool {
         return true
     }
-
+    
+    override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.willTransition(to: newCollection, with: coordinator)
+        
+        var snapshot = dataSource.snapshot()
+        snapshot.deleteAllItems()
+        dataSource.apply(snapshot)
+                
+        DispatchQueue.main.async { [weak self] in
+            self?.updateSnapshot()
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/EyeSpeak/Features/Presets/PresetsViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsViewController.swift
@@ -240,16 +240,25 @@ class PresetsViewController: UICollectionViewController {
     }
 
     func updateSnapshot(animated: Bool = true) {
-
         var snapshot = NSDiffableDataSourceSnapshot<Section, ItemWrapper>()
         
+        // Helper functions
+        func appendSaveButton() {
+            if phraseIsSaved(textTransaction.text) {
+                snapshot.appendItems([.topBarButton(.unsave)])
+            } else {
+                snapshot.appendItems([.topBarButton(.save)])
+            }
+        }
+        
+        // Snapshot construction
         snapshot.appendSections([.textField])
         snapshot.appendItems([.textField(textTransaction.attributedText)])
-        if phraseIsSaved(textTransaction.text) {
-            snapshot.appendItems([.topBarButton(.unsave)])
-        } else {
-            snapshot.appendItems([.topBarButton(.save)])
+        
+        if case .regular = traitCollection.horizontalSizeClass {
+           appendSaveButton()
         }
+        
         snapshot.appendItems([.topBarButton(.togglePreset), .topBarButton(.settings)])
         
         if showKeyboard {

--- a/EyeSpeak/Features/Presets/TextFieldCollectionViewCell.swift
+++ b/EyeSpeak/Features/Presets/TextFieldCollectionViewCell.swift
@@ -24,7 +24,6 @@ class TextFieldCollectionViewCell: VocableCollectionViewCell {
         borderedView.borderColor = .cellBorderHighlightColor
         borderedView.backgroundColor = .collectionViewBackgroundColor
         super.fillColor = .collectionViewBackgroundColor
-        font = .systemFont(ofSize: 48, weight: .bold)
         
         updateContentViews()
         backgroundView = borderedView
@@ -36,6 +35,12 @@ class TextFieldCollectionViewCell: VocableCollectionViewCell {
         textLabel.textColor = isSelected ? .selectedTextColor : .defaultTextColor
         textLabel.backgroundColor = .collectionViewBackgroundColor
         textLabel.isOpaque = true
+        font = .systemFont(ofSize: 48, weight: .bold)
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateContentViews()
     }
 
     func setup(title: NSAttributedString) {

--- a/EyeSpeak/Features/Presets/TextFieldCollectionViewCell.xib
+++ b/EyeSpeak/Features/Presets/TextFieldCollectionViewCell.xib
@@ -16,11 +16,14 @@
                 <rect key="frame" x="0.0" y="0.0" width="269" height="218"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="headTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lJv-EU-CHR">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="headTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.25" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lJv-EU-CHR">
                         <rect key="frame" x="16" y="44" width="237" height="174"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
+                        <variation key="widthClass=compact">
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        </variation>
                     </label>
                 </subviews>
             </view>

--- a/EyeSpeak/Features/Presets/TextFieldCollectionViewCell.xib
+++ b/EyeSpeak/Features/Presets/TextFieldCollectionViewCell.xib
@@ -16,14 +16,11 @@
                 <rect key="frame" x="0.0" y="0.0" width="269" height="218"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="headTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.25" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lJv-EU-CHR">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="headTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lJv-EU-CHR">
                         <rect key="frame" x="16" y="44" width="237" height="174"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
-                        <variation key="widthClass=compact">
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        </variation>
                     </label>
                 </subviews>
             </view>


### PR DESCRIPTION
- Add iPhone support
- Update layouts for compact width environment for the Presets view

Roadmap: 
- [x] Finalize landscape handset layouts once design is ready
- [x] Handle trait collection changes
- [ ] Edit pagination behavior to auto-select category in compact width environment

**Before**:
![IMG_0295](https://user-images.githubusercontent.com/16855664/75717186-a28d9f80-5c9e-11ea-83be-78e4e81b0214.PNG)
**After**:
![IMG_0294](https://user-images.githubusercontent.com/16855664/75717192-a4eff980-5c9e-11ea-8870-079716006bd1.PNG)

