### PR TITLE
Vocable 361 -  Updates to Categories Screen

### DIFF
--- a/Vocable/Features/Settings/EditCategories/EditCategoriesCompactCollectionViewCell.xib
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesCompactCollectionViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -42,6 +42,16 @@
                         <color key="tintColor" name="DefaultFontColor"/>
                         <state key="normal" image="chevron.up" catalog="system"/>
                     </button>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qmg-4b-lFp" userLabel="HideCategoryButton" customClass="GazeableButton" customModule="Vocable" customModuleProvider="target">
+                        <rect key="frame" x="204" y="132" width="84" height="54"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="84" id="tmB-W4-2CW"/>
+                            <constraint firstAttribute="height" constant="54" id="ygG-I8-Hik"/>
+                        </constraints>
+                        <state key="normal" image="eye.fill" catalog="system">
+                            <color key="titleColor" name="DefaultFontColor"/>
+                        </state>
+                    </button>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfR-1l-Qp7" userLabel="ShowCategoryDetailButton" customClass="GazeableButton" customModule="Vocable" customModuleProvider="target">
                         <rect key="frame" x="636" y="71" width="48" height="54"/>
                         <constraints>
@@ -66,6 +76,8 @@
                     <constraint firstAttribute="trailingMargin" secondItem="PfR-1l-Qp7" secondAttribute="trailing" id="Tbi-AC-x8g"/>
                     <constraint firstItem="hWY-nm-Hv6" firstAttribute="top" secondItem="yIe-C4-EHn" secondAttribute="bottom" constant="8" id="USs-jy-BFS"/>
                     <constraint firstItem="PfR-1l-Qp7" firstAttribute="centerY" secondItem="PX7-fo-08L" secondAttribute="centerY" id="lXg-ij-cFv"/>
+                    <constraint firstItem="qmg-4b-lFp" firstAttribute="leading" secondItem="Ieb-WK-NlS" secondAttribute="trailing" constant="8" id="o1e-gT-ej6"/>
+                    <constraint firstItem="hWY-nm-Hv6" firstAttribute="top" secondItem="qmg-4b-lFp" secondAttribute="bottom" constant="8" id="ozM-yr-PkO"/>
                     <constraint firstAttribute="trailingMargin" secondItem="hWY-nm-Hv6" secondAttribute="trailing" id="t13-Fa-Tul"/>
                     <constraint firstAttribute="bottomMargin" secondItem="hWY-nm-Hv6" secondAttribute="bottom" id="v6b-vv-Ztm"/>
                     <constraint firstItem="Ieb-WK-NlS" firstAttribute="leading" secondItem="yIe-C4-EHn" secondAttribute="trailing" constant="8" id="xeB-Dh-o8W"/>
@@ -77,6 +89,7 @@
             <connections>
                 <outlet property="bottomSeparator" destination="hWY-nm-Hv6" id="p5S-gZ-TPN"/>
                 <outlet property="categoryNameLabel" destination="3t9-YV-add" id="ENB-CO-MgT"/>
+                <outlet property="hideCategoryButton" destination="qmg-4b-lFp" id="4Zt-Qg-eVY"/>
                 <outlet property="moveDownButton" destination="Ieb-WK-NlS" id="L81-qa-uYF"/>
                 <outlet property="moveUpButton" destination="yIe-C4-EHn" id="zhH-op-CcN"/>
                 <outlet property="showCategoryDetailButton" destination="PfR-1l-Qp7" id="csS-I7-Imd"/>
@@ -88,6 +101,7 @@
         <image name="chevron.down" catalog="system" width="128" height="72"/>
         <image name="chevron.right" catalog="system" width="96" height="128"/>
         <image name="chevron.up" catalog="system" width="128" height="72"/>
+        <image name="eye.fill" catalog="system" width="128" height="78"/>
         <namedColor name="DefaultCellBackground">
             <color red="0.21799999475479126" green="0.19499999284744263" blue="0.62699997425079346" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesDefaultCollectionViewCell.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesDefaultCollectionViewCell.swift
@@ -12,11 +12,10 @@ final class EditCategoriesDefaultCollectionViewCell: UICollectionViewCell {
     
     @IBOutlet weak var moveDownButton: GazeableButton!
     @IBOutlet weak var moveUpButton: GazeableButton!
-    
-    @IBOutlet private weak var categoryNameLabel: UILabel!
-    
+    @IBOutlet weak var hideCategoryButton: GazeableButton!
     @IBOutlet weak var showCategoryDetailButton: GazeableButton!
-    
+
+    @IBOutlet private weak var categoryNameLabel: UILabel!
     @IBOutlet private weak var topSeparator: UIView!
     @IBOutlet private weak var bottomSeparator: UIView!
     
@@ -40,7 +39,7 @@ final class EditCategoriesDefaultCollectionViewCell: UICollectionViewCell {
         super.awakeFromNib()
 
         updateSeparatorMask()
-        for button in [moveUpButton, moveDownButton, showCategoryDetailButton].compactMap({$0}) {
+        for button in [moveUpButton, moveDownButton, hideCategoryButton, showCategoryDetailButton].compactMap({$0}) {
             button.backgroundColor = .collectionViewBackgroundColor
             button.setFillColor(.defaultCellBackgroundColor, for: .normal)
             button.setTitleColor(.defaultTextColor, for: .normal)

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesDefaultCollectionViewCell.xib
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesDefaultCollectionViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -54,8 +54,18 @@
                                     <color key="titleColor" name="DefaultFontColor"/>
                                 </state>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NvG-PJ-EHy" userLabel="HideCategoryButton" customClass="GazeableButton" customModule="Vocable" customModuleProvider="target">
+                                <rect key="frame" x="184" y="54" width="84" height="54"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="54" id="896-D0-r7y"/>
+                                    <constraint firstAttribute="width" constant="84" id="MpJ-vr-07N"/>
+                                </constraints>
+                                <state key="normal" image="eye.slash" catalog="system">
+                                    <color key="titleColor" name="DefaultFontColor"/>
+                                </state>
+                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1. General" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3t9-YV-add" userLabel="CategoryName">
-                                <rect key="frame" x="184" y="64.5" width="428" height="33.5"/>
+                                <rect key="frame" x="276" y="64.5" width="336" height="33.5"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
                                 <color key="textColor" name="DefaultFontColor"/>
                                 <nil key="highlightedColor"/>
@@ -91,6 +101,7 @@
             <connections>
                 <outlet property="bottomSeparator" destination="hWY-nm-Hv6" id="Sue-pL-2Uw"/>
                 <outlet property="categoryNameLabel" destination="3t9-YV-add" id="Ehe-LR-iFr"/>
+                <outlet property="hideCategoryButton" destination="NvG-PJ-EHy" id="fYj-hG-d25"/>
                 <outlet property="moveDownButton" destination="Ieb-WK-NlS" id="uok-e2-jWH"/>
                 <outlet property="moveUpButton" destination="yIe-C4-EHn" id="e1c-iy-MGb"/>
                 <outlet property="showCategoryDetailButton" destination="PfR-1l-Qp7" id="yjb-aR-8sS"/>
@@ -103,6 +114,7 @@
         <image name="chevron.down" catalog="system" width="128" height="72"/>
         <image name="chevron.right" catalog="system" width="96" height="128"/>
         <image name="chevron.up" catalog="system" width="128" height="72"/>
+        <image name="eye.slash" catalog="system" width="128" height="86"/>
         <namedColor name="DefaultCellBackground">
             <color red="0.21799999475479126" green="0.19499999284744263" blue="0.62699997425079346" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
@@ -29,6 +29,7 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
 
         cell.moveUpButton.addTarget(self, action: #selector(self.handleMoveCategoryUp(_:)), for: .primaryActionTriggered)
         cell.moveDownButton.addTarget(self, action: #selector(self.handleMoveCategoryDown(_:)), for: .primaryActionTriggered)
+        cell.hideCategoryButton.addTarget(self, action: #selector(self.handleHideToggle(_:)), for: .primaryActionTriggered)
         cell.showCategoryDetailButton.addTarget(self, action: #selector(self.handleShowEditCategoryDetail(_:)), for: .primaryActionTriggered)
 
         return cell
@@ -147,8 +148,10 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
         let hiddenTitleString = NSMutableAttributedString(string: "\(category.name ?? "")")
 
         if category.isHidden {
-            cell.setup(title: addHiddenIconIfNeeded(to: hiddenTitleString))
+            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.slash.fill")?.withTintColor(.white), for: .normal)
+            cell.setup(title: hiddenTitleString)
         } else {
+            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.fill")?.withTintColor(.white), for: .normal)
             cell.setup(title: visibleTitleString)
         }
 
@@ -191,6 +194,18 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
         let toCategory = fetchResultsController.object(at: toIndexPath)
 
         swapOrdinal(fromCategory: fromCategory, toCategory: toCategory)
+        saveContext()
+    }
+
+    @objc private func handleHideToggle(_ sender: UIButton) {
+        guard let _indexPath = collectionView.indexPath(containing: sender) else {
+            assertionFailure("Failed to obtain index path")
+            return
+        }
+
+        let indexPath = diffableDataSource.indexPath(fromMappedIndexPath: _indexPath)
+        let category = fetchResultsController.object(at: indexPath)
+        category.setValue(!category.isHidden, forKey: "isHidden")
         saveContext()
     }
 

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
@@ -133,7 +133,6 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
                 window.cancelActiveGazeTarget()
             }
         })
-
     }
 
     private static let rowIndexFormatter = NumberFormatter()
@@ -148,16 +147,17 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
         let hiddenTitleString = NSMutableAttributedString(string: "\(category.name ?? "")")
 
         if category.isHidden {
-            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.slash.fill")?.withTintColor(.white), for: .normal)
             cell.setup(title: hiddenTitleString)
+            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.slash.fill")?.withTintColor(.white), for: .normal)
+            cell.showCategoryDetailButton.isEnabled = false
         } else {
-            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.fill")?.withTintColor(.white), for: .normal)
             cell.setup(title: visibleTitleString)
+            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.fill")?.withTintColor(.white), for: .normal)
+            cell.showCategoryDetailButton.isEnabled = category.isUserGenerated || category.identifier == .userFavorites
         }
 
         cell.separatorMask = collectionView.layout.separatorMask(for: indexPath)
         cell.ordinalButtonMask = cellOrdinalButtonMask(for: indexPath)
-        cell.showCategoryDetailButton.isEnabled = (category.identifier != .userFavorites)
     }
 
     @objc private func handleMoveCategoryUp(_ sender: UIButton) {
@@ -235,15 +235,6 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
         } catch {
             assertionFailure("Failed to move category: \(error)")
         }
-    }
-
-    private func addHiddenIconIfNeeded(to titleString: NSMutableAttributedString) -> NSMutableAttributedString {
-        let imageAttachment = NSTextAttachment()
-        imageAttachment.image = UIImage(systemName: "eye.slash.fill")?.withTintColor(UIColor.white)
-        imageAttachment.bounds = CGRect(x: -2, y: 0, width: imageAttachment.image!.size.width, height: imageAttachment.image!.size.height)
-        titleString.insert(NSAttributedString(string: " "), at: 0)
-        titleString.insert(NSAttributedString(attachment: imageAttachment), at: 0)
-        return titleString
     }
 
     private func cellOrdinalButtonMask(for indexPath: IndexPath) -> CellOrdinalButtonMask {

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -25,4 +25,25 @@ class SettingsScreen {
         }
         
     }
+    
+    func toggleHideShowCategory(category: String, toggle: String){
+        var toggleLabel = ""
+        switch toggle {
+        case "Hide":
+            toggleLabel = "eye.slash.fill"
+        case "Show":
+            toggleLabel = "eye.fill"
+        default:
+            break
+        }
+        
+        
+        if XCUIApplication().collectionViews.cells.otherElements.containing(.staticText, identifier: category).element.exists {
+            XCUIApplication().collectionViews.cells.otherElements.containing(.staticText, identifier: category).buttons[toggleLabel].tap()
+    } else {
+            XCUIApplication().buttons["bottomPagination.right_chevron"].tap()
+            XCUIApplication().collectionViews.cells.otherElements.containing(.staticText, identifier: category).buttons[toggleLabel].tap()
+
+        }
+    }
 }

--- a/VocableUITests/Tests/MainScreenTests.swift
+++ b/VocableUITests/Tests/MainScreenTests.swift
@@ -39,15 +39,14 @@ class MainScreenTests: BaseTest {
     
     func testDisablingCategory() {
         let generalCategoryText = "1. General"
-        let hiddenGeneralCategoryText = " General"
+        let hiddenGeneralCategoryText = "General"
         
         mainScreen.settingsButton.tap()
         settingsScreen.categoriesButton.tap()
         
-        settingsScreen.openCategorySettings(category: generalCategoryText)
-        settingsScreen.showCategoryToggle.tap()
+        settingsScreen.toggleHideShowCategory(category: generalCategoryText, toggle: "Show")
 
-        settingsScreen.leaveCategoryDetailButton.tap()
+        //settingsScreen.leaveCategoryDetailButton.tap()
         settingsScreen.leaveCategoriesButton.tap()
         settingsScreen.exitSettings.tap()
         
@@ -58,8 +57,7 @@ class MainScreenTests: BaseTest {
         mainScreen.settingsButton.tap()
         settingsScreen.categoriesButton.tap()
         
-        settingsScreen.openCategorySettings(category: hiddenGeneralCategoryText)
-        settingsScreen.showCategoryToggle.tap()
+        settingsScreen.toggleHideShowCategory(category: hiddenGeneralCategoryText, toggle: "Hide")
     }
     
     private func verifyGivenPhrasesDisplay(setOfPhrases: [String]) {


### PR DESCRIPTION
https://github.com/willowtreeapps/vocable-ios/issues/361

From the Github issue:
- The title "Categories" should change to "Categories and Phrases" on the Settings main screen.
- The hide category toggle should be brought to the Category main screen beside the up and down arrows. When a category is toggled off, it should be moved to the end of the list and the ">" button and up and down arrows should be inaccessible, at 50% opacity.
- For default categories (non-custom categories), the ">" icon that accesses the detail screen should be inaccessible, at 50% opacity, as these cannot be edited.
