### PR TITLE
Disable crashlytics for debug builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,14 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 12.0.0
+      xcode: 12.0.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
     steps:
       - checkout
+      - run: rm ~/.ssh/id_rsa || true
+      - run: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
       - run: bundle install
       - run:
           name: Fastlane
@@ -19,12 +21,14 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 12.0.0
+      xcode: 12.0.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
     steps:
       - checkout
+      - run: rm ~/.ssh/id_rsa || true
+      - run: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
       - run: bundle install
       - run:
           name: Fastlane
@@ -34,12 +38,14 @@ jobs:
 
   buildanddeploytotestflight:
     macos:
-      xcode: 12.0.0
+      xcode: 12.0.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: buildanddeploytotestflight
     steps:
       - checkout
+      - run: rm ~/.ssh/id_rsa || true
+      - run: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
       - run: bundle install
       - run:
           name: Fastlane
@@ -48,9 +54,11 @@ jobs:
           path: output
   export-localizations-for-crowdin:
     macos: 
-      xcode: 12.0.0
+      xcode: 12.0.1
     steps:
       - checkout
+      - run: rm ~/.ssh/id_rsa || true
+      - run: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
       - run: bundle install
       - run:
           name: Fastlane
@@ -68,9 +76,11 @@ jobs:
             
   update-localizations-test-deploy:
     macos: 
-      xcode: 12.0.0
+      xcode: 12.0.1
     steps:
       - checkout
+      - run: rm ~/.ssh/id_rsa || true
+      - run: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
       - run: bundle install
       - run:
           name: Fastlane

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @jrtb @Clstroud @pg8wood @jsmorgan42 @thomasshealy @stevefosterwta
+*       @jrtb @Clstroud @pg8wood @jsmorgan42 @thomasshealy @stevefosterwta @carolinelaw

--- a/CrowdinExport/en.xliff
+++ b/CrowdinExport/en.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Vocable/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.0" build-num="12A8189n"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.0.1" build-num="12A7300"/>
     </header>
     <body>
       <trans-unit id="CFBundleDisplayName" xml:space="preserve">
@@ -24,7 +24,7 @@
   </file>
   <file original="Vocable/Supporting Files/en.lproj/Localizable.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.0" build-num="12A8189n"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.0.1" build-num="12A7300"/>
     </header>
     <body>
       <trans-unit id="categories_list_editor.header.title" xml:space="preserve">
@@ -293,7 +293,7 @@
   </file>
   <file original="Vocable/Supporting Files/en.lproj/Presets.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.0" build-num="12A8189n"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="12.0.1" build-num="12A7300"/>
     </header>
     <body>
       <trans-unit id="preset_0B491C3E-1A7F-4A94-A523-6DE329BF9E72" xml:space="preserve">

--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -1572,8 +1572,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
-				branch = "6.32-spm-beta";
-				kind = branch;
+				kind = revision;
+				revision = 70b54ba972e5768fe84f69f700ae362c8fbf8e8b;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,19 +3,19 @@
     "pins": [
       {
         "package": "abseil",
-        "repositoryURL": "https://github.com/firebase/abseil-cpp.git",
+        "repositoryURL": "https://github.com/firebase/abseil-cpp-SwiftPM.git",
         "state": {
           "branch": null,
-          "revision": "d30bd7751ce343a05fca6413de0dec062163e5e9",
+          "revision": "05d8107f2971a37e6c77245b7c4c6b0a7e97bc99",
           "version": null
         }
       },
       {
         "package": "BoringSSL-GRPC",
-        "repositoryURL": "https://github.com/firebase/boringssl.git",
+        "repositoryURL": "https://github.com/firebase/boringssl-SwiftPM.git",
         "state": {
           "branch": null,
-          "revision": "897ffb6fbb5a5ea149216d664ce8b04d77e3df22",
+          "revision": "7bcafa2660bc58715c39637494550d1ed7cd7229",
           "version": null
         }
       },
@@ -23,17 +23,17 @@
         "package": "Firebase",
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
-          "branch": "6.32-spm-beta",
-          "revision": "f25eda58236c2408302bf0f981ac59e951264cea",
+          "branch": null,
+          "revision": "70b54ba972e5768fe84f69f700ae362c8fbf8e8b",
           "version": null
         }
       },
       {
         "package": "gRPC",
-        "repositoryURL": "https://github.com/firebase/grpc.git",
+        "repositoryURL": "https://github.com/firebase/grpc-SwiftPM.git",
         "state": {
           "branch": null,
-          "revision": "cae939a8823bbc39912aa2990cf95e29ace381b3",
+          "revision": "5bb2669317ae2183f4cb00c675423af1924f0b46",
           "version": null
         }
       },
@@ -51,7 +51,7 @@
         "repositoryURL": "https://github.com/firebase/leveldb.git",
         "state": {
           "branch": null,
-          "revision": "3f046978ecffd57ea6eb9a0897cc8a3b45b44df8",
+          "revision": "fa1f25f296a766e5a789c4dacd4798dea798b2c2",
           "version": null
         }
       },
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/nanopb/nanopb.git",
         "state": {
           "branch": null,
-          "revision": "3cfa21200eea012d8765239ad4c50d8a36c283f1",
+          "revision": "8119dfe5631f2616d11e50ead95448d12e816062",
           "version": null
         }
       },
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/google/promises.git",
         "state": {
           "branch": null,
-          "revision": "c5cdb6bdc2d3db8ef81e3bc71d55d31baf638837",
-          "version": "1.2.10"
+          "revision": "d8accebc8fa32f57196df191e733f946e955c549",
+          "version": "1.2.11"
         }
       }
     ]

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -44,7 +44,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             AppConfig.isHeadTrackingEnabled = false
         }
 
+        #if RELEASE
         FirebaseApp.configure()
+        #endif
     
         // Ensure that the persistent store has the current
         // default presets before presenting UI


### PR DESCRIPTION
# Description of Work
We only want crash reports for release builds so this disables them for the Development scheme in Xcode. Builds made with the AdHoc scheme or AppStore scheme will still report crashes

# Notes to Test (Optional)
Run a build using the Development scheme locally on simulator and view the console logs, you should not see any messages about Firebase/Analytics starting up. You can then run another build via the AdHoc/AppStore scheme and view the initialization of Firebase in the console logs 
