### PR TITLE
Feature/phrases feature flag

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -1345,7 +1345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.willowtreeapps.eyespeakaac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.willowtreeapps.eyespeakaac";
@@ -1372,7 +1372,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.willowtreeapps.eyespeakaac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc com.willowtreeapps.eyespeakaac";
@@ -1565,7 +1565,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.willowtreeapps.eyespeakaac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.willowtreeapps.eyespeakaac";

--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -72,9 +72,9 @@
 		6BFB18C724005E18002C3515 /* CategoryPaginationContainerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B838202C23FD8934005A79CD /* CategoryPaginationContainerCollectionViewCell.swift */; };
 		71004B0D242926A2006833B8 /* SelectionMode.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71004B0C242926A2006833B8 /* SelectionMode.storyboard */; };
 		714407ED243CEEA1009D077B /* Category+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714407EC243CEEA1009D077B /* Category+Helpers.swift */; };
-		714EFD45241964D800DC773C /* EditSayingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714EFD44241964D800DC773C /* EditSayingsViewController.swift */; };
-		718D7FAE2419546F00FDEF93 /* EditSayingsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718D7FAD2419546F00FDEF93 /* EditSayingsCollectionViewCell.swift */; };
-		718D7FB0241954C400FDEF93 /* EditSayingsCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 718D7FAF241954C400FDEF93 /* EditSayingsCollectionViewCell.xib */; };
+		714EFD45241964D800DC773C /* EditPhrasesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714EFD44241964D800DC773C /* EditPhrasesViewController.swift */; };
+		718D7FAE2419546F00FDEF93 /* EditPhrasesCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718D7FAD2419546F00FDEF93 /* EditPhrasesCollectionViewCell.swift */; };
+		718D7FB0241954C400FDEF93 /* EditPhrasesCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 718D7FAF241954C400FDEF93 /* EditPhrasesCollectionViewCell.xib */; };
 		7192E409242BC58F008E4A0A /* ToastWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7192E408242BC58F008E4A0A /* ToastWindow.swift */; };
 		7192E40B242E6562008E4A0A /* ToastContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7192E40A242E6562008E4A0A /* ToastContainerViewController.swift */; };
 		7192E4122433E4BE008E4A0A /* EditCategoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7192E4112433E4BE008E4A0A /* EditCategoryDetailViewController.swift */; };
@@ -121,7 +121,7 @@
 		A9B6960D2433CD30004E6960 /* EditCategoriesCompactCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A9B6960C2433CD30004E6960 /* EditCategoriesCompactCollectionViewCell.xib */; };
 		A9B696112433CF31004E6960 /* EditCategoriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B696102433CF31004E6960 /* EditCategoriesViewController.swift */; };
 		A9C32CFF242271F3000EC6F7 /* Phrase+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C32CFE242271F3000EC6F7 /* Phrase+Helpers.swift */; };
-		A9CF2AE9242D41BE005633A7 /* EditSayings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A9CF2AE8242D41BE005633A7 /* EditSayings.storyboard */; };
+		A9CF2AE9242D41BE005633A7 /* EditPhrases.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A9CF2AE8242D41BE005633A7 /* EditPhrases.storyboard */; };
 		A9CF2AEB242D431E005633A7 /* TimingSensitivity.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A9CF2AEA242D431E005633A7 /* TimingSensitivity.storyboard */; };
 		A9CF2AED242D44CA005633A7 /* TimingSensitivityCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CF2AEC242D44CA005633A7 /* TimingSensitivityCollectionViewController.swift */; };
 		A9CF2AEF242D44EE005633A7 /* TimingSensitivityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CF2AEE242D44EE005633A7 /* TimingSensitivityViewController.swift */; };
@@ -266,9 +266,9 @@
 		6BFB18C524004711002C3515 /* ModelObjectExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelObjectExtensions.swift; sourceTree = "<group>"; };
 		71004B0C242926A2006833B8 /* SelectionMode.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SelectionMode.storyboard; sourceTree = "<group>"; };
 		714407EC243CEEA1009D077B /* Category+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Category+Helpers.swift"; sourceTree = "<group>"; };
-		714EFD44241964D800DC773C /* EditSayingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSayingsViewController.swift; sourceTree = "<group>"; };
-		718D7FAD2419546F00FDEF93 /* EditSayingsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSayingsCollectionViewCell.swift; sourceTree = "<group>"; };
-		718D7FAF241954C400FDEF93 /* EditSayingsCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditSayingsCollectionViewCell.xib; sourceTree = "<group>"; };
+		714EFD44241964D800DC773C /* EditPhrasesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPhrasesViewController.swift; sourceTree = "<group>"; };
+		718D7FAD2419546F00FDEF93 /* EditPhrasesCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPhrasesCollectionViewCell.swift; sourceTree = "<group>"; };
+		718D7FAF241954C400FDEF93 /* EditPhrasesCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditPhrasesCollectionViewCell.xib; sourceTree = "<group>"; };
 		7192E408242BC58F008E4A0A /* ToastWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastWindow.swift; sourceTree = "<group>"; };
 		7192E40A242E6562008E4A0A /* ToastContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastContainerViewController.swift; sourceTree = "<group>"; };
 		7192E4112433E4BE008E4A0A /* EditCategoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCategoryDetailViewController.swift; sourceTree = "<group>"; };
@@ -316,7 +316,7 @@
 		A9B6960E2433CF23004E6960 /* EditCategoriesCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCategoriesCollectionViewController.swift; sourceTree = "<group>"; };
 		A9B696102433CF31004E6960 /* EditCategoriesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCategoriesViewController.swift; sourceTree = "<group>"; };
 		A9C32CFE242271F3000EC6F7 /* Phrase+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Phrase+Helpers.swift"; sourceTree = "<group>"; };
-		A9CF2AE8242D41BE005633A7 /* EditSayings.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = EditSayings.storyboard; sourceTree = "<group>"; };
+		A9CF2AE8242D41BE005633A7 /* EditPhrases.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = EditPhrases.storyboard; sourceTree = "<group>"; };
 		A9CF2AEA242D431E005633A7 /* TimingSensitivity.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TimingSensitivity.storyboard; sourceTree = "<group>"; };
 		A9CF2AEC242D44CA005633A7 /* TimingSensitivityCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingSensitivityCollectionViewController.swift; sourceTree = "<group>"; };
 		A9CF2AEE242D44EE005633A7 /* TimingSensitivityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingSensitivityViewController.swift; sourceTree = "<group>"; };
@@ -466,8 +466,8 @@
 		64A220BC245217220014EA80 /* Root */ = {
 			isa = PBXGroup;
 			children = (
-				64A220BA2452171C0014EA80 /* RootViewController.swift */,
 				64A220BD2452173C0014EA80 /* Root.storyboard */,
+				64A220BA2452171C0014EA80 /* RootViewController.swift */,
 			);
 			path = Root;
 			sourceTree = "<group>";
@@ -538,10 +538,10 @@
 		714EFD412419636500DC773C /* EditSayings */ = {
 			isa = PBXGroup;
 			children = (
-				A9CF2AE8242D41BE005633A7 /* EditSayings.storyboard */,
-				714EFD44241964D800DC773C /* EditSayingsViewController.swift */,
-				718D7FAD2419546F00FDEF93 /* EditSayingsCollectionViewCell.swift */,
-				718D7FAF241954C400FDEF93 /* EditSayingsCollectionViewCell.xib */,
+				A9CF2AE8242D41BE005633A7 /* EditPhrases.storyboard */,
+				714EFD44241964D800DC773C /* EditPhrasesViewController.swift */,
+				718D7FAD2419546F00FDEF93 /* EditPhrasesCollectionViewCell.swift */,
+				718D7FAF241954C400FDEF93 /* EditPhrasesCollectionViewCell.xib */,
 			);
 			path = EditSayings;
 			sourceTree = "<group>";
@@ -565,8 +565,8 @@
 			isa = PBXGroup;
 			children = (
 				64253CEC2419358D0044EAAA /* Settings.storyboard */,
-				A92FFB8C23ECCB5400AF2D0B /* SettingsCollectionViewController.swift */,
 				A944D0062405C61400F3863E /* SettingsViewController.swift */,
+				A92FFB8C23ECCB5400AF2D0B /* SettingsCollectionViewController.swift */,
 				714EFD412419636500DC773C /* EditSayings */,
 				A9B696002433C33F004E6960 /* EditCategories */,
 				A9DFCC21242D3A5000136136 /* TimingSensitivity */,
@@ -595,8 +595,8 @@
 		A96D61D82422A00D00577144 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				A944D00A2406D55F00F3863E /* SettingsToggleCollectionViewCell.xib */,
 				A944D0082406D54400F3863E /* SettingsToggleCollectionViewCell.swift */,
+				A944D00A2406D55F00F3863E /* SettingsToggleCollectionViewCell.xib */,
 				A98E8A2223F1DBDF00BF1F22 /* SettingsFooterCollectionViewCell.swift */,
 				A98E8A2423F1DBF200BF1F22 /* SettingsFooterCollectionViewCell.xib */,
 				A96D61D424229F6400577144 /* SettingsCollectionViewCell.swift */,
@@ -634,10 +634,10 @@
 		A9CF2AFA242D4F11005633A7 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				A9CF2AF2242D4EDE005633A7 /* DwellTimeCollectionViewCell.xib */,
 				A9CF2AF6242D4EFD005633A7 /* DwellTimeCollectionViewCell.swift */,
-				A9CF2AF4242D4EF1005633A7 /* SensitivityCollectionViewCell.xib */,
+				A9CF2AF2242D4EDE005633A7 /* DwellTimeCollectionViewCell.xib */,
 				A9CF2AF8242D4F0A005633A7 /* SensitivityCollectionViewCell.swift */,
+				A9CF2AF4242D4EF1005633A7 /* SensitivityCollectionViewCell.xib */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -928,7 +928,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9CF2AF5242D4EF1005633A7 /* SensitivityCollectionViewCell.xib in Resources */,
-				718D7FB0241954C400FDEF93 /* EditSayingsCollectionViewCell.xib in Resources */,
+				718D7FB0241954C400FDEF93 /* EditPhrasesCollectionViewCell.xib in Resources */,
 				71DBE5EB240DE4D000BA8D01 /* WarningView.xib in Resources */,
 				A9F56FC42436599E008162B6 /* FunctionKeyboardKeyCollectionViewCell.xib in Resources */,
 				A99AF23523FDA8DC00BE1184 /* SuggestionCollectionViewCell.xib in Resources */,
@@ -941,7 +941,7 @@
 				B81D236723FF31F6005741E8 /* PageIndicatorCollectionViewCell.xib in Resources */,
 				A99FA08A2447A595007A6D82 /* EditTextViewController.storyboard in Resources */,
 				B81D235B23FED8EF005741E8 /* PresetPaginationContainerCollectionViewCell.xib in Resources */,
-				A9CF2AE9242D41BE005633A7 /* EditSayings.storyboard in Resources */,
+				A9CF2AE9242D41BE005633A7 /* EditPhrases.storyboard in Resources */,
 				30B979B82425583E00309D7C /* InfoPlist.strings in Resources */,
 				A9F56FC824365BE8008162B6 /* SpeakFunctionKeyboardKeyCollectionViewCell.xib in Resources */,
 				130C00C420D2AD2C007C3163 /* LaunchScreen.storyboard in Resources */,
@@ -1073,7 +1073,7 @@
 				A95D07BE24326475004ECE64 /* CursorSensitivity.swift in Sources */,
 				B81D235623FED535005741E8 /* PresetPaginationContainerCollectionViewCell.swift in Sources */,
 				71FA2857242413670051498A /* SelectionModeCollectionViewController.swift in Sources */,
-				714EFD45241964D800DC773C /* EditSayingsViewController.swift in Sources */,
+				714EFD45241964D800DC773C /* EditPhrasesViewController.swift in Sources */,
 				6B9DFA7423E8D1270037673E /* TrackingContainerViewController.swift in Sources */,
 				A93E94052450EEC8008B61D2 /* KeyboardViewController.swift in Sources */,
 				6B32EA96244F717E007DC6BB /* PhraseCollectionEmptyStateView.swift in Sources */,
@@ -1120,7 +1120,7 @@
 				6B9DFA5F23E889DB0037673E /* UIHeadGazeEvent.swift in Sources */,
 				A9DE170023F4900C0094DB64 /* TextExpression.swift in Sources */,
 				A9B32C8C240EB6250084E151 /* KeyboardModel.swift in Sources */,
-				718D7FAE2419546F00FDEF93 /* EditSayingsCollectionViewCell.swift in Sources */,
+				718D7FAE2419546F00FDEF93 /* EditPhrasesCollectionViewCell.swift in Sources */,
 				A9299C7523F5FBEE00903AB6 /* KeyboardKeyCollectionViewCell.swift in Sources */,
 				7192E41B2434050E008E4A0A /* EditCategoryRemoveCollectionViewCell.swift in Sources */,
 				6B9DFA5B23E889DB0037673E /* UIHeadGazeViewController.swift in Sources */,

--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -77,7 +77,7 @@
 		718D7FB0241954C400FDEF93 /* EditSayingsCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 718D7FAF241954C400FDEF93 /* EditSayingsCollectionViewCell.xib */; };
 		7192E409242BC58F008E4A0A /* ToastWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7192E408242BC58F008E4A0A /* ToastWindow.swift */; };
 		7192E40B242E6562008E4A0A /* ToastContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7192E40A242E6562008E4A0A /* ToastContainerViewController.swift */; };
-		7192E4122433E4BE008E4A0A /* EditCategoriesDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7192E4112433E4BE008E4A0A /* EditCategoriesDetailViewController.swift */; };
+		7192E4122433E4BE008E4A0A /* EditCategoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7192E4112433E4BE008E4A0A /* EditCategoryDetailViewController.swift */; };
 		7192E4162433FD8B008E4A0A /* EditCategoryToggleCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7192E4152433FD8B008E4A0A /* EditCategoryToggleCollectionViewCell.xib */; };
 		7192E4182433FDF5008E4A0A /* EditCategoryToggleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7192E4172433FDF5008E4A0A /* EditCategoryToggleCollectionViewCell.swift */; };
 		7192E41B2434050E008E4A0A /* EditCategoryRemoveCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7192E4192434050E008E4A0A /* EditCategoryRemoveCollectionViewCell.swift */; };
@@ -271,7 +271,7 @@
 		718D7FAF241954C400FDEF93 /* EditSayingsCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditSayingsCollectionViewCell.xib; sourceTree = "<group>"; };
 		7192E408242BC58F008E4A0A /* ToastWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastWindow.swift; sourceTree = "<group>"; };
 		7192E40A242E6562008E4A0A /* ToastContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastContainerViewController.swift; sourceTree = "<group>"; };
-		7192E4112433E4BE008E4A0A /* EditCategoriesDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCategoriesDetailViewController.swift; sourceTree = "<group>"; };
+		7192E4112433E4BE008E4A0A /* EditCategoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCategoryDetailViewController.swift; sourceTree = "<group>"; };
 		7192E4152433FD8B008E4A0A /* EditCategoryToggleCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditCategoryToggleCollectionViewCell.xib; sourceTree = "<group>"; };
 		7192E4172433FDF5008E4A0A /* EditCategoryToggleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCategoryToggleCollectionViewCell.swift; sourceTree = "<group>"; };
 		7192E4192434050E008E4A0A /* EditCategoryRemoveCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCategoryRemoveCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -611,7 +611,7 @@
 				A927A5242433D0240026EF40 /* EditCategories.storyboard */,
 				A9B696102433CF31004E6960 /* EditCategoriesViewController.swift */,
 				A9B6960E2433CF23004E6960 /* EditCategoriesCollectionViewController.swift */,
-				7192E4112433E4BE008E4A0A /* EditCategoriesDetailViewController.swift */,
+				7192E4112433E4BE008E4A0A /* EditCategoryDetailViewController.swift */,
 				A9B696032433C3DF004E6960 /* Views */,
 			);
 			path = EditCategories;
@@ -620,13 +620,13 @@
 		A9B696032433C3DF004E6960 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				A9B6960A2433CCFD004E6960 /* EditCategoriesDefaultCollectionViewCell.swift */,
 				A9B696042433C422004E6960 /* EditCategoriesDefaultCollectionViewCell.xib */,
 				7192E4192434050E008E4A0A /* EditCategoryRemoveCollectionViewCell.swift */,
 				7192E41A2434050E008E4A0A /* EditCategoryRemoveCollectionViewCell.xib */,
-				A9B6960A2433CCFD004E6960 /* EditCategoriesDefaultCollectionViewCell.swift */,
-				A9B6960C2433CD30004E6960 /* EditCategoriesCompactCollectionViewCell.xib */,
-				7192E4152433FD8B008E4A0A /* EditCategoryToggleCollectionViewCell.xib */,
 				7192E4172433FDF5008E4A0A /* EditCategoryToggleCollectionViewCell.swift */,
+				7192E4152433FD8B008E4A0A /* EditCategoryToggleCollectionViewCell.xib */,
+				A9B6960C2433CD30004E6960 /* EditCategoriesCompactCollectionViewCell.xib */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1108,7 +1108,7 @@
 				6B8440E3244A1007007A4DC6 /* CarouselGridLayout.swift in Sources */,
 				6B8440E1244A0F97007A4DC6 /* VocableCollectionViewLayoutTransitioningDelegate.swift in Sources */,
 				A9DFCC18242BDCD700136136 /* CategoryPaginationCollectionViewCell.swift in Sources */,
-				7192E4122433E4BE008E4A0A /* EditCategoriesDetailViewController.swift in Sources */,
+				7192E4122433E4BE008E4A0A /* EditCategoryDetailViewController.swift in Sources */,
 				9DB58D4922666BC200E99C3B /* UIColor+AppExtensions.swift in Sources */,
 				6B823BCB23F4ADE30099F65E /* Pulse.swift in Sources */,
 				A9CF2AEF242D44EE005633A7 /* TimingSensitivityViewController.swift in Sources */,

--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -86,6 +86,11 @@
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "AddPhraseEnabled"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "RefactoredInterfaceEnabled"
             value = ""
             isEnabled = "NO">

--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -86,7 +86,7 @@
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "AddPhraseEnabled"
+            key = "EditPhrasesEnabled"
             value = ""
             isEnabled = "YES">
          </EnvironmentVariable>

--- a/Vocable/AppConfig.swift
+++ b/Vocable/AppConfig.swift
@@ -44,4 +44,9 @@ struct AppConfig {
     static var refactoredInterfaceEnabled: Bool {
         return ProcessInfo.processInfo.environment.keys.contains("RefactoredInterfaceEnabled")
     }
+
+    static var addPhraseEnabled: Bool {
+        return ProcessInfo.processInfo.environment.keys.contains("AddPhraseEnabled")
+    }
+
 }

--- a/Vocable/AppConfig.swift
+++ b/Vocable/AppConfig.swift
@@ -45,8 +45,8 @@ struct AppConfig {
         return ProcessInfo.processInfo.environment.keys.contains("RefactoredInterfaceEnabled")
     }
 
-    static var addPhraseEnabled: Bool {
-        return ProcessInfo.processInfo.environment.keys.contains("AddPhraseEnabled")
+    static var editPhrasesEnabled: Bool {
+        return ProcessInfo.processInfo.environment.keys.contains("EditPhrasesEnabled")
     }
 
 }

--- a/Vocable/Common/EditTextViewController.swift
+++ b/Vocable/Common/EditTextViewController.swift
@@ -18,22 +18,22 @@ final class EditTextViewController: UIViewController, UICollectionViewDelegate {
     
     private var keyboardViewController: KeyboardViewController?
     
-    @IBOutlet var textView: OutputTextView!
     var initialText: String = ""
-    
-    @IBOutlet private var confirmEditButton: GazeableButton!
-    
+
     private var textHasChanged = false
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "KeyboardViewController" {
             keyboardViewController = segue.destination as? KeyboardViewController
         }
     }
-    
+
     var editTextCompletionHandler: (String) -> Void = { (_) in
         assertionFailure("Completion not handled")
     }
+
+    @IBOutlet var textView: OutputTextView!
+    @IBOutlet private var confirmEditButton: GazeableButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Vocable/CoreData/ModelObjectExtensions.swift
+++ b/Vocable/CoreData/ModelObjectExtensions.swift
@@ -23,6 +23,13 @@ extension Category: NSManagedObjectIdentifiable {
         let category = Category.fetch(.userFavorites, in: context)
         return category.name ?? ""
     }
+
+    static func userFavoritesCategory() -> Category {
+        let context = NSPersistentContainer.shared.viewContext
+        let category = Category.fetch(.userFavorites, in: context)
+        return category
+    }
+
 }
 
 extension Phrase: NSManagedObjectIdentifiable {

--- a/Vocable/Features/Settings/EditCategories/EditCategories.storyboard
+++ b/Vocable/Features/Settings/EditCategories/EditCategories.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -186,7 +186,7 @@
             <objects>
                 <collectionViewController id="W98-u1-6GB" customClass="EditCategoriesCollectionViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="f36-Ss-9hs">
-                        <rect key="frame" x="0.0" y="0.0" width="374" height="634"/>
+                        <rect key="frame" x="0.0" y="0.0" width="536" height="634"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <collectionViewLayout key="collectionViewLayout" id="4c5-Wx-dzH" customClass="CarouselGridLayout" customModule="Vocable" customModuleProvider="target"/>
@@ -201,10 +201,10 @@
             </objects>
             <point key="canvasLocation" x="3722" y="143"/>
         </scene>
-        <!--Edit Categories Detail View Controller-->
+        <!--Edit Category Detail View Controller-->
         <scene sceneID="FIn-Tv-o2a">
             <objects>
-                <viewController storyboardIdentifier="EditCategoryDetail" id="6hz-tb-yd2" customClass="EditCategoriesDetailViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="EditCategoryDetail" id="6hz-tb-yd2" customClass="EditCategoryDetailViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="6iL-6J-UCo" customClass="GazeEatingView" customModule="Vocable" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Vocable/Features/Settings/EditCategories/EditCategories.storyboard
+++ b/Vocable/Features/Settings/EditCategories/EditCategories.storyboard
@@ -186,7 +186,7 @@
             <objects>
                 <collectionViewController id="W98-u1-6GB" customClass="EditCategoriesCollectionViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="f36-Ss-9hs">
-                        <rect key="frame" x="0.0" y="0.0" width="536" height="634"/>
+                        <rect key="frame" x="0.0" y="0.0" width="374" height="634"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <collectionViewLayout key="collectionViewLayout" id="4c5-Wx-dzH" customClass="CarouselGridLayout" customModule="Vocable" customModuleProvider="target"/>
@@ -256,7 +256,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <action selector="editButtonPressed:" destination="6hz-tb-yd2" eventType="primaryActionTriggered" id="ggX-Qt-Mkk"/>
+                                            <action selector="editCategoryButtonPressed:" destination="6hz-tb-yd2" eventType="primaryActionTriggered" id="ggX-Qt-Mkk"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesCollectionViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesCollectionViewController.swift
@@ -1,12 +1,11 @@
 //
 //  EditCategoriesCollectionViewController.swift
-//  Vocable
+//  Vocable AAC
 //
 //  Created by Jesse Morgan on 3/31/20.
 //  Copyright © 2020 WillowTree. All rights reserved.
 //
 
-import Foundation
 import UIKit
 import CoreData
 
@@ -47,10 +46,8 @@ final class EditCategoriesCollectionViewController: CarouselGridCollectionViewCo
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        collectionView.register(UINib(nibName: "EditCategoriesDefaultCollectionViewCell", bundle: nil),
-                                forCellWithReuseIdentifier: "EditCategoriesDefaultCollectionViewCell")
-        collectionView.register(UINib(nibName: "EditCategoriesCompactCollectionViewCell", bundle: nil),
-                                forCellWithReuseIdentifier: "EditCategoriesCompactCollectionViewCell")
+        collectionView.register(UINib(nibName: "EditCategoriesDefaultCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: EditCategoriesDefaultCollectionViewCell.reuseIdentifier)
+        collectionView.register(UINib(nibName: "EditCategoriesCompactCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "EditCategoriesCompactCollectionViewCell")
         collectionView.backgroundColor = .collectionViewBackgroundColor
 
         updateLayoutForCurrentTraitCollection()
@@ -190,11 +187,9 @@ final class EditCategoriesCollectionViewController: CarouselGridCollectionViewCo
             return
         }
         
-        let vc = UIStoryboard(name: "EditCategories", bundle: nil).instantiateViewController(identifier: "EditCategoryDetail") as! EditCategoryDetailViewController
-        
-        vc.category = fetchResultsController.object(at: indexPath)
-        show(vc, sender: nil)
-        
+        let viewController = UIStoryboard(name: "EditCategories", bundle: nil).instantiateViewController(identifier: "EditCategoryDetail") as! EditCategoryDetailViewController
+        viewController.category = fetchResultsController.object(at: indexPath)
+        show(viewController, sender: nil)
     }
     
     private func indexPath(after indexPath: IndexPath) -> IndexPath? {

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesCollectionViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesCollectionViewController.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 import CoreData
 
-class EditCategoriesCollectionViewController: CarouselGridCollectionViewController, NSFetchedResultsControllerDelegate {
+final class EditCategoriesCollectionViewController: CarouselGridCollectionViewController, NSFetchedResultsControllerDelegate {
     
     private lazy var diffableDataSource = UICollectionViewDiffableDataSource<Int, Category>(collectionView: collectionView!) { [weak self] (collectionView, indexPath, category) -> UICollectionViewCell? in
         guard let self = self else { return nil }
@@ -190,7 +190,7 @@ class EditCategoriesCollectionViewController: CarouselGridCollectionViewControll
             return
         }
         
-        let vc = UIStoryboard(name: "EditCategories", bundle: nil).instantiateViewController(identifier: "EditCategoryDetail") as! EditCategoriesDetailViewController
+        let vc = UIStoryboard(name: "EditCategories", bundle: nil).instantiateViewController(identifier: "EditCategoryDetail") as! EditCategoryDetailViewController
         
         vc.category = fetchResultsController.object(at: indexPath)
         show(vc, sender: nil)

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 import Combine
 import CoreData
 
-class EditCategoriesViewController: UIViewController {
+final class EditCategoriesViewController: UIViewController {
     
     @IBOutlet private var addCategoryButton: GazeableButton!
     @IBOutlet private var titleLabel: UILabel!

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
@@ -1,31 +1,30 @@
 //
 //  EditCategoriesViewController.swift
-//  Vocable
+//  Vocable AAC
 //
 //  Created by Jesse Morgan on 3/31/20.
 //  Copyright © 2020 WillowTree. All rights reserved.
 //
 
-import Foundation
 import UIKit
 import Combine
 import CoreData
 
 final class EditCategoriesViewController: UIViewController {
-    
+
+    private var carouselCollectionViewController: CarouselGridCollectionViewController?
+    private var disposables = Set<AnyCancellable>()
+
     @IBOutlet private var addCategoryButton: GazeableButton!
     @IBOutlet private var titleLabel: UILabel!
     @IBOutlet private weak var pageNavigationView: PaginationView!
-    
-    private var carouselCollectionViewController: CarouselGridCollectionViewController?
-    private var disposables = Set<AnyCancellable>()
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "CarouselCollectionViewController" {
            carouselCollectionViewController = segue.destination as? CarouselGridCollectionViewController
         }
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         carouselCollectionViewController?.progressPublisher.sink(receiveValue: { (pagingProgress) in

--- a/Vocable/Features/Settings/EditCategories/Views/EditCategoriesDefaultCollectionViewCell.swift
+++ b/Vocable/Features/Settings/EditCategories/Views/EditCategoriesDefaultCollectionViewCell.swift
@@ -1,15 +1,14 @@
 //
 //  EditCategoriesRegularCollectionViewCell.swift
-//  Vocable
+//  Vocable AAC
 //
 //  Created by Jesse Morgan on 3/31/20.
 //  Copyright © 2020 WillowTree. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
-class EditCategoriesDefaultCollectionViewCell: UICollectionViewCell {
+final class EditCategoriesDefaultCollectionViewCell: UICollectionViewCell {
     
     @IBOutlet var moveDownButton: GazeableButton!
     @IBOutlet var moveUpButton: GazeableButton!

--- a/Vocable/Features/Settings/EditCategories/Views/EditCategoryRemoveCollectionViewCell.swift
+++ b/Vocable/Features/Settings/EditCategories/Views/EditCategoryRemoveCollectionViewCell.swift
@@ -1,6 +1,6 @@
 //
 //  EditCategoryRemoveCollectionViewCell.swift
-//  Vocable
+//  Vocable AAC
 //
 //  Created by Thomas Shealy on 3/31/20.
 //  Copyright © 2020 WillowTree. All rights reserved.
@@ -8,15 +8,9 @@
 
 import UIKit
 
-class EditCategoryRemoveCollectionViewCell: VocableCollectionViewCell {
+final class EditCategoryRemoveCollectionViewCell: VocableCollectionViewCell {
 
     @IBOutlet weak var textLabel: UILabel!
-    
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        
-        textLabel.text = NSLocalizedString("category_editor.detail.button.remove_category.title", comment: "Remove category button label within the category detail screen.")
-    }
 
     override func updateContentViews() {
         super.updateContentViews()

--- a/Vocable/Features/Settings/EditCategories/Views/EditCategoryRemoveCollectionViewCell.xib
+++ b/Vocable/Features/Settings/EditCategories/Views/EditCategoryRemoveCollectionViewCell.xib
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Vocable/Features/Settings/EditCategories/Views/EditCategoryToggleCollectionViewCell.swift
+++ b/Vocable/Features/Settings/EditCategories/Views/EditCategoryToggleCollectionViewCell.swift
@@ -1,6 +1,6 @@
 //
 //  EditCategoryToggleCollectionViewCell.swift
-//  Vocable
+//  Vocable AAC
 //
 //  Created by Thomas Shealy on 3/31/20.
 //  Copyright © 2020 WillowTree. All rights reserved.
@@ -8,20 +8,19 @@
 
 import UIKit
 
-class EditCategoryToggleCollectionViewCell: VocableCollectionViewCell {
+final class EditCategoryToggleCollectionViewCell: VocableCollectionViewCell {
     
     @IBOutlet weak var showCategorySwitch: UISwitch!
-    @IBOutlet weak var showCategoryLabel: UILabel!
+    @IBOutlet weak var textLabel: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()
         
         showCategorySwitch.isUserInteractionEnabled = false
-        showCategoryLabel.text = NSLocalizedString("category_editor.detail.button.show_category.title", comment: "Show category button label within the category detail screen.")
     }
 
     override func updateContentViews() {
         super.updateContentViews()
-        showCategoryLabel?.textColor = isEnabled ? .defaultTextColor : .disabledTextColor
+        textLabel?.textColor = isEnabled ? .defaultTextColor : .disabledTextColor
     }
 }

--- a/Vocable/Features/Settings/EditCategories/Views/EditCategoryToggleCollectionViewCell.xib
+++ b/Vocable/Features/Settings/EditCategories/Views/EditCategoryToggleCollectionViewCell.xib
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -39,8 +39,8 @@
             </collectionViewCellContentView>
             <size key="customSize" width="523" height="99"/>
             <connections>
-                <outlet property="showCategoryLabel" destination="an4-x2-fF0" id="bzH-ua-ng4"/>
                 <outlet property="showCategorySwitch" destination="ZoC-cN-J0k" id="wrE-Aw-tzJ"/>
+                <outlet property="textLabel" destination="an4-x2-fF0" id="bzH-ua-ng4"/>
             </connections>
             <point key="canvasLocation" x="-667.39130434782612" y="-405.46875"/>
         </collectionViewCell>

--- a/Vocable/Features/Settings/EditSayings/EditPhrases.storyboard
+++ b/Vocable/Features/Settings/EditSayings/EditPhrases.storyboard
@@ -5,14 +5,13 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Edit Sayings View Controller-->
+        <!--Edit Phrases View Controller-->
         <scene sceneID="8J2-gW-BaT">
             <objects>
-                <viewController storyboardIdentifier="MySayings" id="KLI-zL-Q9x" customClass="EditSayingsViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MyPhrases" id="KLI-zL-Q9x" customClass="EditPhrasesViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="XHU-T2-eKa" customClass="GazeEatingView" customModule="Vocable" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -89,25 +88,16 @@
                                 </constraints>
                                 <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                             </view>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="XxC-Wq-DWE" customClass="CarouselGridCollectionView" customModule="Vocable" customModuleProvider="target">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="XxC-Wq-DWE" customClass="CarouselGridCollectionView" customModule="Vocable" customModuleProvider="target">
                                 <rect key="frame" x="16" y="132" width="343" height="542"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <collectionViewLayout key="collectionViewLayout" id="RJg-hs-fDZ" customClass="CarouselGridLayout" customModule="Vocable" customModuleProvider="target"/>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="EditSayingsCell" id="Qjr-Rq-IoO">
-                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="u8n-P7-naF">
-                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                    </collectionViewCell>
-                                </cells>
+                                <cells/>
                                 <connections>
                                     <outlet property="delegate" destination="KLI-zL-Q9x" id="WKe-JG-Hl5"/>
                                 </connections>
                             </collectionView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xsL-XA-YD7" customClass="PaginationView" customModule="Vocable" customModuleProvider="target">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xsL-XA-YD7" customClass="PaginationView" customModule="Vocable" customModuleProvider="target">
                                 <rect key="frame" x="51.666666666666657" y="698" width="272" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="aHj-3P-gGo"/>
@@ -174,53 +164,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gxk-ad-LrW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2559" y="144"/>
-        </scene>
-        <!--Edit Sayings Keyboard View Controller-->
-        <scene sceneID="WU4-lR-j23">
-            <objects>
-                <viewController storyboardIdentifier="EditSaying" id="qBB-qb-4us" customClass="EditSayingsKeyboardViewController" customModule="Vocable" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="nxM-ki-o4S">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="zBG-MP-Uvj">
-                                <rect key="frame" x="16" y="52" width="343" height="718"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="MPw-us-ZBK">
-                                    <size key="itemSize" width="50" height="50"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells/>
-                                <connections>
-                                    <outlet property="delegate" destination="qBB-qb-4us" id="3hX-tf-aZQ"/>
-                                </connections>
-                            </collectionView>
-                        </subviews>
-                        <color key="backgroundColor" name="Background"/>
-                        <constraints>
-                            <constraint firstItem="zBG-MP-Uvj" firstAttribute="top" secondItem="nxM-ki-o4S" secondAttribute="topMargin" id="Syx-Rh-0JA"/>
-                            <constraint firstItem="zBG-MP-Uvj" firstAttribute="leading" secondItem="nxM-ki-o4S" secondAttribute="leadingMargin" id="bKs-Wb-6AT"/>
-                            <constraint firstItem="zBG-MP-Uvj" firstAttribute="trailing" secondItem="nxM-ki-o4S" secondAttribute="trailingMargin" id="g0f-Fr-opn"/>
-                            <constraint firstItem="zBG-MP-Uvj" firstAttribute="bottom" secondItem="nxM-ki-o4S" secondAttribute="bottomMargin" id="mM3-Au-Wcd"/>
-                        </constraints>
-                        <edgeInsets key="layoutMargins" top="32" left="32" bottom="32" right="32"/>
-                        <viewLayoutGuide key="safeArea" id="8d6-BI-B1P"/>
-                        <variation key="heightClass=compact">
-                            <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
-                        </variation>
-                        <variation key="widthClass=compact">
-                            <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
-                        </variation>
-                    </view>
-                    <connections>
-                        <outlet property="collectionView" destination="zBG-MP-Uvj" id="NE3-hU-w72"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Bj1-rW-RH8" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4778" y="138"/>
         </scene>
     </scenes>
     <resources>

--- a/Vocable/Features/Settings/EditSayings/EditPhrasesCollectionViewCell.swift
+++ b/Vocable/Features/Settings/EditSayings/EditPhrasesCollectionViewCell.swift
@@ -6,23 +6,19 @@
 //  Copyright © 2020 WillowTree. All rights reserved.
 //
 
-import Foundation
 import UIKit
 import Combine
 
-final class EditSayingsCollectionViewCell: VocableCollectionViewCell {
+final class EditPhrasesCollectionViewCell: VocableCollectionViewCell {
     
-    @IBOutlet private var textLabel: UILabel!
+    @IBOutlet var textLabel: UILabel!
     @IBOutlet var deleteButton: UIButton!
     @IBOutlet var editButton: UIButton!
     
     override func updateContentViews() {
         super.updateContentViews()
+
         borderedView.fillColor = .defaultCellBackgroundColor
     }
 
-    func setup(title: String) {
-        textLabel.text = title
-    }
-    
 }

--- a/Vocable/Features/Settings/EditSayings/EditPhrasesCollectionViewCell.xib
+++ b/Vocable/Features/Settings/EditSayings/EditPhrasesCollectionViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="" id="d0b-Hs-dtY" customClass="EditSayingsCollectionViewCell" customModule="Vocable" customModuleProvider="target">
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="" id="d0b-Hs-dtY" customClass="EditPhrasesCollectionViewCell" customModule="Vocable" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="562" height="266"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="jCC-WP-535">
@@ -73,8 +73,8 @@
         </collectionViewCell>
     </objects>
     <resources>
-        <image name="pencil" catalog="system" width="64" height="56"/>
-        <image name="trash" catalog="system" width="60" height="64"/>
+        <image name="pencil" catalog="system" width="128" height="113"/>
+        <image name="trash" catalog="system" width="121" height="128"/>
         <namedColor name="DefaultFontColor">
             <color red="0.81599998474121094" green="0.93199998140335083" blue="0.91299998760223389" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Vocable/Features/Settings/EditSayings/EditPhrasesViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditPhrasesViewController.swift
@@ -12,13 +12,15 @@ import CoreData
 
 final class EditPhrasesViewController: UIViewController, UICollectionViewDelegate, NSFetchedResultsControllerDelegate {
 
+    var category: Category!
+
     private var carouselCollectionViewController: CarouselGridCollectionViewController?
     private var disposables = Set<AnyCancellable>()
 
     private lazy var diffableDataSource = CarouselCollectionViewDataSourceProxy<Int, PhraseViewModel>(collectionView: collectionView!) { [weak self] (collectionView, indexPath, phrase) -> UICollectionViewCell? in
         guard let self = self else { return nil }
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditSayingsCollectionViewCell.reuseIdentifier, for: indexPath) as! EditSayingsCollectionViewCell
-        cell.setup(title: phrase.utterance)
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditPhrasesCollectionViewCell.reuseIdentifier, for: indexPath) as! EditPhrasesCollectionViewCell
+        cell.textLabel.text = phrase.utterance
         cell.deleteButton.addTarget(self,
                                     action: #selector(self.handleCellDeletionButton(_:)),
                                     for: .primaryActionTriggered)
@@ -55,8 +57,9 @@ final class EditPhrasesViewController: UIViewController, UICollectionViewDelegat
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        collectionView.register(UINib(nibName: "EditSayingsCollectionViewCell", bundle: nil),
-                                forCellWithReuseIdentifier: "EditSayingsCollectionViewCell")
+        assert(category != nil, "Category not provided")
+
+        collectionView.register(UINib(nibName: "EditPhrasesCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: EditPhrasesCollectionViewCell.reuseIdentifier)
         collectionView.backgroundColor = .collectionViewBackgroundColor
 
         updateLayoutForCurrentTraitCollection()
@@ -73,8 +76,8 @@ final class EditPhrasesViewController: UIViewController, UICollectionViewDelegat
         paginationView.nextPageButton.addTarget(carouselCollectionViewController, action: #selector(CarouselGridCollectionViewController.scrollToNextPage), for: .primaryActionTriggered)
         paginationView.previousPageButton.addTarget(carouselCollectionViewController, action: #selector(CarouselGridCollectionViewController.scrollToPreviousPage), for: .primaryActionTriggered)
 
-        titleLabel.text = Category.userFavoritesCategoryName()
-    }   
+        titleLabel.text = category.name
+    }
     
     @IBAction private func backToSettings(_ sender: Any) {
         self.navigationController?.popViewController(animated: true)
@@ -92,7 +95,7 @@ final class EditPhrasesViewController: UIViewController, UICollectionViewDelegat
 
                 let alertMessage: String = {
                     let format = NSLocalizedString("phrase_editor.toast.successfully_saved_to_favorites.title_format", comment: "Saved to user favorites category toast title")
-                    let categoryName = Category.userFavoritesCategoryName()
+                    let categoryName = self.category.name ?? ""
                     return String.localizedStringWithFormat(format, categoryName)
                 }()
 

--- a/Vocable/Features/Settings/EditSayings/EditSayings.storyboard
+++ b/Vocable/Features/Settings/EditSayings/EditSayings.storyboard
@@ -89,7 +89,7 @@
                                 </constraints>
                                 <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                             </view>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="XxC-Wq-DWE" customClass="CarouselGridCollectionView" customModule="Vocable" customModuleProvider="target">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="XxC-Wq-DWE" customClass="CarouselGridCollectionView" customModule="Vocable" customModuleProvider="target">
                                 <rect key="frame" x="16" y="132" width="343" height="542"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <collectionViewLayout key="collectionViewLayout" id="RJg-hs-fDZ" customClass="CarouselGridLayout" customModule="Vocable" customModuleProvider="target"/>
@@ -107,7 +107,7 @@
                                     <outlet property="delegate" destination="KLI-zL-Q9x" id="WKe-JG-Hl5"/>
                                 </connections>
                             </collectionView>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xsL-XA-YD7" customClass="PaginationView" customModule="Vocable" customModuleProvider="target">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xsL-XA-YD7" customClass="PaginationView" customModule="Vocable" customModuleProvider="target">
                                 <rect key="frame" x="51.666666666666657" y="698" width="272" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="aHj-3P-gGo"/>

--- a/Vocable/Features/Settings/EditSayings/EditSayingsViewController.swift
+++ b/Vocable/Features/Settings/EditSayings/EditSayingsViewController.swift
@@ -76,7 +76,7 @@ class EditSayingsViewController: UIViewController, UICollectionViewDelegate, NSF
         paginationView.previousPageButton.addTarget(carouselCollectionViewController, action: #selector(CarouselGridCollectionViewController.scrollToPreviousPage), for: .primaryActionTriggered)
 
         titleLabel.text = Category.userFavoritesCategoryName()
-    }
+    }   
     
     @IBAction private func backToSettings(_ sender: Any) {
         self.navigationController?.popViewController(animated: true)

--- a/Vocable/Features/Settings/SelectionMode/SelectionMode.storyboard
+++ b/Vocable/Features/Settings/SelectionMode/SelectionMode.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="sMt-ye-FpV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="sMt-ye-FpV">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -118,8 +118,8 @@
         </scene>
     </scenes>
     <resources>
-        <image name="arrow.left" catalog="system" width="64" height="48"/>
-        <image name="xmark.circle" catalog="system" width="64" height="60"/>
+        <image name="arrow.left" catalog="system" width="128" height="98"/>
+        <image name="xmark.circle" catalog="system" width="128" height="121"/>
         <namedColor name="Background">
             <color red="0.12800000607967377" green="0.10899999737739563" blue="0.3580000102519989" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Vocable/Features/Settings/SelectionMode/SelectionModeCollectionViewController.swift
+++ b/Vocable/Features/Settings/SelectionMode/SelectionModeCollectionViewController.swift
@@ -11,11 +11,12 @@ import UIKit
 final class SelectionModeCollectionViewController: UICollectionViewController {
     
     private enum SelectionModeItem: String, Hashable {
+
+        case headTrackingToggle = "Head Tracking"
+
         var title: String {
             return self.rawValue
         }
-        
-        case headTrackingToggle = "Head Tracking"
     }
     
     private lazy var dataSource: UICollectionViewDiffableDataSource<Int, SelectionModeItem> = .init(collectionView: collectionView) { (collectionView, indexPath, item) -> UICollectionViewCell in
@@ -38,7 +39,7 @@ final class SelectionModeCollectionViewController: UICollectionViewController {
     
     private func setupCollectionView() {
         collectionView.backgroundColor = .collectionViewBackgroundColor
-        collectionView.register(UINib(nibName: "SettingsToggleCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "SettingsToggleCollectionViewCell")
+        collectionView.register(UINib(nibName: "SettingsToggleCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: SettingsToggleCollectionViewCell.reuseIdentifier)
         
         updateDataSource()
         

--- a/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
+++ b/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
@@ -8,7 +8,8 @@
 
 import UIKit
 
-class SelectionModeViewController: UIViewController {
+final class SelectionModeViewController: UIViewController {
+
     @IBOutlet var backButton: GazeableButton!
     
     @IBAction func backButtonPressed(_ sender: Any) {

--- a/Vocable/Features/Settings/SettingsCollectionViewController.swift
+++ b/Vocable/Features/Settings/SettingsCollectionViewController.swift
@@ -1,5 +1,5 @@
 //
-//  SettingsViewController.swift
+//  SettingsCollectionViewController.swift
 //  Vocable AAC
 //
 //  Created by Jesse Morgan on 2/6/20.
@@ -9,9 +9,7 @@
 import UIKit
 import MessageUI
 
-class SettingsCollectionViewController: UICollectionViewController, MFMailComposeViewControllerDelegate {
-
-    @IBOutlet private var headerView: UINavigationItem!
+final class SettingsCollectionViewController: UICollectionViewController, MFMailComposeViewControllerDelegate {
 
     private weak var composeVC: MFMailComposeViewController?
 
@@ -19,6 +17,17 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
     private let externalLinksItemCount = 3
 
     private enum SettingsItem: Hashable {
+
+        case editMySayings
+        case categories
+        case timingSensitivity
+        case resetAppSettings
+        case selectionMode
+        case privacyPolicy
+        case contactDevs
+        case pidTuner
+        case versionNum
+
         var title: String {
             switch self {
             case .editMySayings:
@@ -59,16 +68,6 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
             }
             return true
         }
-
-        case editMySayings
-        case categories
-        case timingSensitivity
-        case resetAppSettings
-        case selectionMode
-        case privacyPolicy
-        case contactDevs
-        case pidTuner
-        case versionNum
     }
 
     private lazy var dataSource: UICollectionViewDiffableDataSource<Int, SettingsItem> = .init(collectionView: collectionView) { (collectionView, indexPath, item) -> UICollectionViewCell in
@@ -80,6 +79,8 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
         return "Version \(versionNumber)-\(buildNumber)"
     }
+
+    @IBOutlet private var headerView: UINavigationItem!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -113,9 +114,9 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
         collectionView.isScrollEnabled = false
 
         collectionView.register(PresetItemCollectionViewCell.self, forCellWithReuseIdentifier: PresetItemCollectionViewCell.reuseIdentifier)
-        collectionView.register(UINib(nibName: "SettingsFooterCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "SettingsFooterCollectionViewCell")
-        collectionView.register(UINib(nibName: "SettingsToggleCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "SettingsToggleCollectionViewCell")
-        collectionView.register(UINib(nibName: "SettingsCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "SettingsCollectionViewCell")
+        collectionView.register(UINib(nibName: "SettingsFooterCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: SettingsFooterCollectionViewCell.reuseIdentifier)
+        collectionView.register(UINib(nibName: "SettingsToggleCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: SettingsToggleCollectionViewCell.reuseIdentifier)
+        collectionView.register(UINib(nibName: "SettingsCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: SettingsCollectionViewCell.reuseIdentifier)
 
         updateDataSource()
 
@@ -254,7 +255,8 @@ class SettingsCollectionViewController: UICollectionViewController, MFMailCompos
         case .privacyPolicy:
             presentLeavingHeadTrackableDomainAlert(withConfirmation: presentPrivacyAlert)
         case .editMySayings:
-            if let vc = UIStoryboard(name: "EditSayings", bundle: nil).instantiateViewController(identifier: "MySayings") as? EditSayingsViewController {
+            if let vc = UIStoryboard(name: "EditPhrases", bundle: nil).instantiateViewController(identifier: "MyPhrases") as? EditPhrasesViewController {
+                vc.category = Category.userFavoritesCategory()
                 show(vc, sender: nil)
             }
         case .timingSensitivity:

--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -6,19 +6,13 @@
 //  Copyright © 2020 WillowTree. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
-class SettingsViewController: UIViewController {
+final class SettingsViewController: UIViewController {
     
-    @IBOutlet var dismissButton: GazeableButton!
+    @IBOutlet private weak var dismissButton: GazeableButton!
+    @IBOutlet private weak var titleLabel: UILabel!
 
-    @IBOutlet var titleLabel: UILabel!
-
-    @IBAction func dismissSettings(_ sender: Any) {
-        dismiss(animated: true, completion: nil)
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         dismissButton.buttonImage = UIImage(systemName: "xmark.circle")!
@@ -29,5 +23,9 @@ class SettingsViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         (self.view.window as? HeadGazeWindow)?.cancelActiveGazeTarget()
+    }
+
+    @IBAction func dismissSettings(_ sender: Any) {
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/Vocable/Features/Settings/TimingSensitivity/Model/CursorSensitivity.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/Model/CursorSensitivity.swift
@@ -1,12 +1,11 @@
 //
 //  Sensitivity.swift
-//  Vocable
+//  Vocable AAC
 //
 //  Created by Jesse Morgan on 3/30/20.
 //  Copyright © 2020 WillowTree. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 enum CursorSensitivity: Int, Codable {

--- a/Vocable/Features/Settings/TimingSensitivity/TimingSensitivityCollectionViewController.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/TimingSensitivityCollectionViewController.swift
@@ -1,6 +1,6 @@
 //
 //  TimingSensitivityCollectionViewController.swift
-//  Vocable
+//  Vocable AAC
 //
 //  Created by Jesse Morgan on 3/26/20.
 //  Copyright © 2020 WillowTree. All rights reserved.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class TimingSensitivityCollectionViewController: UICollectionViewController {
+final class TimingSensitivityCollectionViewController: UICollectionViewController {
     
     private enum SelectionModeItem: Hashable {
         case dwellTime

--- a/Vocable/Features/Settings/TimingSensitivity/TimingSensitivityViewController.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/TimingSensitivityViewController.swift
@@ -1,15 +1,14 @@
 //
 //  TimingSensitivityViewController.swift
-//  Vocable
+//  Vocable AAC
 //
 //  Created by Jesse Morgan on 3/26/20.
 //  Copyright © 2020 WillowTree. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
-class TimingSensitivityViewController: UIViewController {
+final class TimingSensitivityViewController: UIViewController {
     
     @IBOutlet var backButton: GazeableButton!
     

--- a/Vocable/Features/Settings/TimingSensitivity/Views/SensitivityCollectionViewCell.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/Views/SensitivityCollectionViewCell.swift
@@ -1,6 +1,6 @@
 //
 //  SensitivityCollectionViewCell.swift
-//  Vocable
+//  Vocable AAC
 //
 //  Created by Jesse Morgan on 3/26/20.
 //  Copyright © 2020 WillowTree. All rights reserved.
@@ -9,17 +9,17 @@
 import UIKit
 import Combine
 
-class SensitivityCollectionViewCell: UICollectionViewCell {
-    
-    @IBOutlet private var lowSensitivityButton: GazeableSegmentedButton!
-    @IBOutlet private var mediumSensitivityButton: GazeableSegmentedButton!
-    @IBOutlet private var highSensitivityButton: GazeableSegmentedButton!
-    
-    @IBOutlet var topSeparator: UIView!
-    @IBOutlet var bottomSeparator: UIView!
+final class SensitivityCollectionViewCell: UICollectionViewCell {
     
     private var disposables = Set<AnyCancellable>()
-    
+
+    @IBOutlet private weak var lowSensitivityButton: GazeableSegmentedButton!
+    @IBOutlet private weak var mediumSensitivityButton: GazeableSegmentedButton!
+    @IBOutlet private weak var highSensitivityButton: GazeableSegmentedButton!
+
+    @IBOutlet weak var topSeparator: UIView!
+    @IBOutlet weak var bottomSeparator: UIView!
+
     override func awakeFromNib() {
         super.awakeFromNib()
         

--- a/Vocable/Features/Settings/Views/SettingsCollectionViewCell.swift
+++ b/Vocable/Features/Settings/Views/SettingsCollectionViewCell.swift
@@ -6,18 +6,16 @@
 //  Copyright © 2020 WillowTree. All rights reserved.
 //
 
-import Foundation
 import UIKit
 import Combine
 
-class SettingsCollectionViewCell: VocableCollectionViewCell {
-    @IBOutlet var textLabel: UILabel!
-    @IBOutlet var imageView: UIImageView!
+final class SettingsCollectionViewCell: VocableCollectionViewCell {
+
+    @IBOutlet private weak var textLabel: UILabel!
+    @IBOutlet private weak var imageView: UIImageView!
     
     func setup(title: String, image: UIImage?) {
-        guard let image = image else {
-            return
-        }
+        guard let image = image else { return }
         
         textLabel.text = title
         imageView.image = image

--- a/Vocable/Features/Settings/Views/SettingsFooterCollectionViewCell.swift
+++ b/Vocable/Features/Settings/Views/SettingsFooterCollectionViewCell.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2020 WillowTree. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
-class SettingsFooterCollectionViewCell: UICollectionViewCell {
+final class SettingsFooterCollectionViewCell: UICollectionViewCell {
     
-    @IBOutlet var versionLabel: UILabel!
+    @IBOutlet private weak var versionLabel: UILabel!
     
     func setup(versionLabel: String) {
         self.versionLabel.text = versionLabel

--- a/Vocable/Features/Settings/Views/SettingsToggleCollectionViewCell.swift
+++ b/Vocable/Features/Settings/Views/SettingsToggleCollectionViewCell.swift
@@ -12,16 +12,19 @@ import Combine
 import ARKit
 
 class SettingsToggleCollectionViewCell: VocableCollectionViewCell {
-    @IBOutlet var textLabel: UILabel!
-    @IBOutlet var enabledSwitch: UISwitch!
+
+    @IBOutlet private weak var textLabel: UILabel!
+    @IBOutlet weak var enabledSwitch: UISwitch!
     
     private var cancellables = Set<AnyCancellable>()
 
     override func awakeFromNib() {
         super.awakeFromNib()
+
         enabledSwitch.isUserInteractionEnabled = false
         enabledSwitch.isEnabled = AppConfig.isHeadTrackingSupported
         enabledSwitch.isOn = AppConfig.isHeadTrackingEnabled
+        
         AppConfig.$isHeadTrackingEnabled.sink { [weak self] isEnabled in
             self?.enabledSwitch.setOn(isEnabled, animated: true)
         }.store(in: &cancellables)

--- a/Vocable/Features/Settings/Views/SettingsToggleCollectionViewCell.xib
+++ b/Vocable/Features/Settings/Views/SettingsToggleCollectionViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Vocable/Supporting Files/Info.plist
+++ b/Vocable/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Vocable uses ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. Vocable needs permission to use the camera for this purpose.</string>
+	<string>Vocable uses ARKit head tracking to detect the user's face as seen in the device's TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. Vocable needs permission to use the camera for this purpose.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
- There is a single path to adding phrases  to custom categories that is now behind the `EditPhrasesEnabled` environment variable. The path is Settings -> Categories -> Your Custom Category -> MISSING_LOCALIZTION_Add Phrases. 
- Refactored EditPhrases to handle editing any category. It was previously hardcoded to just 'My Sayings'


Note: It is possible to successfully add phrases to a custom category those phrases are not showing up when selecting the custom category in the main screen. Updating that screen is part of the refactor and out of scope for this PR.