### PR TITLE
Modifying suggestive text iPhone layout to match designs

### DIFF
--- a/Vocable/Features/Keyboard/SuggestionCollectionViewCell.swift
+++ b/Vocable/Features/Keyboard/SuggestionCollectionViewCell.swift
@@ -12,12 +12,6 @@ class SuggestionCollectionViewCell: VocableCollectionViewCell {
     
     @IBOutlet var textLabel: UILabel!
     
-    var roundedCorners: UIRectCorner = .allCorners {
-        didSet {
-            borderedView.roundedCorners = roundedCorners
-        }
-    }
-    
     func setup(title: String) {
         if title.isEmpty {
             textLabel.text = title
@@ -44,7 +38,8 @@ class SuggestionCollectionViewCell: VocableCollectionViewCell {
     }
     
     private func adjustBackgroundColorForSizeClass() {
-        if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular {
+        if (traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular)
+            || traitCollection.verticalSizeClass == .compact {
             borderedView.backgroundColor = .clear
         } else {
             borderedView.backgroundColor = .categoryBackgroundColor

--- a/Vocable/Features/Presets/PresetCollectionViewCompositionalLayout.swift
+++ b/Vocable/Features/Presets/PresetCollectionViewCompositionalLayout.swift
@@ -225,18 +225,27 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
             let suggestiveTextItem = NSCollectionLayoutItem(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1 / itemCount),
                                                    heightDimension: .fractionalHeight(1.0)))
+            if environment.traitCollection.verticalSizeClass == .compact {
+                suggestiveTextItem.contentInsets = .init(top: 0, leading: 4, bottom: 0, trailing: 4)
+            }
             
             let containerGroup = NSCollectionLayoutGroup.horizontal(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                                    heightDimension: .fractionalHeight(116.0 / totalSize.height)),
                 subitem: suggestiveTextItem, count: Int(itemCount))
-            containerGroup.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
+            if environment.traitCollection.verticalSizeClass != .compact {
+                containerGroup.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
+            }
+            
             let section = NSCollectionLayoutSection(group: containerGroup)
             
-            let backgroundDecoration = NSCollectionLayoutDecorationItem.background(elementKind: "CategorySectionBackground")
-            backgroundDecoration.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0)
-            
-            section.decorationItems = [backgroundDecoration]
+            if environment.traitCollection.verticalSizeClass != .compact {
+                let backgroundDecoration = NSCollectionLayoutDecorationItem.background(elementKind: "CategorySectionBackground")
+                backgroundDecoration.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0)
+                
+                section.decorationItems = [backgroundDecoration]
+            }
+
             section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0)
             return section
         }


### PR DESCRIPTION
The suggestive text options for landscape on iPhone did not match designs, the buttons were a lot smaller making it more difficult to select an option.

Before:
![IMG_0813](https://user-images.githubusercontent.com/37670742/79897244-6db4e380-83d7-11ea-9cd9-ca5729612e43.PNG)

After:
![IMG_0812](https://user-images.githubusercontent.com/37670742/79897260-73122e00-83d7-11ea-86ed-fea8da9c98bf.PNG)
