### PR TITLE
Bugfix QWERTY keyboard on small iPhone 

### DIFF
--- a/EyeSpeak/Features/Presets/PresetsViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsViewController.swift
@@ -241,7 +241,7 @@ class PresetsViewController: UICollectionViewController {
             }
             
             snapshot.appendSections([.keyboard])
-            if traitCollection.horizontalSizeClass == .compact {
+            if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular {
                 snapshot.appendItems(KeyboardKeys.alphabetical.map { ItemWrapper.key("\($0)") })
             } else {
                 snapshot.appendItems(KeyboardKeys.qwerty.map { ItemWrapper.key("\($0)") })


### PR DESCRIPTION
Changes included:
- Updated logic to only show alphabetic keyboard when device has compact width & regular regular (all iPhones)