### PR TITLE
Update README, add contributing guidelines and project roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Vocable Contributing Guidelines
+
+🥳🎉 Thank you for contributing to Vocable! 🎉🥳 
+
+Contributions from the open-source community are crucial in helping us meet make the best AAC app possible.
+
+# How to Contribute
+
+### Reporting Bugs
+- Check the existing issues to make sure the bug has not already been reported.
+- Open an issue describing the bug. 
+  - Be sure to use a descriptive title and include detailed steps on how to reproduce the issue. 
+  - Explain the expected behavior vs. the actual behavior. 
+  - Include the version number.
+  - Tag the issue with the `bug` label.
+
+
+### Suggesting Enhancements 
+- Open an issue clearly describing the behavior you would like to see. 
+- If applicable, provide a few examples of how the feature would work and what purpose it would serve.
+- Tag the issue with the `enhancement` label.
+
+### Contributing Code by Opening a Pull Request
+To contribute to Vocable, please fork the GitHub repo and submit a pull request to the `develop` branch. 
+
+Our code owners will review your work and merge once any issues have been addressed. If the PR gets too outdated we may ask you to rebase and force push to update the PR. 
+
+That's it! Our team will merge your PR, and your changes will be included in the next app version. Thanks for your contribution! 💯

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Platform iOS](https://img.shields.io/badge/platform-iOS-orange.svg)
 ![license MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)
 
-Empowering people to communicate with care takers and loved ones.
+> Empowering people to communicate with care takers and loved ones.
 
 [![Watch the video](marketing_assets/vocable_vimeo_still.gif)](https://player.vimeo.com/video/394212430)
 
@@ -14,7 +14,6 @@ Empowering people to communicate with care takers and loved ones.
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [Requirements](#requirements)
-- [Build instructions](#build-instructions)
 - [Credits](#credits)
 - [License](#license)
 
@@ -23,24 +22,35 @@ Vocable AAC allows those with conditions such as MS, stroke, ALS, or spinal cord
 
 ## Features
 
+### Multimodal User Interface
+
+Vocable uses ARKit to track the user's head movements and understand where the user is looking at on the screen. This allows the app to be used completely hands-free: users can look around the screen and make selections by lingering their gaze at a particular element. 
+
+For users with more mobility, the app can be operated by touch.
+
+### Saved Phrases
+Use a list of common phrases provided by speech language pathologists, or create and save your own.
+
+### Full QWERTY Keyboard
+Type with your head or your hands.
+
 ## Roadmap
+For the current progress on features, please visit the [project board](https://github.com/willowtreeapps/vocable-ios/projects/1).
 
-## In-Progress:
-
-## Up Next:
-
-## Future:
+For a high-level roadmap, see the [Vocable Roadmap](./ROADMAP.md)
 
 ## Contributing
+We love contributions! To get started, please see our [Contributing Guidelines](./CONTRIBUTING.md).
 
-## Requirements
+## Device Requirements
 - iOS 13.0
-- iOS devices with TrueDepth camera (currently iPad Pro only for v1.0)
-
-## Build instructions
+- iOS devices with TrueDepth camera
 
 ## Credits
 Matt Kubota, Kyle Ohanian, Duncan Lewis, Ameir Al-Zoubi, and many more from [WillowTree](https://willowtreeapps.com/) 💙.
 
 ## License
 vocable-ios is released under the MIT license. See [LICENSE](LICENSE) for details.
+
+## Other Variants
+vocable-android is available on [Google Play](https://play.google.com/store/apps/details?id=com.willowtree.vocable) and is also [open-source](https://github.com/willowtreeapps/vocable-android). 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,16 @@
+# Vocable Roadmap
+
+- [ ] Handset Support
+- [ ] Edit and delete customized presets
+- [ ] Custom Categories: create, edit, and delete
+- [ ] Custom category/phrase sorting and UI placement
+- [ ] History: recently-spoken phrases
+- [ ] Head tracking calibration
+- [ ] Audio feedback for navigation
+- [ ] Potential Voice integration
+- [ ] Alternative modalities / input actions (e.g. touch, joystick method, scanning)
+- [ ] Light / Dark Mode
+- [ ] Localization of app strings
+- [ ] Localization of keyboard(s)
+- [ ] Photo upload / pictoral buttons
+- [ ] Translate selected phrase ↔️ spoken phrase


### PR DESCRIPTION
Here's a first pass at a more open-source-friendly README. There's a few more additions I'd like to run by the team:
- Adding a short architecture overview
- Is there value in adding building instructions / a note on how WillowTree owns the provisioning?
- Thoughts on adding something to help hype up any open-source contributions? I've seen  some open-source projects have success with something like [hall-of-fame](https://github.com/sourcerer-io/hall-of-fame): it automates celebrating contributions, and is a neat way to thank contributors that come our way.

Closes #19
