### PR TITLE
ARKit Dependency Removal

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		6B9DFA7023E88A630037673E /* InterpolableValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9DFA6B23E88A250037673E /* InterpolableValues.swift */; };
 		6B9DFA7423E8D1270037673E /* TrackingContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9DFA7323E8D1270037673E /* TrackingContainerViewController.swift */; };
 		6B9DFA7623E8D59A0037673E /* UICollectionView+Gaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9DFA7523E8D5990037673E /* UICollectionView+Gaze.swift */; };
+		6BB56BA82422AC2500EA787E /* PhraseSavedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB56BA72422AC2500EA787E /* PhraseSavedView.swift */; };
+		6BB56BAA2422B40300EA787E /* PublishedDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB56BA92422B40200EA787E /* PublishedDefault.swift */; };
 		6BFB18BE24002BFE002C3515 /* NSPersistentContainer+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFB18BD24002BFE002C3515 /* NSPersistentContainer+Shared.swift */; };
 		6BFB18C224002C7B002C3515 /* Phrases.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 6BFB18C024002C7B002C3515 /* Phrases.xcdatamodeld */; };
 		6BFB18C424004406002C3515 /* NSManagedObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFB18C324004406002C3515 /* NSManagedObject+Helpers.swift */; };
@@ -165,6 +167,8 @@
 		6B9DFA6D23E88A250037673E /* LowPassInterpolator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LowPassInterpolator.swift; sourceTree = "<group>"; };
 		6B9DFA7323E8D1270037673E /* TrackingContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingContainerViewController.swift; sourceTree = "<group>"; };
 		6B9DFA7523E8D5990037673E /* UICollectionView+Gaze.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Gaze.swift"; sourceTree = "<group>"; };
+		6BB56BA72422AC2500EA787E /* PhraseSavedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhraseSavedView.swift; sourceTree = "<group>"; };
+		6BB56BA92422B40200EA787E /* PublishedDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedDefault.swift; sourceTree = "<group>"; };
 		6BFB18BD24002BFE002C3515 /* NSPersistentContainer+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPersistentContainer+Shared.swift"; sourceTree = "<group>"; };
 		6BFB18C124002C7B002C3515 /* Phrases.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Phrases.xcdatamodel; sourceTree = "<group>"; };
 		6BFB18C324004406002C3515 /* NSManagedObject+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Helpers.swift"; sourceTree = "<group>"; };
@@ -455,6 +459,7 @@
 				A944D0042405AE8C00F3863E /* GazeableButton.swift */,
 				71DBE5EA240DE4D000BA8D01 /* WarningView.xib */,
 				71B856432416CEB600CB163B /* PhraseSavedView.xib */,
+				6BB56BA72422AC2500EA787E /* PhraseSavedView.swift */,
 				A94720CD241A8D9B00F7B4FF /* PaginationView.swift */,
 			);
 			path = Views;
@@ -474,6 +479,7 @@
 			isa = PBXGroup;
 			children = (
 				B838202723FC99AE005A79CD /* Views */,
+				6BB56BA92422B40200EA787E /* PublishedDefault.swift */,
 				B81AC0AC2405D8C400972E85 /* ItemSelection.swift */,
 				A9E665A6241A785F00FE577A /* CarouselGridCollectionViewController.swift */,
 			);
@@ -727,6 +733,7 @@
 				B81AC0AD2405D8C400972E85 /* ItemSelection.swift in Sources */,
 				6B17CD8023EA045D0050BCB8 /* ViewControllerWrapperView.swift in Sources */,
 				B8DA9DF223F30BAF00FEBE19 /* Cell+NibLoading.swift in Sources */,
+				6BB56BA82422AC2500EA787E /* PhraseSavedView.swift in Sources */,
 				6B9DFA6E23E88A5F0037673E /* LowPassInterpolator.swift in Sources */,
 				A9326C8D241C1A3300F7026C /* EditSayingsCollectionViewController.swift in Sources */,
 				B81D235623FED535005741E8 /* PresetPaginationContainerCollectionViewCell.swift in Sources */,
@@ -764,6 +771,7 @@
 				718D7FAE2419546F00FDEF93 /* EditSayingsCollectionViewCell.swift in Sources */,
 				A9299C7523F5FBEE00903AB6 /* KeyboardKeyCollectionViewCell.swift in Sources */,
 				6B9DFA5B23E889DB0037673E /* UIHeadGazeViewController.swift in Sources */,
+				6BB56BAA2422B40300EA787E /* PublishedDefault.swift in Sources */,
 				6B823BCD23F4ADE30099F65E /* TunningWindow.swift in Sources */,
 				A94720CE241A8D9B00F7B4FF /* PaginationView.swift in Sources */,
 				B838200F23F4B011005A79CD /* VocableCollectionViewCell.swift in Sources */,

--- a/Vocable/AppConfig.swift
+++ b/Vocable/AppConfig.swift
@@ -10,7 +10,7 @@ import Foundation
 import Combine
 import ARKit
 
-final class AppConfig {
+struct AppConfig {
 
     static let showPIDTunerDebugMenu: Bool = {
         #if DEBUG

--- a/Vocable/AppConfig.swift
+++ b/Vocable/AppConfig.swift
@@ -8,8 +8,10 @@
 
 import Foundation
 import Combine
+import ARKit
 
-struct AppConfig {
+final class AppConfig {
+
     static let showPIDTunerDebugMenu: Bool = {
         #if DEBUG
         return true
@@ -17,16 +19,10 @@ struct AppConfig {
         return false
         #endif
     }()
-    
-    static var isHeadTrackingEnabled = UserDefaults.standard.value(forKey: "isHeadTrackingEnabled") as? Bool ?? true {
-        didSet {
-            UserDefaults.standard.set(isHeadTrackingEnabled, forKey: "isHeadTrackingEnabled")
-            headTrackingValueSubject.send(isHeadTrackingEnabled)
-            if !isHeadTrackingEnabled {
-                NotificationCenter.default.post(name: .headTrackingDisabled, object: nil)
-            }
-        }
+
+    @PublishedDefault(key: "isHeadTrackingEnabled", defaultValue: AppConfig.isHeadTrackingSupported)
+    static var isHeadTrackingEnabled: Bool
+    static var isHeadTrackingSupported: Bool {
+        return ARFaceTrackingConfiguration.isSupported
     }
-    
-    static let headTrackingValueSubject = CurrentValueSubject<Bool, Never>(isHeadTrackingEnabled)
 }

--- a/Vocable/Base.lproj/Main.storyboard
+++ b/Vocable/Base.lproj/Main.storyboard
@@ -16,12 +16,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h77-DW-Ra2" userLabel="TrackingContainer">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <connections>
-                                    <segue destination="Gya-9R-y3J" kind="embed" id="hQM-OQ-1Dc"/>
-                                </connections>
-                            </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AQq-Gr-kNC" userLabel="ContentViewController">
                                 <rect key="frame" x="16" y="8" width="343" height="651"/>
                                 <connections>
@@ -31,14 +25,10 @@
                         </subviews>
                         <color key="backgroundColor" name="Background"/>
                         <constraints>
-                            <constraint firstItem="h77-DW-Ra2" firstAttribute="leading" secondItem="QoN-fl-FyW" secondAttribute="leading" id="2vi-F0-7jD"/>
-                            <constraint firstItem="h77-DW-Ra2" firstAttribute="top" secondItem="QoN-fl-FyW" secondAttribute="top" id="35q-ga-C7k"/>
                             <constraint firstItem="AQq-Gr-kNC" firstAttribute="top" secondItem="QoN-fl-FyW" secondAttribute="topMargin" id="Pkw-eU-h0R"/>
                             <constraint firstItem="AQq-Gr-kNC" firstAttribute="leading" secondItem="QoN-fl-FyW" secondAttribute="leadingMargin" id="aS7-NB-aKe"/>
-                            <constraint firstAttribute="bottom" secondItem="h77-DW-Ra2" secondAttribute="bottom" id="aiY-pn-mC3"/>
                             <constraint firstAttribute="bottomMargin" secondItem="AQq-Gr-kNC" secondAttribute="bottom" id="gjT-Qg-rfd"/>
                             <constraint firstAttribute="trailingMargin" secondItem="AQq-Gr-kNC" secondAttribute="trailing" id="oal-gs-OpX"/>
-                            <constraint firstAttribute="trailing" secondItem="h77-DW-Ra2" secondAttribute="trailing" id="tKc-EE-VNA"/>
                         </constraints>
                         <edgeInsets key="layoutMargins" top="32" left="32" bottom="32" right="32"/>
                         <viewLayoutGuide key="safeArea" id="N6F-RO-WaJ"/>
@@ -53,21 +43,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9OF-pV-I9m" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1668.1640625" y="-1443.3382137628109"/>
-        </scene>
-        <!--Head Gaze View Controller-->
-        <scene sceneID="RBx-lz-Ojp">
-            <objects>
-                <viewController id="Gya-9R-y3J" customClass="UIHeadGazeViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="0FP-BP-SNo">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" name="Background"/>
-                        <viewLayoutGuide key="safeArea" id="GGj-AU-Ual"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="BPb-7J-yob" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-489" y="-2119"/>
         </scene>
         <!--Presets View Controller-->
         <scene sceneID="wcZ-O0-4Me">

--- a/Vocable/Common/PublishedDefault.swift
+++ b/Vocable/Common/PublishedDefault.swift
@@ -1,0 +1,48 @@
+//
+//  PublishedDefault.swift
+//  Vocable
+//
+//  Created by Chris Stroud on 3/18/20.
+//  Copyright © 2020 WillowTree. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+@propertyWrapper
+struct PublishedDefault<T: Codable> {
+
+    private let defaultsKey: String
+    private let subject = PassthroughSubject<T, Never>()
+
+    var wrappedValue: T {
+        didSet {
+            guard let encoded = try? JSONEncoder().encode(wrappedValue) else {
+                UserDefaults.standard.removeObject(forKey: defaultsKey)
+                return
+            }
+            UserDefaults.standard.set(encoded, forKey: defaultsKey)
+            subject.send(wrappedValue)
+        }
+    }
+
+    var projectedValue: AnyPublisher<T, Never> {
+        mutating get {
+            return subject.eraseToAnyPublisher()
+        }
+    }
+
+    init(key: String, defaultValue: T) {
+        self.defaultsKey = key
+        self.wrappedValue = PublishedDefault.currentDefaultsValue(for: key) ?? defaultValue
+    }
+
+    private static func currentDefaultsValue(for key: String) -> T? {
+        if let data = UserDefaults.standard.data(forKey: key) {
+            if let decoded = try? JSONDecoder().decode(T.self, from: data) {
+                return decoded
+            }
+        }
+        return nil
+    }
+}

--- a/Vocable/Common/Views/PhraseSavedView.swift
+++ b/Vocable/Common/Views/PhraseSavedView.swift
@@ -1,0 +1,31 @@
+//
+//  PhraseSavedView.swift
+//  Vocable
+//
+//  Created by Chris Stroud on 3/18/20.
+//  Copyright © 2020 WillowTree. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+class PhraseSavedView: BorderedView {
+
+    override var bounds: CGRect {
+        didSet {
+            cornerRadius = bounds.height / 2
+        }
+    }
+
+    override var frame: CGRect {
+        didSet {
+            cornerRadius = frame.height / 2
+        }
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setContentHuggingPriority(.required, for: .vertical)
+        setContentHuggingPriority(.required, for: .horizontal)
+    }
+}

--- a/Vocable/Common/Views/PhraseSavedView.xib
+++ b/Vocable/Common/Views/PhraseSavedView.xib
@@ -1,40 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view alpha="0.0" contentMode="scaleToFill" restorationIdentifier="WarningView" id="yiJ-Tr-Jim" userLabel="savePhraseView">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+        <view opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="yiJ-Tr-Jim" userLabel="savePhraseView" customClass="PhraseSavedView" customModule="Vocable" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="387" height="108"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Saved to &quot;My Savings&quot;" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="fEx-Zh-S4e">
-                    <rect key="frame" x="25" y="434" width="364" height="38.5"/>
-                    <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="32"/>
-                    <color key="textColor" red="0.96079725029999996" green="0.96076112989999995" blue="0.960785687" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="750" text="Saved to My Sayings" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEx-Zh-S4e">
+                    <rect key="frame" x="32" y="16" width="323" height="76"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="48"/>
+                    <color key="textColor" name="DefaultFontColor"/>
                     <nil key="highlightedColor"/>
+                    <variation key="widthClass=compact">
+                        <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
+                    </variation>
                 </label>
             </subviews>
-            <color key="backgroundColor" red="0.12549019607843137" green="0.10980392156862745" blue="0.35686274509803922" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <accessibility key="accessibilityConfiguration" identifier="WarningView"/>
             <constraints>
-                <constraint firstItem="fEx-Zh-S4e" firstAttribute="leading" secondItem="PHA-Wo-3xQ" secondAttribute="leading" constant="25" id="F6a-Yj-fwh"/>
-                <constraint firstItem="fEx-Zh-S4e" firstAttribute="centerX" secondItem="PHA-Wo-3xQ" secondAttribute="centerX" id="I6i-n0-aZ6"/>
-                <constraint firstItem="fEx-Zh-S4e" firstAttribute="centerY" secondItem="PHA-Wo-3xQ" secondAttribute="centerY" id="XFX-L7-r4v"/>
-                <constraint firstItem="PHA-Wo-3xQ" firstAttribute="trailing" secondItem="fEx-Zh-S4e" secondAttribute="trailing" constant="25" id="Z72-3D-DUY"/>
+                <constraint firstAttribute="trailingMargin" secondItem="fEx-Zh-S4e" secondAttribute="trailing" id="GWB-Ur-efQ"/>
+                <constraint firstItem="fEx-Zh-S4e" firstAttribute="top" secondItem="yiJ-Tr-Jim" secondAttribute="topMargin" id="U0j-0K-NGR"/>
+                <constraint firstItem="fEx-Zh-S4e" firstAttribute="leading" secondItem="yiJ-Tr-Jim" secondAttribute="leadingMargin" id="eSP-vo-rwj"/>
+                <constraint firstAttribute="bottomMargin" secondItem="fEx-Zh-S4e" secondAttribute="bottom" id="jqx-on-aBa"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="PHA-Wo-3xQ"/>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <edgeInsets key="layoutMargins" top="28" left="48" bottom="28" right="48"/>
             <userDefinedRuntimeAttributes>
-                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                    <integer key="value" value="20"/>
+                <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
+                    <color key="value" red="0.12549019610000001" green="0.10980392160000001" blue="0.35686274509999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </userDefinedRuntimeAttribute>
             </userDefinedRuntimeAttributes>
-            <point key="canvasLocation" x="45" y="33"/>
+            <variation key="widthClass=compact">
+                <edgeInsets key="layoutMargins" top="16" left="32" bottom="16" right="32"/>
+            </variation>
+            <point key="canvasLocation" x="313.768115942029" y="110.49107142857143"/>
         </view>
     </objects>
+    <resources>
+        <namedColor name="DefaultFontColor">
+            <color red="0.81599998474121094" green="0.93199998140335083" blue="0.91299998760223389" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/Vocable/Common/Views/TrackingContainerViewController.swift
+++ b/Vocable/Common/Views/TrackingContainerViewController.swift
@@ -13,27 +13,21 @@ final class TrackingContainerViewController: UIViewController {
 
     @IBOutlet private var cursorView: UIVirtualCursorView!
 
-    private var headTrackingEnabledPublisher: AnyCancellable?
-
     private var contentViewController: UIViewController!
     private var trackingViewController: UIHeadGazeViewController?
 
+    private var cancellables = Set<AnyCancellable>()
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        headTrackingEnabledPublisher = AppConfig.$isHeadTrackingEnabled.sink { [weak self] isEnabled in
-            DispatchQueue.main.async {
-                self?.updateTrackingViewControllerForHeadTrackingState(isEnabled: isEnabled)
+        AppConfig.$isHeadTrackingEnabled.sink { [weak self] isEnabled in
+            guard let self = self else { return }
+            if isEnabled {
+                self.installTrackingViewController()
+            } else {
+                self.removeTrackingViewController()
             }
-        }
-        updateTrackingViewControllerForHeadTrackingState(isEnabled: AppConfig.isHeadTrackingEnabled)
-    }
-
-    private func updateTrackingViewControllerForHeadTrackingState(isEnabled: Bool) {
-        if isEnabled {
-            installTrackingViewController()
-        } else {
-            removeTrackingViewController()
-        }
+        }.store(in: &cancellables)
     }
 
     private func installTrackingViewController() {

--- a/Vocable/Common/Views/TrackingContainerViewController.swift
+++ b/Vocable/Common/Views/TrackingContainerViewController.swift
@@ -7,13 +7,62 @@
 //
 
 import UIKit
+import Combine
 
 final class TrackingContainerViewController: UIViewController {
 
     @IBOutlet private var cursorView: UIVirtualCursorView!
-    
+
+    private var headTrackingEnabledPublisher: AnyCancellable?
+
     private var contentViewController: UIViewController!
-    
+    private var trackingViewController: UIHeadGazeViewController?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        headTrackingEnabledPublisher = AppConfig.$isHeadTrackingEnabled.sink { [weak self] isEnabled in
+            DispatchQueue.main.async {
+                self?.updateTrackingViewControllerForHeadTrackingState(isEnabled: isEnabled)
+            }
+        }
+        updateTrackingViewControllerForHeadTrackingState(isEnabled: AppConfig.isHeadTrackingEnabled)
+    }
+
+    private func updateTrackingViewControllerForHeadTrackingState(isEnabled: Bool) {
+        if isEnabled {
+            installTrackingViewController()
+        } else {
+            removeTrackingViewController()
+        }
+    }
+
+    private func installTrackingViewController() {
+        guard trackingViewController?.parent == nil else { return }
+
+        let trackingViewController = UIHeadGazeViewController()
+        let trackingView = trackingViewController.view!
+        trackingView.isHidden = true
+        addChild(trackingViewController)
+
+        trackingView.translatesAutoresizingMaskIntoConstraints = false
+        view.insertSubview(trackingView, at: 0)
+        trackingView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        trackingView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+        trackingView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        trackingView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+
+        trackingViewController.didMove(toParent: self)
+        self.trackingViewController = trackingViewController
+    }
+
+    private func removeTrackingViewController() {
+        guard let trackingViewController = trackingViewController else { return }
+        trackingViewController.willMove(toParent: nil)
+        trackingViewController.removeFromParent()
+        trackingViewController.view.removeFromSuperview()
+        self.trackingViewController = nil
+    }
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "ContentViewControllerSegue" {
             self.contentViewController = segue.destination

--- a/Vocable/Common/Views/WarningView.xib
+++ b/Vocable/Common/Views/WarningView.xib
@@ -3,24 +3,23 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view alpha="0.0" contentMode="scaleToFill" restorationIdentifier="WarningView" id="vne-Os-cO5" userLabel="warningView">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+        <view contentMode="scaleToFill" restorationIdentifier="WarningView" id="vne-Os-cO5" userLabel="warningView">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="96"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" spacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="S4d-WD-rX7">
-                    <rect key="frame" x="25" y="435" width="364" height="36"/>
+                <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" spacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="S4d-WD-rX7">
+                    <rect key="frame" x="24" y="60" width="366" height="20"/>
                     <subviews>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" image="CircleAlert" translatesAutoresizingMaskIntoConstraints="NO" id="vV9-av-v3S">
-                            <rect key="frame" x="0.0" y="0.0" width="36" height="36"/>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" insetsLayoutMarginsFromSafeArea="NO" image="CircleAlert" translatesAutoresizingMaskIntoConstraints="NO" id="vV9-av-v3S">
+                            <rect key="frame" x="0.0" y="0.0" width="37.5" height="20"/>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Please move closer to the device." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="OzB-7o-j7j">
-                            <rect key="frame" x="49" y="0.0" width="315" height="36"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" insetsLayoutMarginsFromSafeArea="NO" text="Please move closer to the device." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="OzB-7o-j7j">
+                            <rect key="frame" x="50.5" y="0.0" width="315.5" height="20"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                             <color key="textColor" red="0.96079725029999996" green="0.96076112989999995" blue="0.960785687" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <nil key="highlightedColor"/>
@@ -28,23 +27,28 @@
                     </subviews>
                     <color key="backgroundColor" red="0.67843137249999996" green="0.0" blue="0.42352941179999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <color key="tintColor" red="0.67843137249999996" green="0.0" blue="0.42352941179999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" priority="250" constant="427" id="Qz0-Hu-BF5"/>
+                    </constraints>
                 </stackView>
             </subviews>
             <color key="backgroundColor" red="0.67843137249999996" green="0.0" blue="0.42352941179999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <accessibility key="accessibilityConfiguration" identifier="WarningView"/>
             <constraints>
-                <constraint firstItem="S4d-WD-rX7" firstAttribute="centerX" secondItem="AQu-Vm-ZvT" secondAttribute="centerX" id="0nA-XJ-UmI"/>
-                <constraint firstItem="S4d-WD-rX7" firstAttribute="centerY" secondItem="AQu-Vm-ZvT" secondAttribute="centerY" id="FaT-JM-wM4"/>
-                <constraint firstItem="S4d-WD-rX7" firstAttribute="leading" secondItem="AQu-Vm-ZvT" secondAttribute="leading" constant="25" id="Ur4-Ey-gW2"/>
-                <constraint firstItem="AQu-Vm-ZvT" firstAttribute="trailing" secondItem="S4d-WD-rX7" secondAttribute="trailing" constant="25" id="izi-Ji-eVb"/>
+                <constraint firstAttribute="bottomMargin" secondItem="S4d-WD-rX7" secondAttribute="bottom" id="6Hw-OE-h6J"/>
+                <constraint firstAttribute="trailingMargin" secondItem="S4d-WD-rX7" secondAttribute="trailing" id="Ae0-AK-re5"/>
+                <constraint firstItem="S4d-WD-rX7" firstAttribute="leading" secondItem="vne-Os-cO5" secondAttribute="leadingMargin" id="J4T-dO-7gl"/>
+                <constraint firstItem="S4d-WD-rX7" firstAttribute="top" secondItem="vne-Os-cO5" secondAttribute="topMargin" id="OXs-DF-elY"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="AQu-Vm-ZvT"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <edgeInsets key="layoutMargins" top="16" left="24" bottom="16" right="24"/>
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                     <integer key="value" value="10"/>
                 </userDefinedRuntimeAttribute>
             </userDefinedRuntimeAttributes>
-            <point key="canvasLocation" x="45" y="33"/>
+            <point key="canvasLocation" x="44.927536231884062" y="-235.04464285714283"/>
         </view>
     </objects>
     <resources>

--- a/Vocable/Features/Settings/SettingsCollectionViewController.swift
+++ b/Vocable/Features/Settings/SettingsCollectionViewController.swift
@@ -217,7 +217,9 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
         switch item {
         case .headTrackingToggle:
             if AppConfig.isHeadTrackingEnabled {
-                let alertViewController = GazeableAlertViewController.make { AppConfig.isHeadTrackingEnabled.toggle() }
+                let alertViewController = GazeableAlertViewController.make {
+                    AppConfig.isHeadTrackingEnabled.toggle()
+                }
                 present(alertViewController, animated: true)
                 alertViewController.setAlertTitle("Turn off head tracking?")
             } else {
@@ -243,7 +245,7 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
             for child in gazeWindow.rootViewController?.children ?? [] {
                 if let child = child as? UIHeadGazeViewController {
                     child.pidInterpolator.pidSmoothingInterpolator.pulse.showTunningView(minimumValue: -1.0, maximumValue: 1.0)
-                    gazeWindow.cursorView.isDebugCursorHidden = false
+                    gazeWindow.cursorView?.isDebugCursorHidden = false
                 }
             }
         case .versionNum:
@@ -256,6 +258,8 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
         switch item {
         case .versionNum:
             return false
+        case .headTrackingToggle:
+            return AppConfig.isHeadTrackingSupported
         default:
             return true
         }
@@ -266,6 +270,8 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
         switch item {
         case .versionNum:
             return false
+        case .headTrackingToggle:
+            return AppConfig.isHeadTrackingSupported
         default:
             return true
         }

--- a/Vocable/Features/Settings/SettingsCollectionViewController.swift
+++ b/Vocable/Features/Settings/SettingsCollectionViewController.swift
@@ -260,6 +260,8 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
             return false
         case .headTrackingToggle:
             return AppConfig.isHeadTrackingSupported
+        case .pidTuner:
+            return AppConfig.isHeadTrackingEnabled
         default:
             return true
         }
@@ -272,6 +274,8 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
             return false
         case .headTrackingToggle:
             return AppConfig.isHeadTrackingSupported
+        case .pidTuner:
+            return AppConfig.isHeadTrackingEnabled
         default:
             return true
         }

--- a/Vocable/Features/Settings/SettingsToggleCollectionViewCell.swift
+++ b/Vocable/Features/Settings/SettingsToggleCollectionViewCell.swift
@@ -15,15 +15,16 @@ class SettingsToggleCollectionViewCell: VocableCollectionViewCell {
     @IBOutlet var textLabel: UILabel!
     @IBOutlet var enabledSwitch: UISwitch!
     
-    private var subscriber: AnyCancellable?
+    private var cancellables = Set<AnyCancellable>()
+
     override func awakeFromNib() {
         super.awakeFromNib()
         enabledSwitch.isUserInteractionEnabled = false
         enabledSwitch.isEnabled = AppConfig.isHeadTrackingSupported
         enabledSwitch.isOn = AppConfig.isHeadTrackingEnabled
-        subscriber = AppConfig.$isHeadTrackingEnabled.sink { [weak self] isEnabled in
+        AppConfig.$isHeadTrackingEnabled.sink { [weak self] isEnabled in
             self?.enabledSwitch.setOn(isEnabled, animated: true)
-        }
+        }.store(in: &cancellables)
     }
     
     override func updateContentViews() {

--- a/Vocable/Features/Settings/SettingsToggleCollectionViewCell.swift
+++ b/Vocable/Features/Settings/SettingsToggleCollectionViewCell.swift
@@ -9,19 +9,21 @@
 import Foundation
 import UIKit
 import Combine
+import ARKit
 
 class SettingsToggleCollectionViewCell: VocableCollectionViewCell {
     @IBOutlet var textLabel: UILabel!
     @IBOutlet var enabledSwitch: UISwitch!
     
-    private var disposables = Set<AnyCancellable>()
-    
+    private var subscriber: AnyCancellable?
     override func awakeFromNib() {
         super.awakeFromNib()
         enabledSwitch.isUserInteractionEnabled = false
-        _ = AppConfig.headTrackingValueSubject.sink { (isHeadTrackingEnabled) in
-            self.enabledSwitch.setOn(isHeadTrackingEnabled, animated: true)
-        }.store(in: &disposables)
+        enabledSwitch.isEnabled = AppConfig.isHeadTrackingSupported
+        enabledSwitch.isOn = AppConfig.isHeadTrackingEnabled
+        subscriber = AppConfig.$isHeadTrackingEnabled.sink { [weak self] isEnabled in
+            self?.enabledSwitch.setOn(isEnabled, animated: true)
+        }
     }
     
     override func updateContentViews() {

--- a/Vocable/HeadGazeLib/HeadGazeWindow.swift
+++ b/Vocable/HeadGazeLib/HeadGazeWindow.swift
@@ -92,17 +92,28 @@ class HeadGazeWindow: UIWindow {
                 phraseSavedView.centerXAnchor.constraint(equalTo: centerXAnchor)
             ])
         }
-        UIView.animateKeyframes(withDuration: 2.0, delay: 0, options: [.beginFromCurrentState], animations: {
-            UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 0.1) {
-                self.phraseSavedView?.alpha = 1
-            }
-            UIView.addKeyframe(withRelativeStartTime: 0.9, relativeDuration: 0.1) {
-                self.phraseSavedView?.alpha = 0
-            }
-        }, completion: { [weak self] didFinish in
-            if didFinish {
-                self?.phraseSavedView?.removeFromSuperview()
-            }
+
+        let fadeInOutDuration: TimeInterval = 0.5
+        let presentationDuration: TimeInterval = 4
+
+        // Fade in
+        UIView.animate(withDuration: fadeInOutDuration,
+                       delay: 0,
+                       options: [.beginFromCurrentState, .curveEaseIn],
+                       animations: { self.phraseSavedView?.alpha = 1 },
+                       completion: { [weak self] entranceDidFinish in
+
+                        guard entranceDidFinish else { return }
+
+                        // Fade out
+                        UIView.animate(withDuration: fadeInOutDuration,
+                                       delay: presentationDuration,
+                                       options: [.beginFromCurrentState, .curveEaseOut],
+                                       animations: { self?.phraseSavedView?.alpha = 0 },
+                                       completion: { dismissalDidFinish in
+                                        guard dismissalDidFinish else { return }
+                                        self?.phraseSavedView?.removeFromSuperview()
+                        })
         })
     }
 

--- a/Vocable/HeadGazeLib/HeadGazeWindow.swift
+++ b/Vocable/HeadGazeLib/HeadGazeWindow.swift
@@ -157,6 +157,7 @@ class HeadGazeWindow: UIWindow {
             self.touchGazeDisableBeganDate = .distantPast
         } else {
             self.cursorView?.removeFromSuperview()
+            handleWarning(shouldDisplay: false)
         }
     }
 

--- a/Vocable/HeadGazeLib/Interpolation/PulseController/TunningWindow.swift
+++ b/Vocable/HeadGazeLib/Interpolation/PulseController/TunningWindow.swift
@@ -140,7 +140,7 @@ class TuningContainerViewController: UIViewController {
             TunningWindow.shared.isHidden = true
             for window in UIApplication.shared.windows {
                 if let window = window as? HeadGazeWindow {
-                    window.cursorView.isDebugCursorHidden = true
+                    window.cursorView?.isDebugCursorHidden = true
                 }
             }
         }

--- a/Vocable/HeadGazeLib/UIHeadGazeViewController.swift
+++ b/Vocable/HeadGazeLib/UIHeadGazeViewController.swift
@@ -41,8 +41,6 @@ class UIHeadGazeViewController: UIViewController, ARSessionDelegate, ARSCNViewDe
     private var computedScale: CGFloat = 0
     private var xAngleCorrectionAmount = 0.0
     private var yAngleCorrectionAmount = 0.0
-    
-    private var disposables = Set<AnyCancellable>()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -68,15 +66,11 @@ class UIHeadGazeViewController: UIViewController, ARSessionDelegate, ARSCNViewDe
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        _ = AppConfig.headTrackingValueSubject.sink { isHeadTrackingEnabled in
-            if isHeadTrackingEnabled {
-                self.resetTracking()
-            } else {
-                self.sceneview?.session.pause()
-            }
-        }.store(in: &disposables)
 
+        let configuration = ARFaceTrackingConfiguration()
+        configuration.worldAlignment = .camera
+        sceneview?.session.run(configuration, options: [.resetTracking, .removeExistingAnchors])
+        
         if let sceneView = sceneview {
             sceneView.isHidden = false
             view.sendSubviewToBack(sceneView)
@@ -86,16 +80,6 @@ class UIHeadGazeViewController: UIViewController, ARSessionDelegate, ARSCNViewDe
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         sceneview?.session.pause()
-    }
-    
-    private func resetTracking() {
-        guard ARFaceTrackingConfiguration.isSupported else {
-            return
-        }
-
-        let configuration = ARFaceTrackingConfiguration()
-        configuration.worldAlignment = .camera
-        sceneview?.session.run(configuration, options: [.resetTracking, .removeExistingAnchors])
     }
 
     func session(_ session: ARSession, didUpdate frame: ARFrame) {
@@ -110,7 +94,7 @@ class UIHeadGazeViewController: UIViewController, ARSessionDelegate, ARSCNViewDe
                 window.sendEvent(event)
             }
             if let debugEvent = debugInterpolator.event, let gaze = debugEvent.allGazes?.first {
-                window.cursorView.debugCursorMoved(gaze, with: debugEvent)
+                window.cursorView?.debugCursorMoved(gaze, with: debugEvent)
             }
         }
     }

--- a/Vocable/HeadGazeLib/UIVirtualCursorView.swift
+++ b/Vocable/HeadGazeLib/UIVirtualCursorView.swift
@@ -95,4 +95,53 @@ class UIVirtualCursorView: UIView {
         self.cursorView.center = cursorPosition
         self.debugCursorView.center = debugCursorPosition
     }
+
+    func setCursorViewsHidden(_ isCursorHidden: Bool, animated: Bool) {
+
+        func actions() {
+            for cursor in cursorViews {
+                cursor.alpha = isCursorHidden ? 0.0 : 1.0
+                cursor.transform = isCursorHidden ? CGAffineTransform(scaleX: 0.1, y: 0.1) : .identity
+            }
+        }
+
+        if animated {
+            UIView.animate(withDuration: 0.5,
+                           delay: 0,
+                           usingSpringWithDamping: 0.4,
+                           initialSpringVelocity: 0.4,
+                           options: .beginFromCurrentState,
+                           animations: actions,
+                           completion: nil)
+        } else {
+            actions()
+        }
+    }
+
+    func animateCursorSelection() {
+
+        func performSelectionAnimation(_ cursor: CursorView) {
+            let duration: TimeInterval = 0.6
+            let relativeDownDuration = duration * 0.5
+            let relativeUpDuration = (1.0 - relativeDownDuration) * 0.5
+            let relativeSettleDuration = 1.0 - relativeUpDuration
+            UIView.animateKeyframes(withDuration: duration, delay: 0, options: [.beginFromCurrentState], animations: {
+                UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: relativeDownDuration) {
+                    cursor.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+                    cursor.shadowAmount = 0.8
+                }
+                UIView.addKeyframe(withRelativeStartTime: 1.0 - relativeSettleDuration - relativeUpDuration, relativeDuration: relativeUpDuration) {
+                    cursor.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
+                    cursor.shadowAmount = 1.0
+                }
+                UIView.addKeyframe(withRelativeStartTime: 1.0 - relativeSettleDuration, relativeDuration: relativeSettleDuration) {
+                    cursor.transform = .identity
+                }
+            }, completion: nil)
+        }
+
+        for cursor in cursorViews {
+            performSelectionAnimation(cursor)
+        }
+    }
 }

--- a/Vocable/Supporting Files/Info.plist
+++ b/Vocable/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Vocable uses ARKit head tracking to detect the user's face as seen in the device's TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. Vocable needs permission to use the camera for this purpose.</string>
+	<string>Vocable uses ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. Vocable needs permission to use the camera for this purpose.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -36,7 +36,6 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
-		<string>arkit</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>


### PR DESCRIPTION
Fixes #141 

* Removes the ARKit tracking view controller and virtual cursor from the view hierarchy when head tracking is unavailable or disabled
* Restructures toast notification and tracking error views so they are dynamically added to the view hierarchy
* Refactors Combine code to use a new property wrapper that wraps `UserDefaults` and also mimics `@Published`
* Removes ARKit dependency from Info.plist