### PR TITLE
Scroll to selected category

### DIFF
--- a/Vocable/Common/CarouselGridCollectionViewController.swift
+++ b/Vocable/Common/CarouselGridCollectionViewController.swift
@@ -77,6 +77,22 @@ class CarouselGridCollectionViewController: UICollectionViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         scrollToMiddleSection()
+        scrollToBoundaryOfCurrentPage(animated: false)
+    }
+
+    private func scrollToBoundaryOfCurrentPage(animated: Bool = false) {
+        if let destination = layout.indexPathForLeftmostCellOfCurrentPage() {
+            collectionView.scrollToItem(at: destination,
+                                        at: .left,
+                                        animated: animated)
+        }
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate(alongsideTransition: { (_) in
+            self.scrollToBoundaryOfCurrentPage(animated: false)
+        }, completion: nil)
     }
 
     func scrollToMiddleSection() {
@@ -84,5 +100,6 @@ class CarouselGridCollectionViewController: UICollectionViewController {
         collectionView.scrollToItem(at: IndexPath(item: 0, section: sectionCount / 2),
                                     at: .left,
                                     animated: false)
+        collectionView.layoutIfNeeded()
     }
 }

--- a/Vocable/Common/CarouselGridLayout.swift
+++ b/Vocable/Common/CarouselGridLayout.swift
@@ -262,4 +262,26 @@ class CarouselGridLayout: UICollectionViewLayout {
 
         return attr
     }
+
+    func indexPathForLeftmostCellOfPage(containing indexPath: IndexPath) -> IndexPath? {
+        guard pagesPerSection > 0, itemsPerPage > 0 else {
+            return nil
+        }
+        let currentSection = currentPageIndex / pagesPerSection
+        let pageOfIndexPathWithinSection = indexPath.item / itemsPerPage
+        let firstItemInPage = pageOfIndexPathWithinSection * itemsPerPage
+        let result = IndexPath(item: firstItemInPage, section: currentSection)
+        return result
+    }
+
+    func indexPathForLeftmostCellOfCurrentPage() -> IndexPath? {
+        guard pagesPerSection > 0, itemsPerPage > 0 else {
+            return nil
+        }
+        let currentSection = currentPageIndex / pagesPerSection
+        let pageOfIndexPathWithinSection = currentPageIndex % pagesPerSection
+        let firstItemInPage = pageOfIndexPathWithinSection * itemsPerPage
+        let result = IndexPath(item: firstItemInPage, section: currentSection)
+        return result
+    }
 }

--- a/Vocable/Common/CarouselGridLayout.swift
+++ b/Vocable/Common/CarouselGridLayout.swift
@@ -267,21 +267,19 @@ class CarouselGridLayout: UICollectionViewLayout {
         guard pagesPerSection > 0, itemsPerPage > 0 else {
             return nil
         }
-        let currentSection = currentPageIndex / pagesPerSection
+        
         let pageOfIndexPathWithinSection = indexPath.item / itemsPerPage
         let firstItemInPage = pageOfIndexPathWithinSection * itemsPerPage
-        let result = IndexPath(item: firstItemInPage, section: currentSection)
+        let result = IndexPath(item: firstItemInPage, section: indexPath.section)
         return result
     }
-
+    
     func indexPathForLeftmostCellOfCurrentPage() -> IndexPath? {
-        guard pagesPerSection > 0, itemsPerPage > 0 else {
-            return nil
+        let indexPaths = collectionView?.indexPathsForVisibleItems ?? []
+        if let centerIndexPath = indexPaths[safe: indexPaths.count / 2] {
+            let result = indexPathForLeftmostCellOfPage(containing: centerIndexPath)
+            return result
         }
-        let currentSection = currentPageIndex / pagesPerSection
-        let pageOfIndexPathWithinSection = currentPageIndex % pagesPerSection
-        let firstItemInPage = pageOfIndexPathWithinSection * itemsPerPage
-        let result = IndexPath(item: firstItemInPage, section: currentSection)
-        return result
+        return nil
     }
 }

--- a/Vocable/Features/Presets/Pagination/CategoryCollectionViewController.swift
+++ b/Vocable/Features/Presets/Pagination/CategoryCollectionViewController.swift
@@ -46,6 +46,18 @@ class CategoryCollectionViewController: CarouselGridCollectionViewController, NS
         }
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        scrollToNearestSelectedIndexPath(animated: false)
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate(alongsideTransition: { _ in
+            self.scrollToNearestSelectedIndexPath(animated: false)
+        }, completion: nil)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -61,6 +73,23 @@ class CategoryCollectionViewController: CarouselGridCollectionViewController, NS
 
         self.clearsSelectionOnViewWillAppear = false
     }
+
+    private func scrollToNearestSelectedIndexPath(animated: Bool = false) {
+        let _indexPath: IndexPath? = {
+            guard let selectedMappedIndexPath = collectionView.indexPathsForSelectedItems?.first else {
+                return nil
+            }
+            return dataSourceProxy.indexPath(fromMappedIndexPath: selectedMappedIndexPath)
+        }()
+
+        if let indexPath = _indexPath {
+            if let destination = layout.indexPathForLeftmostCellOfPage(containing: indexPath) {
+                collectionView.scrollToItem(at: destination,
+                                            at: .left,
+                                            animated: animated)
+            }
+        }
+    }
     
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         updateDataSource(animated: true)
@@ -69,9 +98,6 @@ class CategoryCollectionViewController: CarouselGridCollectionViewController, NS
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateLayoutForCurrentTraitCollection()
-        if let indexPath = self.collectionView.indexPathsForSelectedItems?.first {
-            self.collectionView.scrollToItem(at: indexPath, at: .left, animated: false)
-        }
     }
 
     func updateLayoutForCurrentTraitCollection() {

--- a/Vocable/Features/Presets/Pagination/CategoryCollectionViewController.swift
+++ b/Vocable/Features/Presets/Pagination/CategoryCollectionViewController.swift
@@ -75,19 +75,16 @@ class CategoryCollectionViewController: CarouselGridCollectionViewController, NS
     }
 
     private func scrollToNearestSelectedIndexPath(animated: Bool = false) {
-        let _indexPath: IndexPath? = {
-            guard let selectedMappedIndexPath = collectionView.indexPathsForSelectedItems?.first else {
-                return nil
-            }
-            return dataSourceProxy.indexPath(fromMappedIndexPath: selectedMappedIndexPath)
-        }()
-
-        if let indexPath = _indexPath {
-            if let destination = layout.indexPathForLeftmostCellOfPage(containing: indexPath) {
-                collectionView.scrollToItem(at: destination,
-                                            at: .left,
-                                            animated: animated)
-            }
+        let selectedIndexPaths = collectionView.indexPathsForSelectedItems ?? []
+        
+        guard let middleIndexPath = selectedIndexPaths[safe: selectedIndexPaths.count / 2] else {
+            return
+        }
+        
+        if let destination = layout.indexPathForLeftmostCellOfPage(containing: middleIndexPath) {
+            collectionView.scrollToItem(at: destination,
+                                        at: .left,
+                                        animated: animated)
         }
     }
     

--- a/Vocable/Features/Presets/Pagination/PresetCollectionViewController.swift
+++ b/Vocable/Features/Presets/Pagination/PresetCollectionViewController.swift
@@ -103,6 +103,26 @@ class PresetCollectionViewController: CarouselGridCollectionViewController, NSFe
             ItemSelection.presetsPageIndicatorProgress = pagingProgress
         }.store(in: &disposables)
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        scrollToBoundaryOfCurrentPage(animated: false)
+    }
+
+    private func scrollToBoundaryOfCurrentPage(animated: Bool = false) {
+        if let destination = layout.indexPathForLeftmostCellOfCurrentPage() {
+            collectionView.scrollToItem(at: destination,
+                                        at: .left,
+                                        animated: animated)
+        }
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate(alongsideTransition: { (_) in
+            self.scrollToBoundaryOfCurrentPage(animated: false)
+        }, completion: nil)
+    }
     
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         updateDataSource(animated: true)

--- a/Vocable/Features/Presets/Pagination/PresetCollectionViewController.swift
+++ b/Vocable/Features/Presets/Pagination/PresetCollectionViewController.swift
@@ -103,26 +103,6 @@ class PresetCollectionViewController: CarouselGridCollectionViewController, NSFe
             ItemSelection.presetsPageIndicatorProgress = pagingProgress
         }.store(in: &disposables)
     }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        scrollToBoundaryOfCurrentPage(animated: false)
-    }
-
-    private func scrollToBoundaryOfCurrentPage(animated: Bool = false) {
-        if let destination = layout.indexPathForLeftmostCellOfCurrentPage() {
-            collectionView.scrollToItem(at: destination,
-                                        at: .left,
-                                        animated: animated)
-        }
-    }
-
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        coordinator.animate(alongsideTransition: { (_) in
-            self.scrollToBoundaryOfCurrentPage(animated: false)
-        }, completion: nil)
-    }
     
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         updateDataSource(animated: true)


### PR DESCRIPTION
Changes included:
- Scrolls to selected category when switching from portrait iPhone to landscape iPhone & vice versa
- Fixes bug where the category & presets were not starting in the middle section of the collection view