### PR TITLE
CircleCI: Skip committing if no changes exist to resolve git exit code 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
             git config user.email "localization_bot@willowtreeapps.com"
             git config user.name "Localization Bot"
             git add -A
-            git commit -m "Updated localizations [ci skip]"
+            git diff-index --quiet HEAD || git commit -m "Updated localizations [ci skip]"
             git push -q git@github.com:willowtreeapps/vocable-ios.git ${CIRCLE_BRANCH}
     
 workflows:


### PR DESCRIPTION
We received an incorrect failure status after merging into develop. No commit should be created if there are no changes, which will prevent the error from occurring. This was already present in the other commit script but I missed it in the other.