### PR TITLE
Design layout fixes iPhone

### DIFF
--- a/EyeSpeak/Features/Presets/Categories/CategoriesPageViewController.swift
+++ b/EyeSpeak/Features/Presets/Categories/CategoriesPageViewController.swift
@@ -12,8 +12,10 @@ import CoreData
 class CategoriesPageViewController: UIPageViewController, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
     
     private var itemsPerPage: Int {
-        if case .regular = traitCollection.horizontalSizeClass {
+        if traitCollection.horizontalSizeClass == .regular && traitCollection.verticalSizeClass == .regular {
             return 4
+        } else if traitCollection.verticalSizeClass == .compact {
+            return 3
         }
         
         return 1

--- a/EyeSpeak/Features/Presets/PresetItemCollectionViewCell.xib
+++ b/EyeSpeak/Features/Presets/PresetItemCollectionViewCell.xib
@@ -18,9 +18,15 @@
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qn0-yK-CCv">
                         <rect key="frame" x="16" y="44" width="237" height="174"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                        <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
+                        <variation key="heightClass=compact">
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                        </variation>
+                        <variation key="heightClass=regular-widthClass=compact">
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                        </variation>
                     </label>
                 </subviews>
             </view>

--- a/EyeSpeak/Features/Presets/PresetItemCollectionViewCell.xib
+++ b/EyeSpeak/Features/Presets/PresetItemCollectionViewCell.xib
@@ -18,15 +18,9 @@
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qn0-yK-CCv">
                         <rect key="frame" x="16" y="44" width="237" height="174"/>
-                        <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
-                        <variation key="heightClass=compact">
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
-                        </variation>
-                        <variation key="heightClass=regular-widthClass=compact">
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
-                        </variation>
                     </label>
                 </subviews>
             </view>

--- a/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetPageCollectionViewController.swift
@@ -128,7 +128,7 @@ class PresetPageCollectionViewController: UICollectionViewController {
                 case (.compact, .compact):
                     return (2, 3)
                 case (.compact, .regular):
-                    return (3, 2)
+                    return (4, 2)
                 default:
                     return (2, 3)
                 }

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -71,20 +71,18 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
         }
         
         var compactWidthContainerGroupLayout: NSCollectionLayoutGroup {
-            let textFieldItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.5)))
+            let textFieldItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(2 / 3)))
             
-            let leadingFunctionItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0)))
-            leadingFunctionItem.contentInsets = .init(top: 4, leading: 0, bottom: 0, trailing: 4)
-            let trailingFunctionItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0)))
-            trailingFunctionItem.contentInsets = .init(top: 4, leading: 4, bottom: 0, trailing: 0)
+            let functionItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1 / 2), heightDimension: .fractionalHeight(1.0)))
+            functionItem.contentInsets = .init(top: 4, leading: 0, bottom: 0, trailing: 4)
 
             let functionItemGroup = NSCollectionLayoutGroup.horizontal(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                                   heightDimension: .fractionalHeight(0.5)),
-                subitems: [leadingFunctionItem, trailingFunctionItem])
+                                                   heightDimension: .fractionalHeight(1 / 3)),
+                subitems: [functionItem, functionItem])
             
             return NSCollectionLayoutGroup.vertical(
-                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0 / 4.0)),
+                layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0 / 5.0)),
                 subitems: [textFieldItem, functionItemGroup])
         }
         

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -88,7 +88,7 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
                 subitems: [textFieldItem, functionItemGroup])
         }
         
-        let containerGroup = environment.traitCollection.horizontalSizeClass == .regular ? regularWidthContainerGroupLayout : compactWidthContainerGroupLayout
+        let containerGroup = environment.traitCollection.horizontalSizeClass == .compact && environment.traitCollection.verticalSizeClass == .regular ? compactWidthContainerGroupLayout : regularWidthContainerGroupLayout
         
         let section = NSCollectionLayoutSection(group: containerGroup)
         
@@ -155,6 +155,11 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
                 return .fractionalWidth(906.0 / totalSectionWidth)
             }
             
+            if traitCollection.verticalSizeClass == .compact
+                && traitCollection.horizontalSizeClass == .compact {
+                return .fractionalWidth(4 / 5.0)
+            }
+            
             return .fractionalWidth(3.0 / 5.0)
         }
         
@@ -166,6 +171,11 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
         var paginationItemFractionalWidth: NSCollectionLayoutDimension {
             if case .regular = traitCollection.horizontalSizeClass {
                 return .fractionalWidth(104.0 / totalSectionWidth)
+            }
+            
+            if traitCollection.verticalSizeClass == .compact
+                && traitCollection.horizontalSizeClass == .compact {
+                return .fractionalWidth(0.5 / 5.0)
             }
             
             return .fractionalWidth(1.0 / 5.0)

--- a/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
+++ b/EyeSpeak/Features/Presets/PresetUICollectionViewCompositionalLayout.swift
@@ -245,7 +245,7 @@ class PresetUICollectionViewCompositionalLayout: UICollectionViewCompositionalLa
             
             let presetPageItem = NSCollectionLayoutItem(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                                   heightDimension: .fractionalHeight(504.0 / totalSize.height)))
+                                                   heightDimension: .fractionalHeight(490.0 / totalSize.height)))
             
             let leadingPaginationItem = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(146.0 / totalSize.width), heightDimension: .fractionalHeight(1)))
             leadingPaginationItem.edgeSpacing = .init(leading: .flexible(flexibleSpacing), top: nil, trailing: nil, bottom: nil)

--- a/EyeSpeak/Features/Presets/PresetsPageViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsPageViewController.swift
@@ -16,10 +16,10 @@ class PresetsPageViewController: UIPageViewController, UIPageViewControllerDataS
     
     private var itemsPerPage: Int {
         switch (traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass) {
-        case (.compact, .regular):
-            return 12
         case (.regular, .regular), (.regular, .compact):
             return 9
+        case (.compact, .regular):
+            return 8
         default:
             return 6
         }

--- a/EyeSpeak/Features/Presets/PresetsPageViewController.swift
+++ b/EyeSpeak/Features/Presets/PresetsPageViewController.swift
@@ -16,6 +16,8 @@ class PresetsPageViewController: UIPageViewController, UIPageViewControllerDataS
     
     private var itemsPerPage: Int {
         switch (traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass) {
+        case (.compact, .regular):
+            return 12
         case (.regular, .regular), (.regular, .compact):
             return 9
         default:


### PR DESCRIPTION
Changes included:
- Fixing bug where pagination was being cut off on small iPhones (with compact width) because landscape on small iPhones was using portrait top bar layout
- Updated number of categories to always be 3 for landscape on iPhone rather than 1 or 4
- Updated spacing for top bar on portrait on iPhone to be smaller a fractional height to match sizing on keyboard mode

Old Portrait:
<img width="200" alt="Screen Shot 2020-03-09 at 1 38 15 PM" src="https://user-images.githubusercontent.com/37670742/76251669-ce200500-621d-11ea-8dac-56df6f6bd2ef.png">

New Portrait:
<img width="200" alt="Screen Shot 2020-03-09 at 3 50 50 PM" src="https://user-images.githubusercontent.com/37670742/76251680-d710d680-621d-11ea-9178-927b534cdd0d.png">

Old landscape:
<img width="500" alt="Screen Shot 2020-03-09 at 3 50 32 PM" src="https://user-images.githubusercontent.com/37670742/76251704-de37e480-621d-11ea-99b7-87f3276b3540.png">

New landscape:
<img width="500" alt="Screen Shot 2020-03-09 at 3 50 11 PM" src="https://user-images.githubusercontent.com/37670742/76251713-e2fc9880-621d-11ea-98cf-df5600c181c4.png">

