### PR TITLE
Updating settings top nav button sizing

### DIFF
--- a/Vocable/Features/Settings/EditCategories/EditCategories.storyboard
+++ b/Vocable/Features/Settings/EditCategories/EditCategories.storyboard
@@ -32,9 +32,14 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="00c-RK-HF1" userLabel="Back Button" customClass="GazeableButton" customModule="Vocable" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="64" height="64"/>
+                                        <rect key="frame" x="0.0" y="8" width="63" height="48"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="00c-RK-HF1" secondAttribute="height" multiplier="1:1" id="Ybw-Mx-Z25"/>
+                                            <constraint firstAttribute="height" constant="48" id="7za-qB-t9U">
+                                                <variation key="heightClass=regular-widthClass=regular" constant="96"/>
+                                            </constraint>
+                                            <constraint firstAttribute="width" constant="63" id="yU5-er-tY8">
+                                                <variation key="heightClass=regular-widthClass=regular" constant="104"/>
+                                            </constraint>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                         <color key="tintColor" name="DefaultFontColor"/>
@@ -49,7 +54,15 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y3d-hd-xdZ" customClass="GazeableButton" customModule="Vocable" customModuleProvider="target">
-                                        <rect key="frame" x="310" y="0.0" width="64" height="64"/>
+                                        <rect key="frame" x="311" y="8" width="63" height="48"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="48" id="T4G-bF-2SP">
+                                                <variation key="heightClass=regular-widthClass=regular" constant="96"/>
+                                            </constraint>
+                                            <constraint firstAttribute="width" constant="63" id="buV-4d-4Y0">
+                                                <variation key="heightClass=regular-widthClass=regular" constant="104"/>
+                                            </constraint>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                         <color key="tintColor" name="DefaultFontColor"/>
                                         <state key="normal" image="xmark.circle" catalog="system">
@@ -66,21 +79,19 @@
                                 <color key="backgroundColor" name="Background"/>
                                 <constraints>
                                     <constraint firstItem="0CD-i2-i5g" firstAttribute="centerX" secondItem="FaL-BL-aEw" secondAttribute="centerX" id="7hG-Zd-00j"/>
+                                    <constraint firstItem="00c-RK-HF1" firstAttribute="centerY" secondItem="FaL-BL-aEw" secondAttribute="centerY" id="FyE-V0-dl1"/>
                                     <constraint firstItem="0CD-i2-i5g" firstAttribute="top" secondItem="FaL-BL-aEw" secondAttribute="topMargin" constant="8" id="Nmv-ve-AaL">
                                         <variation key="heightClass=regular-widthClass=compact" constant="16"/>
                                     </constraint>
                                     <constraint firstItem="0CD-i2-i5g" firstAttribute="centerX" secondItem="FaL-BL-aEw" secondAttribute="centerX" id="UfO-TZ-C2g"/>
-                                    <constraint firstItem="y3d-hd-xdZ" firstAttribute="width" secondItem="00c-RK-HF1" secondAttribute="width" id="Y2b-FS-QNd"/>
                                     <constraint firstItem="00c-RK-HF1" firstAttribute="leading" secondItem="FaL-BL-aEw" secondAttribute="leadingMargin" id="Yvt-vZ-hNf"/>
                                     <constraint firstAttribute="height" constant="96" id="cfS-cm-2vy">
                                         <variation key="heightClass=compact" constant="48"/>
                                         <variation key="heightClass=regular-widthClass=compact" constant="64"/>
                                     </constraint>
-                                    <constraint firstAttribute="bottomMargin" secondItem="00c-RK-HF1" secondAttribute="bottom" id="dFT-Wk-Bu6"/>
+                                    <constraint firstItem="y3d-hd-xdZ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0CD-i2-i5g" secondAttribute="trailing" constant="24" id="kxU-0c-zIa"/>
                                     <constraint firstItem="y3d-hd-xdZ" firstAttribute="top" secondItem="00c-RK-HF1" secondAttribute="top" id="mBd-2K-v0G"/>
                                     <constraint firstItem="0CD-i2-i5g" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="00c-RK-HF1" secondAttribute="trailing" constant="24" id="oK7-wd-nL0"/>
-                                    <constraint firstItem="y3d-hd-xdZ" firstAttribute="height" secondItem="00c-RK-HF1" secondAttribute="height" id="pS4-za-txR"/>
-                                    <constraint firstItem="00c-RK-HF1" firstAttribute="top" secondItem="FaL-BL-aEw" secondAttribute="topMargin" id="pyq-nd-AXg"/>
                                     <constraint firstAttribute="trailingMargin" secondItem="y3d-hd-xdZ" secondAttribute="trailing" id="u4m-Lt-OzX"/>
                                 </constraints>
                                 <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>

--- a/Vocable/Features/Settings/EditSayings/EditSayings.storyboard
+++ b/Vocable/Features/Settings/EditSayings/EditSayings.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="ipad9_7" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
@@ -13,16 +13,21 @@
             <objects>
                 <viewController storyboardIdentifier="MySayings" id="KLI-zL-Q9x" customClass="EditSayingsViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="XHU-T2-eKa" customClass="GazeEatingView" customModule="Vocable" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FaL-BL-aEw" userLabel="Toolbar">
-                                <rect key="frame" x="20" y="44" width="374" height="64"/>
+                                <rect key="frame" x="32" y="32" width="704" height="96"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DvV-sn-lWq" customClass="GazeableButton" customModule="Vocable" customModuleProvider="target">
-                                        <rect key="frame" x="310" y="0.0" width="64" height="64"/>
+                                        <rect key="frame" x="600" y="0.0" width="104" height="96"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="DvV-sn-lWq" secondAttribute="height" id="kAS-Wb-xZD"/>
+                                            <constraint firstAttribute="width" constant="63" id="Aut-6u-pAg">
+                                                <variation key="heightClass=regular-widthClass=regular" constant="104"/>
+                                            </constraint>
+                                            <constraint firstAttribute="height" constant="48" id="jaT-Sa-T97">
+                                                <variation key="heightClass=regular-widthClass=regular" constant="96"/>
+                                            </constraint>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                         <color key="tintColor" name="DefaultFontColor"/>
@@ -37,7 +42,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My Sayings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0CD-i2-i5g">
-                                        <rect key="frame" x="112" y="16" width="150.5" height="33.5"/>
+                                        <rect key="frame" x="224.5" y="8" width="255.5" height="57.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="48"/>
                                         <color key="textColor" name="DefaultFontColor"/>
                                         <nil key="highlightedColor"/>
@@ -49,9 +54,14 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="00c-RK-HF1" customClass="GazeableButton" customModule="Vocable" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="64" height="64"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="104" height="96"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="00c-RK-HF1" secondAttribute="height" multiplier="1:1" id="Ybw-Mx-Z25"/>
+                                            <constraint firstAttribute="height" constant="48" id="DfX-g4-58b">
+                                                <variation key="heightClass=regular-widthClass=regular" constant="96"/>
+                                            </constraint>
+                                            <constraint firstAttribute="width" constant="63" id="p6i-Ig-ZOZ">
+                                                <variation key="heightClass=regular-widthClass=regular" constant="104"/>
+                                            </constraint>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                         <color key="tintColor" name="DefaultFontColor"/>
@@ -68,28 +78,26 @@
                                 </subviews>
                                 <color key="backgroundColor" name="Background"/>
                                 <constraints>
-                                    <constraint firstItem="DvV-sn-lWq" firstAttribute="top" secondItem="FaL-BL-aEw" secondAttribute="topMargin" id="0fN-F4-AwJ"/>
-                                    <constraint firstAttribute="bottomMargin" secondItem="DvV-sn-lWq" secondAttribute="bottom" id="34H-OF-Dzj"/>
                                     <constraint firstItem="0CD-i2-i5g" firstAttribute="centerX" secondItem="FaL-BL-aEw" secondAttribute="centerX" id="7hG-Zd-00j"/>
                                     <constraint firstAttribute="trailingMargin" secondItem="DvV-sn-lWq" secondAttribute="trailing" id="HPu-Qg-daX"/>
                                     <constraint firstItem="DvV-sn-lWq" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0CD-i2-i5g" secondAttribute="trailing" constant="24" id="J8q-UF-qPs"/>
+                                    <constraint firstItem="DvV-sn-lWq" firstAttribute="centerY" secondItem="FaL-BL-aEw" secondAttribute="centerY" id="LEt-Ad-ts7"/>
                                     <constraint firstItem="0CD-i2-i5g" firstAttribute="top" secondItem="FaL-BL-aEw" secondAttribute="topMargin" constant="8" id="Nmv-ve-AaL">
                                         <variation key="heightClass=regular-widthClass=compact" constant="16"/>
                                     </constraint>
                                     <constraint firstItem="0CD-i2-i5g" firstAttribute="centerX" secondItem="FaL-BL-aEw" secondAttribute="centerX" id="UfO-TZ-C2g"/>
+                                    <constraint firstItem="00c-RK-HF1" firstAttribute="centerY" secondItem="FaL-BL-aEw" secondAttribute="centerY" id="Uh2-JV-C8a"/>
                                     <constraint firstItem="00c-RK-HF1" firstAttribute="leading" secondItem="FaL-BL-aEw" secondAttribute="leadingMargin" id="Yvt-vZ-hNf"/>
                                     <constraint firstAttribute="height" constant="96" id="cfS-cm-2vy">
                                         <variation key="heightClass=compact" constant="48"/>
                                         <variation key="heightClass=regular-widthClass=compact" constant="64"/>
                                     </constraint>
-                                    <constraint firstAttribute="bottomMargin" secondItem="00c-RK-HF1" secondAttribute="bottom" id="dFT-Wk-Bu6"/>
                                     <constraint firstItem="0CD-i2-i5g" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="00c-RK-HF1" secondAttribute="trailing" constant="24" id="oK7-wd-nL0"/>
-                                    <constraint firstItem="00c-RK-HF1" firstAttribute="top" secondItem="FaL-BL-aEw" secondAttribute="topMargin" id="pyq-nd-AXg"/>
                                 </constraints>
                                 <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZPM-Ab-mlI">
-                                <rect key="frame" x="20" y="132" width="374" height="626"/>
+                                <rect key="frame" x="32" y="152" width="704" height="352"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="ZPM-Ab-mlI" secondAttribute="height" multiplier="2" priority="250" id="PK4-eE-9mZ"/>
                                     <constraint firstAttribute="height" constant="322.5" id="V2b-Pm-qsk"/>
@@ -114,7 +122,7 @@
                                 </connections>
                             </containerView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xsL-XA-YD7" customClass="PaginationView" customModule="Vocable" customModuleProvider="target">
-                                <rect key="frame" x="71" y="782" width="272" height="48"/>
+                                <rect key="frame" x="167.5" y="898" width="433.5" height="94"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="aHj-3P-gGo"/>
                                     <constraint firstAttribute="width" constant="400" id="bYi-OY-TtN"/>
@@ -190,7 +198,7 @@
             <objects>
                 <collectionViewController id="W98-u1-6GB" customClass="EditSayingsCollectionViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="f36-Ss-9hs">
-                        <rect key="frame" x="0.0" y="0.0" width="374" height="626"/>
+                        <rect key="frame" x="0.0" y="0.0" width="704" height="352"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <collectionViewLayout key="collectionViewLayout" id="q6l-HL-JPy" customClass="CarouselGridLayout" customModule="Vocable" customModuleProvider="target"/>
@@ -210,11 +218,11 @@
             <objects>
                 <viewController storyboardIdentifier="EditSaying" id="qBB-qb-4us" customClass="EditSayingsKeyboardViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="nxM-ki-o4S">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="zBG-MP-Uvj">
-                                <rect key="frame" x="20" y="52" width="374" height="802"/>
+                                <rect key="frame" x="32" y="32" width="704" height="960"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="MPw-us-ZBK">
                                     <size key="itemSize" width="50" height="50"/>

--- a/Vocable/Features/Settings/Settings.storyboard
+++ b/Vocable/Features/Settings/Settings.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="z2O-mb-WoW">
-    <device id="ipad12_9" orientation="portrait" layout="fullscreen" appearance="light"/>
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
@@ -29,7 +29,7 @@
             <objects>
                 <collectionViewController id="if3-QM-p2o" customClass="SettingsCollectionViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="yYQ-tW-Cgs">
-                        <rect key="frame" x="0.0" y="0.0" width="976" height="1214"/>
+                        <rect key="frame" x="0.0" y="0.0" width="374" height="734"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" sectionInsetReference="safeArea" id="Xga-RH-NHm">
@@ -54,11 +54,11 @@
             <objects>
                 <viewController id="gMn-gX-rfc" customClass="SettingsViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="mXz-yV-vIn" customClass="GazeEatingView" customModule="Vocable" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Settings" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CtZ-qP-xqU">
-                                <rect key="frame" x="32" y="32" width="960" height="57.5"/>
+                                <rect key="frame" x="20" y="60" width="374" height="41"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="48"/>
                                 <color key="textColor" name="DefaultFontColor"/>
                                 <nil key="highlightedColor"/>
@@ -70,7 +70,7 @@
                                 </variation>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="59L-eT-oZ6" customClass="GazeableButton" customModule="Vocable" customModuleProvider="target">
-                                <rect key="frame" x="32" y="32" width="116" height="100"/>
+                                <rect key="frame" x="20" y="60" width="63" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="XFt-fF-4My">
                                         <variation key="heightClass=compact" constant="48"/>
@@ -95,7 +95,7 @@
                                 </connections>
                             </button>
                             <containerView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="6E8-xr-Wux">
-                                <rect key="frame" x="24" y="152" width="976" height="1214"/>
+                                <rect key="frame" x="20" y="128" width="374" height="734"/>
                                 <connections>
                                     <segue destination="if3-QM-p2o" kind="embed" id="npm-Wd-wUb"/>
                                 </connections>


### PR DESCRIPTION
The settings top nav button sizing was not consistent in the Edit my Sayings & Categories screens. The constraints have been updated to reflect the correct sizing

Before:
![IMG_0808](https://user-images.githubusercontent.com/37670742/79876566-36cfd500-83b9-11ea-977c-b20b0d9f17ea.PNG)

After:
![IMG_0810 2](https://user-images.githubusercontent.com/37670742/79876586-3c2d1f80-83b9-11ea-8903-f9f04037e575.PNG)
