### PR TITLE
Relocate head tracking UI to independent windows

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		6B8440E4244A50C1007A4DC6 /* EditCategoriesCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6960E2433CF23004E6960 /* EditCategoriesCollectionViewController.swift */; };
 		6B8440E6244A535A007A4DC6 /* CarouselGridLayout+Masks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8440E5244A535A007A4DC6 /* CarouselGridLayout+Masks.swift */; };
 		6B8440E8244A9557007A4DC6 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8440E7244A9557007A4DC6 /* EmptyStateView.swift */; };
+		6B8A6E3124533789004B5220 /* UIHeadGazeTrackingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8A6E3024533789004B5220 /* UIHeadGazeTrackingWindow.swift */; };
+		6B8A6E3324536085004B5220 /* UIHeadGazeCursorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8A6E3224536085004B5220 /* UIHeadGazeCursorWindow.swift */; };
 		6B9DFA5B23E889DB0037673E /* UIHeadGazeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9DFA4C23E889DB0037673E /* UIHeadGazeViewController.swift */; };
 		6B9DFA5C23E889DB0037673E /* HeadGazeWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9DFA4D23E889DB0037673E /* HeadGazeWindow.swift */; };
 		6B9DFA5D23E889DB0037673E /* UIHeadGaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9DFA4E23E889DB0037673E /* UIHeadGaze.swift */; };
@@ -234,6 +236,8 @@
 		6B8440E2244A1007007A4DC6 /* CarouselGridLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselGridLayout.swift; sourceTree = "<group>"; };
 		6B8440E5244A535A007A4DC6 /* CarouselGridLayout+Masks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CarouselGridLayout+Masks.swift"; sourceTree = "<group>"; };
 		6B8440E7244A9557007A4DC6 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		6B8A6E3024533789004B5220 /* UIHeadGazeTrackingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIHeadGazeTrackingWindow.swift; sourceTree = "<group>"; };
+		6B8A6E3224536085004B5220 /* UIHeadGazeCursorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIHeadGazeCursorWindow.swift; sourceTree = "<group>"; };
 		6B9DFA4C23E889DB0037673E /* UIHeadGazeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIHeadGazeViewController.swift; sourceTree = "<group>"; };
 		6B9DFA4D23E889DB0037673E /* HeadGazeWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeadGazeWindow.swift; sourceTree = "<group>"; };
 		6B9DFA4E23E889DB0037673E /* UIHeadGaze.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIHeadGaze.swift; sourceTree = "<group>"; };
@@ -485,6 +489,8 @@
 				6B9DFA5023E889DB0037673E /* UIHeadGazeEvent.swift */,
 				6B9DFA5423E889DB0037673E /* UIVirtualCursorView.swift */,
 				6B9DFA5623E889DB0037673E /* UIHeadGazeRecognizer.swift */,
+				6B8A6E3024533789004B5220 /* UIHeadGazeTrackingWindow.swift */,
+				6B8A6E3224536085004B5220 /* UIHeadGazeCursorWindow.swift */,
 				6B9DFA6823E88A1B0037673E /* GazeLib.scnassets */,
 				6B9DFA6A23E88A250037673E /* Interpolation */,
 			);
@@ -1066,12 +1072,14 @@
 				6B8440E8244A9557007A4DC6 /* EmptyStateView.swift in Sources */,
 				6B1C7F3223F5BB5200BB3FD9 /* HeadGazeTrackingInterpolator.swift in Sources */,
 				64D04A58242951C00006962D /* GazeableAlertPresentationController.swift in Sources */,
+				6B8A6E3324536085004B5220 /* UIHeadGazeCursorWindow.swift in Sources */,
 				A9F56FCA24378ED6008162B6 /* CategoryCollectionViewController.swift in Sources */,
 				A9DE170223F492B20094DB64 /* Array+Split.swift in Sources */,
 				6B9DFA5D23E889DB0037673E /* UIHeadGaze.swift in Sources */,
 				6B9DFA6F23E88A610037673E /* Interpolation.swift in Sources */,
 				6B823BD023F4ADE30099F65E /* PulseExtension.swift in Sources */,
 				130C00B820D2AD2A007C3163 /* AppDelegate.swift in Sources */,
+				6B8A6E3124533789004B5220 /* UIHeadGazeTrackingWindow.swift in Sources */,
 				A93E9403244E00A6008B61D2 /* UICollectionView+Helpers.swift in Sources */,
 				A9DF00FA23E38DB00072C7E1 /* PageControlReusableView.swift in Sources */,
 				A946D825243B8EFF00E76104 /* PresetCollectionViewController.swift in Sources */,

--- a/Vocable/Common/Views/TrackingContainerViewController.swift
+++ b/Vocable/Common/Views/TrackingContainerViewController.swift
@@ -11,51 +11,8 @@ import Combine
 
 final class TrackingContainerViewController: UIViewController {
 
-    @IBOutlet private var cursorView: UIVirtualCursorView!
-
     private var contentViewController: UIViewController!
     private var trackingViewController: UIHeadGazeViewController?
-
-    private var cancellables = Set<AnyCancellable>()
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        AppConfig.$isHeadTrackingEnabled.sink { [weak self] isEnabled in
-            guard let self = self else { return }
-            if isEnabled {
-                self.installTrackingViewController()
-            } else {
-                self.removeTrackingViewController()
-            }
-        }.store(in: &cancellables)
-    }
-
-    private func installTrackingViewController() {
-        guard trackingViewController?.parent == nil else { return }
-
-        let trackingViewController = UIHeadGazeViewController()
-        let trackingView = trackingViewController.view!
-        trackingView.isHidden = true
-        addChild(trackingViewController)
-
-        trackingView.translatesAutoresizingMaskIntoConstraints = false
-        view.insertSubview(trackingView, at: 0)
-        trackingView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-        trackingView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
-        trackingView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
-        trackingView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-
-        trackingViewController.didMove(toParent: self)
-        self.trackingViewController = trackingViewController
-    }
-
-    private func removeTrackingViewController() {
-        guard let trackingViewController = trackingViewController else { return }
-        trackingViewController.willMove(toParent: nil)
-        trackingViewController.removeFromParent()
-        trackingViewController.view.removeFromSuperview()
-        self.trackingViewController = nil
-    }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "ContentViewControllerSegue" {

--- a/Vocable/Features/Presets/PresetsViewController.swift
+++ b/Vocable/Features/Presets/PresetsViewController.swift
@@ -556,7 +556,7 @@ class PresetsViewController: UICollectionViewController, VocableCollectionViewLa
     private func presentSettingsViewController() {
         let storyboard = UIStoryboard(name: "Settings", bundle: nil)
         let vc = storyboard.instantiateInitialViewController()!
-        vc.modalPresentationStyle = .overFullScreen
+        vc.modalPresentationStyle = .fullScreen
         self.present(vc, animated: true, completion: nil)
     }
 }

--- a/Vocable/HeadGazeLib/HeadGazeWindow.swift
+++ b/Vocable/HeadGazeLib/HeadGazeWindow.swift
@@ -52,11 +52,7 @@ class HeadGazeWindow: UIWindow {
         AppConfig.$isHeadTrackingEnabled.sink { [weak self] isEnabled in
             guard let self = self else { return }
             if isEnabled {
-                self.installCursorViewIfNeeded()
-                self.cursorView?.setCursorViewsHidden(false, animated: true)
                 self.touchGazeDisableBeganDate = .distantPast
-            } else {
-                self.cursorView?.removeFromSuperview()
             }
         }.store(in: &cancellables)
 
@@ -74,13 +70,6 @@ class HeadGazeWindow: UIWindow {
         let title = NSLocalizedString("gaze_tracking.error.excessive_head_distance.title",
                                       comment: "Warning message presented to the user when the head tracking system")
         ToastWindow.shared.presentPersistentWarning(with: title)
-    }
-
-    override func addSubview(_ view: UIView) {
-        super.addSubview(view)
-        if let cursorView = cursorView {
-            bringSubviewToFront(cursorView)
-        }
     }
     
     private func cancelCurrentGazeIfNeeded() {
@@ -111,22 +100,6 @@ class HeadGazeWindow: UIWindow {
             }
         }
         schedule(duration: self.touchGazeDisableDuration)
-    }
-
-    private func installCursorViewIfNeeded() {
-        guard cursorView?.superview == nil else { return }
-
-        let cursorView = UIVirtualCursorView()
-        cursorView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(cursorView)
-
-        NSLayoutConstraint.activate([
-            cursorView.topAnchor.constraint(equalTo: topAnchor),
-            cursorView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            cursorView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            cursorView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
-        self.cursorView = cursorView
     }
 
     func animateCursorSelection() {

--- a/Vocable/HeadGazeLib/UIHeadGazeCursorWindow.swift
+++ b/Vocable/HeadGazeLib/UIHeadGazeCursorWindow.swift
@@ -1,0 +1,38 @@
+//
+//  UIHeadGazeCursorWindow.swift
+//  Vocable
+//
+//  Created by Chris Stroud on 4/24/20.
+//  Copyright © 2020 WillowTree. All rights reserved.
+//
+
+import UIKit
+
+class UIHeadGazeCursorWindow: UIWindow {
+
+    var cursorViewController: UIVirtualCursorViewController {
+        return rootViewController as! UIVirtualCursorViewController
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    override init(windowScene: UIWindowScene) {
+        super.init(windowScene: windowScene)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        self.rootViewController = UIVirtualCursorViewController()
+        self.isUserInteractionEnabled = false
+        self.backgroundColor = .clear
+        self.isOpaque = false
+    }
+}

--- a/Vocable/HeadGazeLib/UIHeadGazeTrackingWindow.swift
+++ b/Vocable/HeadGazeLib/UIHeadGazeTrackingWindow.swift
@@ -1,0 +1,31 @@
+//
+//  UIHeadGazeTrackingWindow.swift
+//  Vocable
+//
+//  Created by Chris Stroud on 4/24/20.
+//  Copyright © 2020 WillowTree. All rights reserved.
+//
+
+import UIKit
+
+final class UIHeadGazeTrackingWindow: UIWindow {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    override init(windowScene: UIWindowScene) {
+        super.init(windowScene: windowScene)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        self.rootViewController = UIHeadGazeViewController()
+    }
+}

--- a/Vocable/HeadGazeLib/UIHeadGazeViewController.swift
+++ b/Vocable/HeadGazeLib/UIHeadGazeViewController.swift
@@ -32,6 +32,14 @@ extension UIApplication {
 class UIHeadGazeViewController: UIViewController, ARSessionDelegate, ARSCNViewDelegate {
  
     private(set) var sceneview: ARSCNView?
+    private lazy var receivingWindow: HeadGazeWindow? = {
+        for window in UIApplication.shared.windows {
+            if let result = window as? HeadGazeWindow {
+                return result
+            }
+        }
+        return nil
+    }()
 
     let pidInterpolator = PIDControlledTrackingInterpolator()
     let debugInterpolator = HeadGazeTrackingInterpolator()
@@ -97,13 +105,12 @@ class UIHeadGazeViewController: UIViewController, ARSessionDelegate, ARSCNViewDe
                                 correctionAmount: correction,
                                 scale: computedScale)
         }
-        if let window = view.window as? HeadGazeWindow {
-            if let event = pidInterpolator.event {
-                window.sendEvent(event)
-            }
-            if let debugEvent = debugInterpolator.event, let gaze = debugEvent.allGazes?.first {
-                window.cursorView?.debugCursorMoved(gaze, with: debugEvent)
-            }
+
+        if let event = pidInterpolator.event {
+            receivingWindow?.sendEvent(event)
+        }
+        if let debugEvent = debugInterpolator.event, let gaze = debugEvent.allGazes?.first {
+            receivingWindow?.cursorView?.debugCursorMoved(gaze, with: debugEvent)
         }
     }
 

--- a/Vocable/HeadGazeLib/UIVirtualCursorView.swift
+++ b/Vocable/HeadGazeLib/UIVirtualCursorView.swift
@@ -2,6 +2,15 @@ import Foundation
 import UIKit
 import SpriteKit
 
+class UIVirtualCursorViewController: UIViewController {
+
+    private(set) var virtualCursorView = UIVirtualCursorView(frame: .zero)
+
+    override func loadView() {
+        self.view = self.virtualCursorView
+    }
+}
+
 class UIVirtualCursorView: UIView {
 
     private var cursorView = CursorView()
@@ -35,7 +44,7 @@ class UIVirtualCursorView: UIView {
 
     override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
-        if (newWindow as? HeadGazeWindow) != nil {
+        if newWindow != nil {
             displayLink = CADisplayLink(target: self, selector: #selector(displayLinkDidFire(_:)))
             displayLink?.preferredFramesPerSecond = UIScreen.main.maximumFramesPerSecond
             displayLink?.add(to: .current, forMode: .common)


### PR DESCRIPTION
This has been needed for quite some time, but it will be necessary for the upcoming cleanup work.

Rather than house everything in a single window, this change relocates both the head tracking SceneKit UI and the virtual cursor into their own respective UIWindow instances. This will allow the UI to operate with less top-level view controller containment and (finally) allow modal presentations to remove the presenting view controller's view from the view hierarchy. The latter has been quite taxing on older iPad/iPhone models.