### PR TITLE
Update to Fastlane's Fastfile for device provisioning via the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Vocable AAC allows those with conditions such as MS, stroke, ALS, or spinal cord
 
 ## Build instructions
 
+## Device Provisioning
+1. Run `fastlane` from the project command line.
+2. From the menu select the option for `Add devices via....`
+3. When prompted enter a `device name` and press enter. This can be any name.
+4. When prompted enter the `device UDID` and press enter. Found in `Xcode -> Window -> Devices and Simulators`
+5. When prompted enter a `eyespeakstore@willowtreeapps.com` for `username` and press enter.
+6. Fastlane might ask you to enter a username again, use `eyespeakstore@willowtreeapps.com`.
+
 ## Credits
 Matt Kubota, Kyle Ohanian, Duncan Lewis, Ameir Al-Zoubi, and many more from [WillowTree](https://willowtreeapps.com/) 💙.
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,7 @@ platform :ios do
     increment_build_number(
       build_number: ENV['CIRCLE_BUILD_NUM'],
     )
-    
+
     gym(export_method: "ad-hoc",
         scheme: "AdHoc",
     )
@@ -52,4 +52,15 @@ platform :ios do
       skip_waiting_for_build_processing: true
     )
   end
+
+  desc "Add devices via the command line to the device portal and regenerate the development provisioning profile with the device"
+  lane :register do
+    device_name = prompt(text: "Enter the device name: ")
+    device_udid = prompt(text: "Enter the device UDID: ")
+    device_hash = {}
+    device_hash[device_name] = device_udid
+    register_devices(devices: device_hash)
+    match(type:"development", force_for_new_devices: true)
+  end
+
 end


### PR DESCRIPTION
Updated the `Fastfile` to allow adding/provisioning devices via the command line.

Steps to add a device:

1. Run `fastlane` from the project command line.
<img width="858" alt="image" src="https://user-images.githubusercontent.com/17725927/75897723-016e2880-5e07-11ea-9707-0925e5c45a30.png">

2. From the menu select the option for `Add devices via...`.
3. When prompted enter a `device name` and press `enter`. This can be any name.
4. When prompted enter the `device UDID` and press `enter`. Found in `Xcode -> Window -> Devices and Simulators` 
5. When prompted enter a `eyespeakstore@willowtreeapps.com` for `username ` and press `enter`.
6. Fastlane might ask you to enter a username again, use `eyespeakstore@willowtreeapps.com`.