### PR TITLE
Confirm deletion & confirm losing edits alerts

### DIFF
--- a/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
+++ b/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
@@ -20,8 +20,8 @@ final class GazeableAlertAction: NSObject {
     }
 
     @objc fileprivate func performActions() {
-        handler?()
         defaultCompletion?()
+        handler?()
     }
 
 }

--- a/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
+++ b/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class GazableAlertAction: NSObject {
+final class GazeableAlertAction: NSObject {
 
     let title: String
     let handler: (() -> Void)?
@@ -155,7 +155,7 @@ final class GazeableAlertViewController: UIViewController {
         return stackView
     }()
 
-    private var actions = [GazableAlertAction]() {
+    private var actions = [GazeableAlertAction]() {
         didSet {
             updateButtonLayout()
         }
@@ -195,7 +195,7 @@ final class GazeableAlertViewController: UIViewController {
         }
     }
 
-    func addAction(_ action: GazableAlertAction) {
+    func addAction(_ action: GazeableAlertAction) {
         action.defaultCompletion = { [weak self] in
             self?.presentingViewController?.dismiss(animated: true)
         }
@@ -255,7 +255,7 @@ final class GazeableAlertViewController: UIViewController {
             let button = GazeableAlertButton(frame: .zero)
             button.setTitle(action.title, for: .normal)
             button.backgroundView.cornerRadius = alertView.cornerRadius
-            button.addTarget(action, action: #selector(GazableAlertAction.performActions), for: .primaryActionTriggered)
+            button.addTarget(action, action: #selector(GazeableAlertAction.performActions), for: .primaryActionTriggered)
 
             if actionButtonStackView.arrangedSubviews.isEmpty {
                 firstButton = button

--- a/Vocable/Features/Settings/EditSayings/EditKeyboardViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditKeyboardViewController.swift
@@ -231,12 +231,10 @@ class EditKeyboardViewController: UIViewController, UICollectionViewDelegate {
                     let originalPhrase = Phrase.fetchObject(in: context, matching: phraseIdentifier)
                     if originalPhrase?.utterance != _textTransaction.text {
                         handleExitAlert()
-                    } else {
-                        self.navigationController?.popViewController(animated: true)
+                        break
                     }
-                } else {
-                    self.navigationController?.popViewController(animated: true)
                 }
+                self.navigationController?.popViewController(animated: true)
             case .confirmEdit:
                 if let phraseIdentifier = phraseIdentifier {
                     let originalPhrase = Phrase.fetchObject(in: context, matching: phraseIdentifier)

--- a/Vocable/Features/Settings/EditSayings/EditKeyboardViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditKeyboardViewController.swift
@@ -330,11 +330,11 @@ class EditKeyboardViewController: UIViewController, UICollectionViewDelegate {
     }
     
     private func handleExitAlert() {
-        let alert = GazeableAlertViewController(alertTitle: "Going back before saving will clear any edits made.")
-        alert.addAction(GazeableAlertAction(title: "Discard", handler: {
+        let alert = GazeableAlertViewController(alertTitle: NSLocalizedString("Going back before saving will clear any edits made.", comment: "Exit edit sayings alert title"))
+        alert.addAction(GazeableAlertAction(title: NSLocalizedString("Discard", comment: "Discard changes alert action title"), handler: {
             self.navigationController?.popViewController(animated: true)
         }))
-        alert.addAction(GazeableAlertAction(title: "Continue Editing"))
+        alert.addAction(GazeableAlertAction(title: NSLocalizedString("Continue Editing", comment: "Continue editing alert action title")))
         self.present(alert, animated: true)
     }
     

--- a/Vocable/Features/Settings/EditSayings/EditKeyboardViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditKeyboardViewController.swift
@@ -332,9 +332,7 @@ class EditKeyboardViewController: UIViewController, UICollectionViewDelegate {
     private func handleExitAlert() {
         let alert = GazeableAlertViewController(alertTitle: "Going back before saving will clear any edits made.")
         alert.addAction(GazeableAlertAction(title: "Discard", handler: {
-            DispatchQueue.main.async {
-                self.navigationController?.popViewController(animated: true)
-            }
+            self.navigationController?.popViewController(animated: true)
         }))
         alert.addAction(GazeableAlertAction(title: "Continue Editing"))
         self.present(alert, animated: true)

--- a/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
@@ -100,16 +100,21 @@ class EditSayingsCollectionViewController: CarouselGridCollectionViewController,
     }
 
     @objc private func handleCellDeletionButton(_ sender: UIButton) {
-        for cell in collectionView.visibleCells where sender.isDescendant(of: cell) {
-            guard let indexPath = collectionView.indexPath(for: cell) else {
+        let alert = GazeableAlertViewController(alertTitle: "Are you sure?\nDeleted phrases cannot be recovered.")
+        alert.addAction(GazeableAlertAction(title: "Delete", handler: {
+            for cell in self.collectionView.visibleCells where sender.isDescendant(of: cell) {
+                guard let indexPath = self.collectionView.indexPath(for: cell) else {
+                    return
+                }
+                let phrase = self.fetchResultsController.object(at: indexPath)
+                let context = NSPersistentContainer.shared.viewContext
+                context.delete(phrase)
+                try? context.save()
                 return
             }
-            let phrase = fetchResultsController.object(at: indexPath)
-            let context = NSPersistentContainer.shared.viewContext
-            context.delete(phrase)
-            try? context.save()
-            return
-        }
+        }))
+        alert.addAction(GazeableAlertAction(title: "Cancel"))
+        self.present(alert, animated: true)
     }
     
     @objc private func handleCellEditButton(_ sender: UIButton) {

--- a/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
@@ -100,9 +100,9 @@ class EditSayingsCollectionViewController: CarouselGridCollectionViewController,
     }
 
     @objc private func handleCellDeletionButton(_ sender: UIButton) {
-        let alert = GazeableAlertViewController(alertTitle: "Are you sure?\nDeleted phrases cannot be recovered.")
-        alert.addAction(GazeableAlertAction(title: "Delete", handler: { self.deletePhrase(sender) }))
-        alert.addAction(GazeableAlertAction(title: "Cancel"))
+        let alert = GazeableAlertViewController(alertTitle: NSLocalizedString("Are you sure?\nDeleted phrases cannot be recovered.", comment: "Delete saying alert title"))
+        alert.addAction(GazeableAlertAction(title: NSLocalizedString("Delete", comment: "Delete saying alert action title"), handler: { self.deletePhrase(sender) }))
+        alert.addAction(GazeableAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel deletion alert action title")))
         self.present(alert, animated: true)
     }
     

--- a/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditSayingsCollectionViewController.swift
@@ -101,20 +101,21 @@ class EditSayingsCollectionViewController: CarouselGridCollectionViewController,
 
     @objc private func handleCellDeletionButton(_ sender: UIButton) {
         let alert = GazeableAlertViewController(alertTitle: "Are you sure?\nDeleted phrases cannot be recovered.")
-        alert.addAction(GazeableAlertAction(title: "Delete", handler: {
-            for cell in self.collectionView.visibleCells where sender.isDescendant(of: cell) {
-                guard let indexPath = self.collectionView.indexPath(for: cell) else {
-                    return
-                }
-                let phrase = self.fetchResultsController.object(at: indexPath)
-                let context = NSPersistentContainer.shared.viewContext
-                context.delete(phrase)
-                try? context.save()
-                return
-            }
-        }))
+        alert.addAction(GazeableAlertAction(title: "Delete", handler: { self.deletePhrase(sender) }))
         alert.addAction(GazeableAlertAction(title: "Cancel"))
         self.present(alert, animated: true)
+    }
+    
+    private func deletePhrase(_ sender: UIButton) {
+        for cell in self.collectionView.visibleCells where sender.isDescendant(of: cell) {
+            guard let indexPath = self.collectionView.indexPath(for: cell) else {
+                return
+            }
+            let phrase = self.fetchResultsController.object(at: indexPath)
+            let context = NSPersistentContainer.shared.viewContext
+            context.delete(phrase)
+            try? context.save()
+        }
     }
     
     @objc private func handleCellEditButton(_ sender: UIButton) {

--- a/Vocable/Features/Settings/Settings.storyboard
+++ b/Vocable/Features/Settings/Settings.storyboard
@@ -248,7 +248,7 @@
                                     <segue destination="W98-u1-6GB" kind="embed" identifier="CarouselCollectionViewController" id="YT0-TB-czc"/>
                                 </connections>
                             </containerView>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xsL-XA-YD7" customClass="PaginationView" customModule="Vocable" customModuleProvider="target">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xsL-XA-YD7" customClass="PaginationView" customModule="Vocable" customModuleProvider="target">
                                 <rect key="frame" x="295.5" y="1240" width="433.5" height="94"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="aHj-3P-gGo"/>

--- a/Vocable/Features/Settings/SettingsCollectionViewController.swift
+++ b/Vocable/Features/Settings/SettingsCollectionViewController.swift
@@ -227,8 +227,8 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
                                                 comment: "You're about to be taken outside of the Vocable app. You may lose head tracking control alert message")
             let alertViewController = GazeableAlertViewController(alertTitle: alertString)
 
-            alertViewController.addAction(GazableAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel alert action title")))
-            alertViewController.addAction(GazableAlertAction(title: NSLocalizedString("Confirm", comment: "Confirm alert action title"), handler: self.presentPrivacyAlert))
+            alertViewController.addAction(GazeableAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel alert action title")))
+            alertViewController.addAction(GazeableAlertAction(title: NSLocalizedString("Confirm", comment: "Confirm alert action title"), handler: self.presentPrivacyAlert))
             present(alertViewController, animated: true)
 
         case .editMySayings:
@@ -242,8 +242,8 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
                                                 comment: "You're about to be taken outside of the Vocable app. You may lose head tracking control alert message")
             let alertViewController = GazeableAlertViewController(alertTitle: alertString)
 
-            alertViewController.addAction(GazableAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel alert action title")))
-            alertViewController.addAction(GazableAlertAction(title: NSLocalizedString("Confirm", comment: "Confirm alert action title"), handler: self.presentEmail))
+            alertViewController.addAction(GazeableAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel alert action title")))
+            alertViewController.addAction(GazeableAlertAction(title: NSLocalizedString("Confirm", comment: "Confirm alert action title"), handler: self.presentEmail))
             present(alertViewController, animated: true)
 
         case .pidTuner:


### PR DESCRIPTION
Changes includes
- Added alert that confirms if a user wants to delete a saying from the My Sayings screen
- Added alert that confirms if a user wants to go back to the My Sayings screen from the Edit My Sayings Keyboard screen if they've made changes to the original phrase
- Fixed typo "GazableAlertAction" -> "GazeableAlertAction"

<img width="500" alt="Screen Shot 2020-03-23 at 5 55 50 PM" src="https://user-images.githubusercontent.com/37670742/77367124-dc971200-6d2f-11ea-88fb-033424551bcd.png">
<img width="500" alt="Screen Shot 2020-03-23 at 5 55 21 PM" src="https://user-images.githubusercontent.com/37670742/77367127-ddc83f00-6d2f-11ea-89ac-abedbbbc136a.png">
