### PR TITLE
Change Category -> Phrase relationship to be one-to-one

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		6B005AE4245B06F3004919F4 /* VocableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableViewController.swift; sourceTree = "<group>"; };
 		6B005AE6245B21ED004919F4 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		6B005AEC245B25E9004919F4 /* VocableNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableNavigationController.swift; sourceTree = "<group>"; };
+		6B1086712463102F00E729A8 /* Phrases v3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Phrases v3.xcdatamodel"; sourceTree = "<group>"; };
 		6B14DC722419590E0050C287 /* OutputTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputTextView.swift; sourceTree = "<group>"; };
 		6B17CD7B23E9DFD50050BCB8 /* AVSpeechSynthesizer+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVSpeechSynthesizer+Shared.swift"; sourceTree = "<group>"; };
 		6B17CD7F23EA045D0050BCB8 /* ViewControllerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerWrapperView.swift; sourceTree = "<group>"; };
@@ -1722,10 +1723,11 @@
 		6BFB18C024002C7B002C3515 /* Phrases.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				6B1086712463102F00E729A8 /* Phrases v3.xcdatamodel */,
 				B8D55689242FE8B900B0F6FE /* Phrases v2.xcdatamodel */,
 				6BFB18C124002C7B002C3515 /* Phrases.xcdatamodel */,
 			);
-			currentVersion = B8D55689242FE8B900B0F6FE /* Phrases v2.xcdatamodel */;
+			currentVersion = 6B1086712463102F00E729A8 /* Phrases v3.xcdatamodel */;
 			path = Phrases.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -237,7 +237,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             
             for identifier in presetPhrase.categoryIds {
                 if let category = Category.fetchObject(in: context, matching: identifier) {
-                    phrase.addToCategories(category)
+                    phrase.category = category
                     category.addToPhrases(phrase)
                 }
             }
@@ -252,7 +252,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let phraseResults = try context.fetch(request)
 
         for phrase in phraseResults {
-            phrase.addToCategories(mySayingsCategory)
+            phrase.category = mySayingsCategory
             mySayingsCategory.addToPhrases(phrase)
         }
     }

--- a/Vocable/CoreData/Phrases.xcdatamodeld/.xccurrentversion
+++ b/Vocable/CoreData/Phrases.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Phrases v2.xcdatamodel</string>
+	<string>Phrases v3.xcdatamodel</string>
 </dict>
 </plist>

--- a/Vocable/CoreData/Phrases.xcdatamodeld/Phrases v3.xcdatamodel/contents
+++ b/Vocable/CoreData/Phrases.xcdatamodeld/Phrases v3.xcdatamodel/contents
@@ -8,7 +8,7 @@
         <attribute name="languageCode" optional="YES" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="ordinal" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
-        <relationship name="phrases" toMany="YES" deletionRule="Nullify" destinationEntity="Phrase" inverseName="categories" inverseEntity="Phrase"/>
+        <relationship name="phrases" toMany="YES" deletionRule="Cascade" destinationEntity="Phrase" inverseName="category" inverseEntity="Phrase"/>
     </entity>
     <entity name="Phrase" representedClassName="Phrase" syncable="YES" codeGenerationType="class">
         <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -17,7 +17,7 @@
         <attribute name="languageCode" optional="YES" attributeType="String"/>
         <attribute name="lastSpokenDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="utterance" optional="YES" attributeType="String"/>
-        <relationship name="categories" toMany="YES" minCount="1" deletionRule="Nullify" destinationEntity="Category" inverseName="phrases" inverseEntity="Category" elementID="categoryRelationship"/>
+        <relationship name="category" maxCount="1" deletionRule="Nullify" destinationEntity="Category" inverseName="phrases" inverseEntity="Category" elementID="categoryRelationship"/>
     </entity>
     <elements>
         <element name="Category" positionX="-63" positionY="-18" width="128" height="163"/>

--- a/Vocable/Features/Presets/Models/PhraseViewModel.swift
+++ b/Vocable/Features/Presets/Models/PhraseViewModel.swift
@@ -16,14 +16,14 @@ struct PhraseViewModel: Hashable {
         return _languageCode ?? AppConfig.activePreferredLanguageCode
     }
     let creationDate: Date
-    let categories: [CategoryViewModel]
+    let category: CategoryViewModel?
     
     init(unpersistedPhrase phrase: String) {
         self.utterance = phrase
         self._languageCode = nil
         self.identifier = UUID().uuidString
         self.creationDate = Date()
-        self.categories = []
+        self.category = nil
     }
     
     init?(_ phrase: Phrase?) {
@@ -32,14 +32,14 @@ struct PhraseViewModel: Hashable {
             let identifier = phrase.identifier,
             let utterance = phrase.utterance,
             let creationDate = phrase.creationDate,
-            let categories = phrase.categories else {
+            let category = phrase.category else {
                 return nil
         }
         self._languageCode = phrase.languageCode
         self.identifier = identifier
         self.utterance = utterance
         self.creationDate = creationDate
-        self.categories = categories.compactMap { CategoryViewModel($0 as? Category) }
+        self.category = CategoryViewModel(category)
     }
 
     private var _languageCode: String?

--- a/Vocable/Features/Presets/Pagination/PresetCollectionViewController.swift
+++ b/Vocable/Features/Presets/Pagination/PresetCollectionViewController.swift
@@ -47,8 +47,8 @@ class PresetCollectionViewController: CarouselGridCollectionViewController, NSFe
     private func updateFetchedResultsController(with selectedCategoryID: NSManagedObjectID? = nil) {
         let request: NSFetchRequest<Phrase> = Phrase.fetchRequest()
         if let selectedCategoryID = selectedCategoryID {
-            let category = NSPersistentContainer.shared.viewContext.object(with: selectedCategoryID)
-            request.predicate = NSComparisonPredicate(\Phrase.categories, .contains, category)
+            let category = NSPersistentContainer.shared.viewContext.object(with: selectedCategoryID) as! Category
+            request.predicate = NSComparisonPredicate(\Phrase.category, .equalTo, category)
         }
         request.sortDescriptors = [NSSortDescriptor(keyPath: \Phrase.creationDate, ascending: false)]
         

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -28,7 +28,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
 
     private lazy var fetchRequest: NSFetchRequest<Phrase> = {
         let request: NSFetchRequest<Phrase> = Phrase.fetchRequest()
-        request.predicate = NSComparisonPredicate(\Phrase.categories, .contains, self.category)
+        request.predicate = NSComparisonPredicate(\Phrase.category, .equalTo, self.category)
         request.sortDescriptors = [NSSortDescriptor(keyPath: \Phrase.creationDate, ascending: false)]
         return request
     }()

--- a/Vocable/Features/Root/RootEditTextViewController.swift
+++ b/Vocable/Features/Root/RootEditTextViewController.swift
@@ -53,7 +53,7 @@ class RootEditTextViewController: EditTextViewController {
         let userFavorites = Category.userFavoritesCategory()
         let fetchRequest: NSFetchRequest<Phrase> = Phrase.fetchRequest()
         fetchRequest.predicate = {
-            let categoryPredicate = NSComparisonPredicate(\Phrase.categories, .contains, userFavorites)
+            let categoryPredicate = NSComparisonPredicate(\Phrase.category, .equalTo, userFavorites)
             let userGenerated = NSComparisonPredicate(\Phrase.isUserGenerated, .equalTo, true)
             let textMatches = NSComparisonPredicate(\Phrase.utterance, .equalTo, trimmed)
             let subpredicates = [categoryPredicate, userGenerated, textMatches]

--- a/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
+++ b/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
@@ -32,7 +32,7 @@ final class EditPhrasesViewController: PagingCarouselViewController, NSFetchedRe
 
     private lazy var fetchRequest: NSFetchRequest<Phrase> = {
         let request: NSFetchRequest<Phrase> = Phrase.fetchRequest()
-        request.predicate = NSComparisonPredicate(\Phrase.categories, .contains, category)
+        request.predicate = NSComparisonPredicate(\Phrase.category, .equalTo, category)
         request.sortDescriptors = [NSSortDescriptor(keyPath: \Phrase.creationDate, ascending: false)]
         return request
     }()

--- a/Vocable/Utilities/Phrase+Helpers.swift
+++ b/Vocable/Utilities/Phrase+Helpers.swift
@@ -24,7 +24,7 @@ extension Phrase {
         phrase.lastSpokenDate = Date()
         phrase.utterance = text
         phrase.languageCode = AppConfig.activePreferredLanguageCode
-        phrase.addToCategories(category)
+        phrase.category = category
         category.addToPhrases(phrase)
         return phrase
     }


### PR DESCRIPTION
# Description of Work
* Fixes an issue where deleting a custom category would crash if the deletion results in orphaned phrases
  - Makes the relationship one-to-one
  - Ensures category deletions cascade down to their phrases
