### PR TITLE
Grazeable alert background bugfix

### DIFF
--- a/Vocable/Common/Views/GazeableAlertController/GazeableAlertPresentationController.swift
+++ b/Vocable/Common/Views/GazeableAlertController/GazeableAlertPresentationController.swift
@@ -10,8 +10,8 @@ import UIKit
 
 final class GazeableAlertPresentationController: UIPresentationController {
 
-    private lazy var dimmedBackgroundView: UIView = {
-        let view = UIView()
+    private lazy var dimmedBackgroundView: GazeEatingView = {
+        let view = GazeEatingView()
         view.backgroundColor = .black
         view.alpha = 0
         return view


### PR DESCRIPTION
The UI in the background of the gazeable alert was still interact-able using the cursor. This is being fixed by setting the dimmed background view of the gazeable alert to a gaze eating view.