### PR TITLE
BugFix #394: Fixed the Show/Hide Category toggle per design.

### DIFF
--- a/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
@@ -148,11 +148,11 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
 
         if category.isHidden {
             cell.setup(title: hiddenTitleString)
-            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.slash.fill")?.withTintColor(.white), for: .normal)
+            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.fill")?.withTintColor(.white), for: .normal)
             cell.showCategoryDetailButton.isEnabled = false
         } else {
             cell.setup(title: visibleTitleString)
-            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.fill")?.withTintColor(.white), for: .normal)
+            cell.hideCategoryButton.setImage(UIImage(systemName: "eye.slash.fill")?.withTintColor(.white), for: .normal)
             cell.showCategoryDetailButton.isEnabled = category.isUserGenerated || category.identifier == .userFavorites
         }
 

--- a/VocableUITests/Tests/MainScreenTests.swift
+++ b/VocableUITests/Tests/MainScreenTests.swift
@@ -44,9 +44,8 @@ class MainScreenTests: BaseTest {
         mainScreen.settingsButton.tap()
         settingsScreen.categoriesButton.tap()
         
-        settingsScreen.toggleHideShowCategory(category: generalCategoryText, toggle: "Show")
+        settingsScreen.toggleHideShowCategory(category: generalCategoryText, toggle: "Hide")
 
-        //settingsScreen.leaveCategoryDetailButton.tap()
         settingsScreen.leaveCategoriesButton.tap()
         settingsScreen.exitSettings.tap()
         
@@ -57,7 +56,7 @@ class MainScreenTests: BaseTest {
         mainScreen.settingsButton.tap()
         settingsScreen.categoriesButton.tap()
         
-        settingsScreen.toggleHideShowCategory(category: hiddenGeneralCategoryText, toggle: "Hide")
+        settingsScreen.toggleHideShowCategory(category: hiddenGeneralCategoryText, toggle: "Show")
     }
     
     private func verifyGivenPhrasesDisplay(setOfPhrases: [String]) {


### PR DESCRIPTION
https://github.com/willowtreeapps/vocable-ios/issues/394

# Description of Work
Per Design below: 
<img width="153" alt="Screen Shot 2020-08-25 at 7 37 59 AM" src="https://user-images.githubusercontent.com/50410188/91169917-205ac280-e6a6-11ea-9046-d863cea164b7.png">

The eye with slash should be displayed with the category is shown.  The show toggle button should be displayed when the category is hidden.

See following screenshot for the fix:
![Screen Shot 2020-08-25 at 7 39 44 AM](https://user-images.githubusercontent.com/50410188/91170092-59933280-e6a6-11ea-9c8a-848abb800b23.png)

---
