### PR TITLE
Touch and gaze events are now passed through the switch

### DIFF
--- a/Vocable/Features/Settings/Edit Categories/EditCategoryToggleCollectionViewCell.xib
+++ b/Vocable/Features/Settings/Edit Categories/EditCategoryToggleCollectionViewCell.xib
@@ -28,6 +28,9 @@
                     </label>
                     <switch userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZoC-cN-J0k">
                         <rect key="frame" x="458" y="34" width="51" height="31"/>
+                        <accessibility key="accessibilityConfiguration">
+                            <accessibilityTraits key="traits" button="YES" notEnabled="YES"/>
+                        </accessibility>
                     </switch>
                 </subviews>
                 <constraints>

--- a/Vocable/Features/Settings/SelectionMode/Views/SettingsToggleCollectionViewCell.xib
+++ b/Vocable/Features/Settings/SelectionMode/Views/SettingsToggleCollectionViewCell.xib
@@ -26,8 +26,11 @@
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                         </variation>
                     </label>
-                    <switch contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rux-wr-INz">
+                    <switch userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rux-wr-INz">
                         <rect key="frame" x="454" y="34" width="51" height="31"/>
+                        <accessibility key="accessibilityConfiguration">
+                            <accessibilityTraits key="traits" button="YES" notEnabled="YES"/>
+                        </accessibility>
                     </switch>
                 </subviews>
                 <constraints>


### PR DESCRIPTION
Closes Github issue 339


# Description of Work
Touch and gazeable events are now passed through the switch UI component. 

## Notes to Test (Optional)
This should be fixed in Selection Mode and Category Details.
