### PR TITLE
Fixes for My Sayings scrolling and deletion animations

### DIFF
--- a/Vocable/Common/CarouselGridCollectionViewController.swift
+++ b/Vocable/Common/CarouselGridCollectionViewController.swift
@@ -18,11 +18,17 @@ class CarouselGridCollectionViewController: UICollectionViewController {
     }
 
     @objc func scrollToNextPage() {
+        guard let pageCount = layout.progress?.pageCount, pageCount > 1 else {
+            return
+        }
         let nextRect = layout.nextPageRect
         collectionView.scrollRectToVisible(nextRect, animated: true)
     }
 
     @objc func scrollToPreviousPage() {
+        guard let pageCount = layout.progress?.pageCount, pageCount > 1 else {
+            return
+        }
         let nextRect = layout.previousPageRect
         collectionView.scrollRectToVisible(nextRect, animated: true)
     }

--- a/Vocable/Common/CarouselGridCollectionViewController.swift
+++ b/Vocable/Common/CarouselGridCollectionViewController.swift
@@ -125,9 +125,6 @@ class CarouselGridLayout: UICollectionViewLayout {
     @Published
     var progress: CarouselGridPagingProgress?
 
-    private var lastInvalidatedSize: CGSize = .zero
-    private var lastInvalidatedVisiblePages = Set<Int>()
-    
     private var numberOfPages: Int {
         guard let collectionView = collectionView, collectionView.window != nil else { return 1 }
         let pageCount = Int((Double(collectionView.numberOfItems(inSection: 0)) / Double(itemsPerPage)).rounded(.up))
@@ -204,22 +201,7 @@ class CarouselGridLayout: UICollectionViewLayout {
     }
 
     override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-
-        // Invalidate in the event the collection view undergoes a size change
-        if newBounds.size != lastInvalidatedSize {
-            lastInvalidatedSize = newBounds.size
-            return true
-        }
-
-        // Invalidate when the visible pages change so we can be sure
-        // the logical content is correct
-        let proposedPages = visiblePages(forBounds: newBounds)
-        if proposedPages != lastInvalidatedVisiblePages {
-            lastInvalidatedVisiblePages = proposedPages
-            return true
-        }
-
-        return false
+        return true
     }
 
     private func visiblePages(forBounds bounds: CGRect) -> Set<Int> {

--- a/Vocable/Common/CarouselGridCollectionViewController.swift
+++ b/Vocable/Common/CarouselGridCollectionViewController.swift
@@ -48,7 +48,7 @@ class CarouselGridCollectionViewController: UICollectionViewController {
         collectionView.contentInsetAdjustmentBehavior = .never
         collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
-
+        collectionView.delaysContentTouches = false
         layout.resetScrollViewOffset(inResponseToUserInteraction: false)
     }
 

--- a/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
@@ -70,6 +70,14 @@ class EditSayingsCollectionViewController: CarouselGridCollectionViewController,
         }
     }
 
+    override func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         updateDataSource(animated: true, completion: { [weak self] in
             self?.layout.resetScrollViewOffset(inResponseToUserInteraction: false,

--- a/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
@@ -71,16 +71,21 @@ class EditSayingsCollectionViewController: CarouselGridCollectionViewController,
     }
 
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        updateDataSource(animated: true)
+        updateDataSource(animated: true, completion: { [weak self] in
+            self?.layout.resetScrollViewOffset(inResponseToUserInteraction: false,
+                                               animateIfNeeded: true)
+        })
     }
 
-    private func updateDataSource(animated: Bool) {
+    private func updateDataSource(animated: Bool, completion: (() -> Void)? = nil) {
         let content = fetchResultsController.fetchedObjects ?? []
         let viewModels = content.compactMap(PhraseViewModel.init)
         var snapshot = NSDiffableDataSourceSnapshot<Int, PhraseViewModel>()
         snapshot.appendSections([0])
         snapshot.appendItems(viewModels)
-        diffableDataSource.apply(snapshot, animatingDifferences: animated)
+        diffableDataSource.apply(snapshot,
+                                 animatingDifferences: animated,
+                                 completion: completion)
     }
 
     @objc private func handleCellDeletionButton(_ sender: UIButton) {


### PR DESCRIPTION
Resolves #139 
* Fixes an issue where deleting the last item on a page would not scroll back to the previous page correctly
* Improves touch handling performance
* Prevents cell selection/highlight on My Sayings