### PR TITLE
Disable Warning Toast While Using Touch

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -1132,8 +1132,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 753J68XC6W;
@@ -1146,7 +1146,7 @@
 				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.willowtreeapps.eyespeakaac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development com.willowtreeapps.eyespeakaac";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -1132,8 +1132,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 753J68XC6W;
@@ -1146,7 +1146,7 @@
 				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.willowtreeapps.eyespeakaac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.willowtreeapps.eyespeakaac";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -12,7 +12,7 @@ import CoreData
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var window: UIWindow?
+    var window: HeadGazeWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
@@ -54,7 +54,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @objc private func applicationDidLoseGaze(_ sender: Any?) {
-        ToastWindow.shared.presentPersistantWarning(with: NSLocalizedString("Please move closer to the device.", comment: "Warning title when head tracking is lost."))
+        
+        if window?.shouldEnableCursor() ?? true {
+            ToastWindow.shared.presentPersistantWarning(with: NSLocalizedString("Please move closer to the device.", comment: "Warning title when head tracking is lost."))
+        }
     }
     
     @objc private func applicationDidAcquireGaze(_ sender: Any?) {

--- a/Vocable/HeadGazeLib/HeadGazeWindow.swift
+++ b/Vocable/HeadGazeLib/HeadGazeWindow.swift
@@ -17,7 +17,6 @@ class HeadGazeWindow: UIWindow {
     private var trackingView: UIView?
     private var lastGaze: UIHeadGaze?
     
-    
     private let touchGazeDisableDuration: TimeInterval = 3
     private var touchGazeDisableBeganDate: Date?
     
@@ -102,6 +101,13 @@ class HeadGazeWindow: UIWindow {
             trackingView.gazeCancelled(lastGaze, with: nil)
         }
     }
+    
+    func shouldEnableCursor() -> Bool {
+        guard let gazeDisabledStart = touchGazeDisableBeganDate else {
+            return true
+        }
+        return Date().timeIntervalSince(gazeDisabledStart) >= touchGazeDisableDuration
+    }
 
     override func gazeableHitTest(_ point: CGPoint, with event: UIHeadGazeEvent?) -> UIView? {
         guard let result = super.gazeableHitTest(point, with: event) else {
@@ -152,13 +158,14 @@ class HeadGazeWindow: UIWindow {
                 if originalEvent.type == .touches {
                     extendGazeDisabledPeriodForTouchEvent()
                     cursorView?.setCursorViewsHidden(true, animated: true)
+                    ToastWindow.shared.dismissPersistantWarning()
                 }
             super.sendEvent(originalEvent)
             return
         }
 
-        if let gazeDisabledStart = touchGazeDisableBeganDate {
-            if Date().timeIntervalSince(gazeDisabledStart) >= touchGazeDisableDuration {
+        if let _ = touchGazeDisableBeganDate {
+            if shouldEnableCursor() {
                 cursorView?.setCursorViewsHidden(false, animated: true)
                 touchGazeDisableBeganDate = nil
             } else {


### PR DESCRIPTION
This fixes the problem where the toast which gets displayed after a user loses head tracking still displays while the user is using touch. 