### PR TITLE
Cancel gaze target on ordinal buttons when reordering category cells

### DIFF
--- a/Vocable/Common/EditTextViewController.swift
+++ b/Vocable/Common/EditTextViewController.swift
@@ -66,6 +66,11 @@ final class EditTextViewController: UIViewController, UICollectionViewDelegate {
         configureDataSource()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        (self.view.window as? HeadGazeWindow)?.cancelActiveGazeTarget()
+    }
+
     private func setupCollectionView() {
         collectionView.delaysContentTouches = false
         collectionView.isScrollEnabled = false

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesCollectionViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesCollectionViewController.swift
@@ -105,8 +105,15 @@ class EditCategoriesCollectionViewController: CarouselGridCollectionViewControll
     
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
         guard [.move, .update].contains(type) else { return }
-        
-        updateDataSource(animated: true)
+
+        updateDataSource(animated: true, completion: { [weak self] in
+            guard let window = self?.view.window as? HeadGazeWindow, let target = window.activeGazeTarget else {
+                    return
+            }
+            if let _ = self?.collectionView.indexPath(containing: target) {
+                window.cancelActiveGazeTarget()
+            }
+        })
         
         if let newIndexPath = newIndexPath {
             setupCell(indexPath: newIndexPath)

--- a/Vocable/HeadGazeLib/HeadGazeWindow.swift
+++ b/Vocable/HeadGazeLib/HeadGazeWindow.swift
@@ -14,6 +14,10 @@ class HeadGazeWindow: UIWindow {
     
     weak var cursorView: UIVirtualCursorView?
 
+    var activeGazeTarget: UIView? {
+        return trackingView
+    }
+
     private var trackingView: UIView?
     private var lastGaze: UIHeadGaze?
     


### PR DESCRIPTION
Fixes an issue where the category ordinal buttons could reorder indefinitely when using gaze