### PR TITLE
Update Crowdin import to pull develop before integrating translations

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,6 +68,7 @@ platform :ios do
 
   desc "Integrate latest XLIFF files with project"
   lane :xliffimport do
+    sh "git pull --no-commit -q origin develop"
     Dir.glob('./../CrowdinImports/*.xliff') do |xliff|
       sh "xcodebuild -importLocalizations -localizationPath #{xliff} -project ./../Vocable.xcodeproj"
     end


### PR DESCRIPTION
Attempts to pull develop into the branch manually to avoid the situation where Crowdin makes a PR based on an older commit than develop's head. This will ensure that the latest localized keys are present so xcodebuild can integrate the translations.