### PR TITLE
Localization auto-export

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,10 +62,9 @@ jobs:
             git config credential.helper 'cache --timeout=120'
             git config user.email "localization_bot@willowtreeapps.com"
             git config user.name "Localization Bot"
-            if ! git diff-index --quiet HEAD --; then
-                git commit -m "Updatedapp localizations for Crowdin Export [ci skip]"
-                git push -q git@github.com:willowtreeapps/vocable-ios.git ${CIRCLE_BRANCH}
-            fi
+            git add -A
+            git diff-index --quiet HEAD || git commit -m "Updated app localizations for Crowdin Export [ci skip]"
+            git push -q git@github.com:willowtreeapps/vocable-ios.git ${CIRCLE_BRANCH}
             
   update-localizations-test-deploy:
     macos: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           command: bundle exec fastlane $FASTLANE_LANE
       - store_artifacts:
           path: output
-  export-locations-for-crowdin:
+  export-localizations-for-crowdin:
     macos: 
       xcode: 11.4.0
     steps:
@@ -62,10 +62,8 @@ jobs:
             git config credential.helper 'cache --timeout=120'
             git config user.email "localization_bot@willowtreeapps.com"
             git config user.name "Localization Bot"
-            if git diff-index --quiet HEAD --; then
-                # No changes
-            else
-                git commit -m "Updated localizations for Crowdin Export [ci skip]"
+            if ! git diff-index --quiet HEAD --; then
+                git commit -m "Updatedapp localizations for Crowdin Export [ci skip]"
                 git push -q git@github.com:willowtreeapps/vocable-ios.git ${CIRCLE_BRANCH}
             fi
             
@@ -95,16 +93,19 @@ jobs:
 workflows:
   build-test-adhoc-testflight:
     jobs:
-      - export-locations-for-crowdin
       - build-and-test:
           filters:
             branches:
               ignore: /crowdin.*/ 
+      - export-localizations-for-crowdin:
+          requires:
+            - build-and-test
       - buildanddeploytotestflight:
           filters:
             branches:
               only: develop
           requires:
+            - export-localizations-for-crowdin
             - build-and-test
   localize-build-test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,29 @@ jobs:
           command: bundle exec fastlane $FASTLANE_LANE
       - store_artifacts:
           path: output
-          
+  export-locations-for-crowdin:
+    macos: 
+      xcode: 11.4.0
+    steps:
+      - checkout
+      - run: bundle install
+      - run:
+          name: Fastlane
+          command: bundle exec fastlane xliffexport
+      - add_ssh_keys
+      - run:
+          name: "Diff xliff and push if needed"
+          command: |
+            git config credential.helper 'cache --timeout=120'
+            git config user.email "localization_bot@willowtreeapps.com"
+            git config user.name "Localization Bot"
+            if git diff-index --quiet HEAD --; then
+                # No changes
+            else
+                git commit -m "Updated localizations for Crowdin Export [ci skip]"
+                git push -q git@github.com:willowtreeapps/vocable-ios.git ${CIRCLE_BRANCH}
+            fi
+            
   update-localizations-test-deploy:
     macos: 
       xcode: 11.4.0
@@ -67,12 +89,13 @@ jobs:
             git config user.email "localization_bot@willowtreeapps.com"
             git config user.name "Localization Bot"
             git add -A
-            git commit --allow-empty -m "Updated localizations [ci skip]"
+            git commit -m "Updated localizations [ci skip]"
             git push -q git@github.com:willowtreeapps/vocable-ios.git ${CIRCLE_BRANCH}
     
 workflows:
   build-test-adhoc-testflight:
     jobs:
+      - export-locations-for-crowdin
       - build-and-test:
           filters:
             branches:

--- a/CrowdinExport/en.xliff
+++ b/CrowdinExport/en.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Vocable/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="11.3.1" build-num="11C504"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="11.4" build-num="11E146"/>
     </header>
     <body>
       <trans-unit id="CFBundleDisplayName" xml:space="preserve">
@@ -24,13 +24,13 @@
   </file>
   <file original="Vocable/Supporting Files/en.lproj/Localizable.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="11.3.1" build-num="11C504"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="11.4" build-num="11E146"/>
     </header>
     <body>
-      <trans-unit id="MISSING_LOCALIZATION_Add Phrases" xml:space="preserve">
-        <source>Add Phrases</source>
-        <target>Add Phrases</target>
-        <note>Add Phrases</note>
+      <trans-unit id="Edit Phrases" xml:space="preserve">
+        <source>Edit Phrases</source>
+        <target>Edit Phrases</target>
+        <note>Edit Phrases</note>
       </trans-unit>
       <trans-unit id="categories_list_editor.header.title" xml:space="preserve">
         <source>Categories</source>
@@ -55,17 +55,17 @@
       <trans-unit id="category_editor.alert.delete_category_confirmation.button.cancel.title" xml:space="preserve">
         <source>Cancel</source>
         <target>Cancel</target>
-        <note>Cancel alert action title</note>
+        <note>Delete category alert cancel button title</note>
       </trans-unit>
       <trans-unit id="category_editor.alert.delete_category_confirmation.button.remove.title" xml:space="preserve">
         <source>Remove</source>
         <target>Remove</target>
-        <note>Remove category alert action title</note>
+        <note>Delete category alert action button title</note>
       </trans-unit>
       <trans-unit id="category_editor.alert.delete_category_confirmation.title" xml:space="preserve">
         <source>Deleted categories cannot be recovered.</source>
         <target>Deleted categories cannot be recovered.</target>
-        <note>Remove category alert title</note>
+        <note>Delete category confirmation alert title</note>
       </trans-unit>
       <trans-unit id="category_editor.alert.delete_phrase_confirmation.button.cancel.title" xml:space="preserve">
         <source>Cancel</source>
@@ -156,7 +156,9 @@
       <trans-unit id="phrase_editor.toast.successfully_saved_to_favorites.title_format" xml:space="preserve">
         <source>Saved to %@</source>
         <target>Saved to %@</target>
-        <note>Saved to user favorites category toast title</note>
+        <note>new entry saved to user favorites category
+   Saved to user favorites category
+   Saved to user favorites category toast title</note>
       </trans-unit>
       <trans-unit id="preset.category.numberpad.phrase.no.title" xml:space="preserve">
         <source>No</source>
@@ -262,7 +264,7 @@
   </file>
   <file original="Vocable/Supporting Files/en.lproj/Presets.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="11.3.1" build-num="11C504"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="11.4" build-num="11E146"/>
     </header>
     <body>
       <trans-unit id="preset_0B491C3E-1A7F-4A94-A523-6DE329BF9E72" xml:space="preserve">

--- a/CrowdinExport/en.xliff
+++ b/CrowdinExport/en.xliff
@@ -103,11 +103,6 @@
         <note>Saved to Categories
    User edited name of the category and saved it successfully</note>
       </trans-unit>
-      <trans-unit id="com.vocable.localization_debugging" xml:space="preserve">
-        <source>com.vocable.localization_debugging</source>
-        <target>com.vocable.localization_debugging</target>
-        <note>Ignore this</note>
-      </trans-unit>
       <trans-unit id="debug.assertion.presets_file_not_found" xml:space="preserve">
         <source>No presets found</source>
         <target>No presets found</target>

--- a/CrowdinExport/en.xliff
+++ b/CrowdinExport/en.xliff
@@ -103,6 +103,11 @@
         <note>Saved to Categories
    User edited name of the category and saved it successfully</note>
       </trans-unit>
+      <trans-unit id="com.vocable.localization_debugging" xml:space="preserve">
+        <source>com.vocable.localization_debugging</source>
+        <target>com.vocable.localization_debugging</target>
+        <note>Ignore this</note>
+      </trans-unit>
       <trans-unit id="debug.assertion.presets_file_not_found" xml:space="preserve">
         <source>No presets found</source>
         <target>No presets found</target>

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -36,6 +36,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         addObservers()
 
+        let _ = NSLocalizedString("com.vocable.localization_debugging", comment: "Ignore this")
+
         // Warm up the speech engine to prevent lag on first invocation
         AVSpeechSynthesizer.shared.speak("", language: "en")
 

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -36,8 +36,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         addObservers()
 
-        let _ = NSLocalizedString("com.vocable.localization_debugging", comment: "Ignore this")
-
         // Warm up the speech engine to prevent lag on first invocation
         AVSpeechSynthesizer.shared.speak("", language: "en")
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,4 +73,12 @@ platform :ios do
     end
   end
   
+  desc "Export current XLIFF file from project"
+  lane :xliffexport do
+    sh "rm -rf ./../CrowdinExport/*"
+    sh "xcodebuild -exportLocalizations -localizationPath ./../CrowdinExport/ -project ./../Vocable.xcodeproj"
+    sh "mv './../CrowdinExport/en.xcloc/Localized Contents/en.xliff' './../CrowdinExport/en.xliff'"
+    sh "rm -rf ./../CrowdinExport/*.xcloc"
+  end
+  
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -46,6 +46,11 @@ Add devices via the command line to the device portal and regenerate the develop
 fastlane ios xliffimport
 ```
 Integrate latest XLIFF files with project
+### ios xliffexport
+```
+fastlane ios xliffexport
+```
+Export current XLIFF file from project
 
 ----
 


### PR DESCRIPTION
After running the normal test suite, this PR makes it so that localized strings are automatically extracted into the `CrowdinExport/en.xliff` file so Crowdin can pick it up next time it runs its periodic sync. If there is no diff between the xliff files, no commits are appended to the PR.