### PR TITLE
Rectify unlocalized selection mode/sensitivity strings

### DIFF
--- a/CrowdinExport/en.xliff
+++ b/CrowdinExport/en.xliff
@@ -170,6 +170,11 @@
         <target>Yes</target>
         <note>'Yes' num pad response</note>
       </trans-unit>
+      <trans-unit id="selection_mode.header.title" xml:space="preserve">
+        <source>Selection Mode</source>
+        <target>Selection Mode</target>
+        <note>Selection mode screen header title</note>
+      </trans-unit>
       <trans-unit id="settings.alert.no_email_configured.button.dismiss.title" xml:space="preserve">
         <source>OK</source>
         <target>OK</target>
@@ -259,6 +264,36 @@
         <source>Going back before saving will clear any edits made.</source>
         <target>Going back before saving will clear any edits made.</target>
         <note>Exit edit sayings alert title</note>
+      </trans-unit>
+      <trans-unit id="timing_and_sensitivity.button.high.title" xml:space="preserve">
+        <source>High</source>
+        <target>High</target>
+        <note>High cursor sensitivity option button</note>
+      </trans-unit>
+      <trans-unit id="timing_and_sensitivity.button.low.title" xml:space="preserve">
+        <source>Low</source>
+        <target>Low</target>
+        <note>Low cursor sensitivity option button</note>
+      </trans-unit>
+      <trans-unit id="timing_and_sensitivity.button.medium.title" xml:space="preserve">
+        <source>Medium</source>
+        <target>Medium</target>
+        <note>Medium cursor sensitivity option button</note>
+      </trans-unit>
+      <trans-unit id="timing_and_sensitivity.cell.cursor_sensitivity.title" xml:space="preserve">
+        <source>Cursor Sensitivity</source>
+        <target>Cursor Sensitivity</target>
+        <note>Cursor sensitivity configuration option name</note>
+      </trans-unit>
+      <trans-unit id="timing_and_sensitivity.cell.dwell_duration.title" xml:space="preserve">
+        <source>Hover Time</source>
+        <target>Hover Time</target>
+        <note>Dwell duration configuration option name</note>
+      </trans-unit>
+      <trans-unit id="timing_and_sensitivity.header.title" xml:space="preserve">
+        <source>Timing and Sensitivity</source>
+        <target>Timing and Sensitivity</target>
+        <note>Timing and sensitivity header title</note>
       </trans-unit>
     </body>
   </file>

--- a/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
+++ b/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
@@ -27,7 +27,7 @@ final class SelectionModeViewController: VocableCollectionViewController {
     }
 
     private func setupNavigationBar() {
-        navigationBar.title = "Selection Mode"
+        navigationBar.title = NSLocalizedString("selection_mode.header.title", comment: "Selection mode screen header title")
     }
 
     // MARK: UICollectionViewDataSource

--- a/Vocable/Features/Settings/TimingSensitivity/TimingSensitivityViewController.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/TimingSensitivityViewController.swift
@@ -31,7 +31,7 @@ final class TimingSensitivityViewController: VocableCollectionViewController {
     }
 
     private func setupNavigationBar() {
-        navigationBar.title = "Timing and Sensitivity"
+        navigationBar.title = NSLocalizedString("timing_and_sensitivity.header.title", comment: "Timing and sensitivity header title")
     }
 
     private func setupCollectionView() {

--- a/Vocable/Features/Settings/TimingSensitivity/Views/DwellTimeCollectionViewCell.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/Views/DwellTimeCollectionViewCell.swift
@@ -10,7 +10,8 @@ import UIKit
 import Combine
 
 final class DwellTimeCollectionViewCell: UICollectionViewCell {
-    
+
+    @IBOutlet private var titleLabel: UILabel!
     @IBOutlet var decreaseTimeButton: GazeableButton!
     @IBOutlet var timeLabel: UILabel!
     @IBOutlet var increaseTimeButton: GazeableButton!
@@ -67,6 +68,7 @@ final class DwellTimeCollectionViewCell: UICollectionViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        titleLabel.text = NSLocalizedString("timing_and_sensitivity.cell.dwell_duration.title", comment: "Dwell duration configuration option name")
         AppConfig.$selectionHoldDuration.sink(receiveValue: { duration in
             self.timeLabel.text = DwellTimeCollectionViewCell.formattedString(forDuration: duration)
         }).store(in: &disposables)

--- a/Vocable/Features/Settings/TimingSensitivity/Views/DwellTimeCollectionViewCell.xib
+++ b/Vocable/Features/Settings/TimingSensitivity/Views/DwellTimeCollectionViewCell.xib
@@ -94,6 +94,7 @@
                 <outlet property="decreaseTimeButton" destination="NYz-0h-pvW" id="b1m-ks-jcb"/>
                 <outlet property="increaseTimeButton" destination="q0m-iz-XHs" id="5eG-Hh-eRr"/>
                 <outlet property="timeLabel" destination="9Ym-ys-KLL" id="2cU-ix-BQl"/>
+                <outlet property="titleLabel" destination="OLA-YL-VeV" id="a8a-n2-7tD"/>
                 <outlet property="topSeparator" destination="aGT-tV-MsX" id="tVN-tq-sq3"/>
             </connections>
             <point key="canvasLocation" x="446.48437499999994" y="116.17862371888725"/>

--- a/Vocable/Features/Settings/TimingSensitivity/Views/SensitivityCollectionViewCell.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/Views/SensitivityCollectionViewCell.swift
@@ -13,6 +13,7 @@ final class SensitivityCollectionViewCell: UICollectionViewCell {
     
     private var disposables = Set<AnyCancellable>()
 
+    @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var lowSensitivityButton: GazeableSegmentedButton!
     @IBOutlet private weak var mediumSensitivityButton: GazeableSegmentedButton!
     @IBOutlet private weak var highSensitivityButton: GazeableSegmentedButton!
@@ -22,7 +23,23 @@ final class SensitivityCollectionViewCell: UICollectionViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        
+
+        titleLabel.text = NSLocalizedString("timing_and_sensitivity.cell.cursor_sensitivity.title",
+                                            comment: "Cursor sensitivity configuration option name")
+
+        let lowTitle = NSLocalizedString("timing_and_sensitivity.button.low.title",
+                                         comment: "Low cursor sensitivity option button")
+
+        let mediumTitle = NSLocalizedString("timing_and_sensitivity.button.medium.title",
+                                            comment: "Medium cursor sensitivity option button")
+
+        let highTitle = NSLocalizedString("timing_and_sensitivity.button.high.title",
+                                          comment: "High cursor sensitivity option button")
+
+        lowSensitivityButton.setTitle(lowTitle, for: .normal)
+        mediumSensitivityButton.setTitle(mediumTitle, for: .normal)
+        highSensitivityButton.setTitle(highTitle, for: .normal)
+
         AppConfig.$cursorSensitivity.sink { (sensitivity) in
             self.lowSensitivityButton.isSelected = false
             self.mediumSensitivityButton.isSelected = false

--- a/Vocable/Features/Settings/TimingSensitivity/Views/SensitivityCollectionViewCell.xib
+++ b/Vocable/Features/Settings/TimingSensitivity/Views/SensitivityCollectionViewCell.xib
@@ -125,6 +125,7 @@
                 <outlet property="highSensitivityButton" destination="J4K-JS-vwn" id="Gf5-3Y-IEW"/>
                 <outlet property="lowSensitivityButton" destination="Ph1-lE-gZj" id="ffD-He-jQH"/>
                 <outlet property="mediumSensitivityButton" destination="PDi-eA-7a0" id="uCt-S2-XmX"/>
+                <outlet property="titleLabel" destination="PJa-d1-ik7" id="548-WN-XxF"/>
                 <outlet property="topSeparator" destination="e0s-dp-HQO" id="oO4-tu-T1l"/>
             </connections>
             <point key="canvasLocation" x="494.20289855072468" y="139.28571428571428"/>

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -121,3 +121,17 @@
 "phrase_editor.alert.cancel_editing_confirmation.button.continue_editing.title" = "Continue Editing";
 
 "categories_list_editor.header.title" = "Categories";
+
+"timing_and_sensitivity.header.title" = "Timing and Sensitivity";
+
+"timing_and_sensitivity.cell.dwell_duration.title" = "Hover Time";
+
+"timing_and_sensitivity.cell.cursor_sensitivity.title" = "Cursor Sensitivity";
+
+"timing_and_sensitivity.button.low.title" = "Low";
+
+"timing_and_sensitivity.button.medium.title" = "Medium";
+
+"timing_and_sensitivity.button.high.title" = "High";
+
+"selection_mode.header.title" = "Selection Mode";


### PR DESCRIPTION
closes #369 

# Description

Many strings on those screens were unlocalized and this PR should get them up on Crowdin for translation once merged into develop. English should display as it did previously.
