### PR TITLE
Gazeable Alert Enhancements

### DIFF
--- a/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
+++ b/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
@@ -294,6 +294,8 @@ final class GazeableAlertViewController: UIViewController, UIViewControllerTrans
             button.setTitle(action.title, for: .normal)
             button.cornerRadius = alertView.cornerRadius
             button.style = action.style
+            button.shouldShrinkWhenTouched = false
+            button.backgroundColor = .clear
             button.addTarget(action, action: #selector(GazeableAlertAction.performActions), for: .primaryActionTriggered)
 
             if actionButtonStackView.arrangedSubviews.isEmpty {

--- a/Vocable/Common/Views/GazeableButton.swift
+++ b/Vocable/Common/Views/GazeableButton.swift
@@ -21,6 +21,12 @@ class GazeableButton: UIButton {
     private var cachedTitleColors = [UIControl.State: UIColor]()
     private let defaultIBStates = [UIControl.State.normal, .highlighted, .selected, .disabled]
 
+    var shouldShrinkWhenTouched = true {
+        didSet {
+            updateSelectionAppearance()
+        }
+    }
+
     private var cachedHighlightColor: UIColor?
     private(set) var isTrackingTouches: Bool = false {
         didSet {
@@ -190,7 +196,7 @@ class GazeableButton: UIButton {
     private func updateSelectionAppearance() {
 
         func actions() {
-            let scale: CGFloat = (isHighlighted && isTrackingTouches) ? 0.95 : 1.0
+            let scale: CGFloat = (isHighlighted && isTrackingTouches && shouldShrinkWhenTouched) ? 0.95 : 1.0
             transform = .init(scaleX: scale, y: scale)
         }
 

--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -230,7 +230,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
             collectionView.deselectItem(at: indexPath, animated: true)
         }
 
-        let item = dataSource.snapshot().itemIdentifiers[indexPath.item]
+        let item = dataSource.itemIdentifier(for: indexPath)
         switch item {
         case .privacyPolicy:
             presentLeavingHeadTrackableDomainAlert(withConfirmation: presentPrivacyAlert)


### PR DESCRIPTION
# Description of Work
* Prevents alert buttons from shrinking when touched
* Prevents alert buttons from rendering a background color in their corners (must be transparent)
* Adds a new alert transition animation to more closely match the system animation, per last design review
* Fixes an issue where the external links were not performing the correct action when selected
 
Transition looks like this:
![alert](https://user-images.githubusercontent.com/143916/81331306-634d4780-906f-11ea-92ca-75551676a31f.gif)

