### PR TITLE
Voice prototype enhancements

### DIFF
--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -60,7 +60,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                name: NSLocale.currentLocaleDidChangeNotification,
                                                object: nil)
 
-        AppConfig.$isHeadTrackingEnabled.receive(on: DispatchQueue.main).sink { isEnabled in
+        AppConfig.$isHeadTrackingEnabled.receive(on: DispatchQueue.main).sink { [weak self] isEnabled in
+            guard let self = self else { return }
             if isEnabled {
                 self.installTrackingWindowsIfNeeded()
             } else {

--- a/Vocable/Common/EditTextViewController.swift
+++ b/Vocable/Common/EditTextViewController.swift
@@ -84,7 +84,8 @@ class EditTextViewController: VocableViewController, UICollectionViewDelegate {
         textView.accessibilityIdentifier = "keyboard.textView"
         textView.textAlignment = .natural
         
-        keyboardViewController.$attributedText.sink(receiveValue: { (attributedText) in
+        keyboardViewController.$attributedText.sink(receiveValue: { [weak self] (attributedText) in
+            guard let self = self else { return }
             self.textView.attributedText = attributedText
             let didTextChange = self.initialText != attributedText?.string
 

--- a/Vocable/Common/PagingCarouselViewController.swift
+++ b/Vocable/Common/PagingCarouselViewController.swift
@@ -57,7 +57,8 @@ import Combine
         paginationView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(paginationView)
 
-        collectionView.progressPublisher.sink(receiveValue: { (pagingProgress) in
+        collectionView.progressPublisher.sink(receiveValue: { [weak self] (pagingProgress) in
+            guard let self = self else { return }
             self.paginationView.setPaginationButtonsEnabled(pagingProgress.pageCount > 1)
             self.paginationView.textLabel.text = pagingProgress.localizedString
         }).store(in: &disposables)

--- a/Vocable/Features/Keyboard/KeyboardViewController.swift
+++ b/Vocable/Features/Keyboard/KeyboardViewController.swift
@@ -63,8 +63,8 @@ class KeyboardViewController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        $attributedText.receive(on: DispatchQueue.main).sink { (newAttributedText) in
-            guard let newAttributedText = newAttributedText,
+        $attributedText.receive(on: DispatchQueue.main).sink { [weak self] (newAttributedText) in
+            guard let self = self, let newAttributedText = newAttributedText,
                 newAttributedText.string != self._textTransaction.text else { return }
             self._textTransaction = TextTransaction(text: newAttributedText.string, intent: .lastCharacter)
         }.store(in: &disposables)

--- a/Vocable/Features/Root/RootViewController.swift
+++ b/Vocable/Features/Root/RootViewController.swift
@@ -89,7 +89,9 @@ import CoreData
         }
         utterancePublisher.receive(on: DispatchQueue.main)
             .filter({!($0?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)})
-            .assign(to: \UILabel.text, on: outputLabel)
+            .sink { [weak self] newValue in
+                self?.updateOutputLabelText(newValue, isDictated: false)
+            }
             .store(in: &disposables)
         setContentViewController(viewController, animated: true)
     }

--- a/Vocable/Features/Root/RootViewController.swift
+++ b/Vocable/Features/Root/RootViewController.swift
@@ -166,7 +166,7 @@ import CoreData
     private func updateOutputLabelText(_ text: String?, isDictated: Bool = false) {
         outputLabel.text = text ?? NSLocalizedString("main_screen.textfield_placeholder.default",
                                                      comment: "Select something below to speak Hint Text")
-        outputLabel.textColor = isDictated ? .cellBorderHighlightColor : .defaultTextColor
+        outputLabel.textColor = isDictated ? .cellSelectionColor : .defaultTextColor
     }
 
     // MARK: VoiceResponseViewControllerDelegate

--- a/Vocable/Features/Root/RootViewController.swift
+++ b/Vocable/Features/Root/RootViewController.swift
@@ -43,8 +43,9 @@ import CoreData
         categoryCarousel.$categoryObjectID
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { self.categoryDidChange($0) }
-            .store(in: &disposables)
+            .sink { [weak self] in
+                self?.categoryDidChange($0)
+            }.store(in: &disposables)
     }
 
     override func prepareForInterfaceBuilder() {

--- a/Vocable/Features/Root/VoiceResponseViewController.swift
+++ b/Vocable/Features/Root/VoiceResponseViewController.swift
@@ -113,8 +113,8 @@ final class VoiceResponseViewController: PagingCarouselViewController, SpeechRec
 
     func didGetFinalResult(_ speechRecognitionResult: SFSpeechRecognitionResult) {
 
-        let text = speechRecognitionResult.bestTranscription.formattedString
-        delegate?.didUpdateSpeechResponse(speechRecognitionResult.bestTranscription.formattedString)
+        let text = speechRecognitionResult.bestTranscription.formattedString.lowercased()
+        delegate?.didUpdateSpeechResponse(text)
 
         let model = try! VocableChoicesModel(configuration: .init())
         guard let prediction = try? model.prediction(text: text) else {

--- a/Vocable/Features/Settings/TimingSensitivity/Views/DwellTimeCollectionViewCell.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/Views/DwellTimeCollectionViewCell.swift
@@ -69,8 +69,8 @@ final class DwellTimeCollectionViewCell: UICollectionViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         titleLabel.text = NSLocalizedString("timing_and_sensitivity.cell.dwell_duration.title", comment: "Dwell duration configuration option name")
-        AppConfig.$selectionHoldDuration.sink(receiveValue: { duration in
-            self.timeLabel.text = DwellTimeCollectionViewCell.formattedString(forDuration: duration)
+        AppConfig.$selectionHoldDuration.sink(receiveValue: { [weak self] duration in
+            self?.timeLabel.text = DwellTimeCollectionViewCell.formattedString(forDuration: duration)
         }).store(in: &disposables)
     }
     

--- a/Vocable/Features/Settings/TimingSensitivity/Views/SensitivityCollectionViewCell.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/Views/SensitivityCollectionViewCell.swift
@@ -40,7 +40,8 @@ final class SensitivityCollectionViewCell: UICollectionViewCell {
         mediumSensitivityButton.setTitle(mediumTitle, for: .normal)
         highSensitivityButton.setTitle(highTitle, for: .normal)
 
-        AppConfig.$cursorSensitivity.sink { (sensitivity) in
+        AppConfig.$cursorSensitivity.sink { [weak self] (sensitivity) in
+            guard let self = self else { return }
             self.lowSensitivityButton.isSelected = false
             self.mediumSensitivityButton.isSelected = false
             self.highSensitivityButton.isSelected = false

--- a/Vocable/Features/Voice/AudioEngineController.swift
+++ b/Vocable/Features/Voice/AudioEngineController.swift
@@ -67,6 +67,9 @@ class AudioEngineController {
 
         node.removeTap(onBus: bus)
         node.installTap(onBus: bus, bufferSize: 1024, format: micInputFormat) { [weak self] buffer, timestamp in
+            guard !AVSpeechSynthesizer.shared.isSpeaking else {
+                return
+            }
             self?.conversionQueue.async {
                 let frameCapacity = AVAudioFrameCount(micInputFormat.sampleRate * 2.0)
                 guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: speechInputFormat, frameCapacity: frameCapacity) else {

--- a/Vocable/Features/Voice/AudioEngineController.swift
+++ b/Vocable/Features/Voice/AudioEngineController.swift
@@ -51,7 +51,7 @@ class AudioEngineController {
 
         let node = audioEngine.inputNode
         let bus = 0
-        let micInputFormat = node.outputFormat(forBus: bus)
+        let micInputFormat = node.inputFormat(forBus: bus)
 
         if micInputFormat.sampleRate == 0 {
             print("Audio engine input node sample rate 0. Cannot proceed.")
@@ -123,14 +123,15 @@ class AudioEngineController {
         do {
 
             if registeredSpeechControllers.isEmpty {
-                try audioSession.setCategory(.playback, mode: .spokenAudio)
                 if audioEngine.isRunning {
                     audioEngine.stop()
                 }
+                try audioSession.setCategory(.playback, mode: .spokenAudio)
             } else {
 
+                try audioSession.setCategory(.playAndRecord, mode: .measurement, options: .mixWithOthers)
+
                 if updateInputNodeTapIfNeeded() {
-                    try audioSession.setCategory(.playAndRecord, mode: .measurement, options: .mixWithOthers)
                     if !audioEngine.isRunning {
                         try audioEngine.start()
                     }

--- a/Vocable/Features/Voice/SpeechRecognizerController.swift
+++ b/Vocable/Features/Voice/SpeechRecognizerController.swift
@@ -24,7 +24,7 @@ class SpeechRecognizerController: NSObject, SFSpeechRecognitionTaskDelegate {
     var requiredPhrase: String?
 
     static private let speechRecognizer: SFSpeechRecognizer? = {
-        let recognizer = SFSpeechRecognizer()
+        let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en_US"))
         recognizer?.supportsOnDeviceRecognition = true
         return recognizer
     }()

--- a/Vocable/Features/Voice/SpeechRecognizerController.swift
+++ b/Vocable/Features/Voice/SpeechRecognizerController.swift
@@ -173,18 +173,19 @@ class SpeechRecognizerController: NSObject, SFSpeechRecognitionTaskDelegate {
 
     // Called for all recognitions, including non-final hypothesis
     func speechRecognitionTask(_ task: SFSpeechRecognitionTask, didHypothesizeTranscription transcription: SFTranscription) {
-        print("didHypothesizeTranscription: \(transcription.formattedString.lowercased())")
-        if let requiredPhrase = requiredPhrase, transcription.formattedString.lowercased().contains(requiredPhrase.lowercased()) {
+        let transcription = transcription.formattedString.lowercased()
+        if let requiredPhrase = requiredPhrase, transcription.contains(requiredPhrase.lowercased()) {
             delegate?.didReceiveRequiredPhrase()
         }
         startTimer()
-        delegate?.didReceivePartialTranscription(transcription.formattedString)
+        delegate?.didReceivePartialTranscription(transcription)
     }
 
     // Called only for final recognitions of utterances. No more about the utterance will be reported
     func speechRecognitionTask(_ task: SFSpeechRecognitionTask, didFinishRecognition recognitionResult: SFSpeechRecognitionResult) {
-        print("didFinishRecognition: \(recognitionResult.bestTranscription.formattedString.lowercased())")
-        if let requiredPhrase = requiredPhrase, recognitionResult.bestTranscription.formattedString.lowercased().contains(requiredPhrase.lowercased()) {
+        let transcription = recognitionResult.bestTranscription.formattedString.lowercased()
+        print("didFinishRecognition: \(transcription)")
+        if let requiredPhrase = requiredPhrase, transcription.contains(requiredPhrase.lowercased()) {
             delegate?.didReceiveRequiredPhrase()
         }
         delegate?.didGetFinalResult(recognitionResult)

--- a/Vocable/HeadTracking/UIHeadGazeViewController.swift
+++ b/Vocable/HeadTracking/UIHeadGazeViewController.swift
@@ -71,7 +71,8 @@ class UIHeadGazeViewController: UIViewController, ARSessionDelegate, ARSCNViewDe
         sceneview?.preferredFramesPerSecond =  UIScreen.main.maximumFramesPerSecond
         setupSceneNode()
         
-        AppConfig.$cursorSensitivity.sink { (sensitivity) in
+        AppConfig.$cursorSensitivity.sink { [weak self] (sensitivity) in
+            guard let self = self else { return }
             self.scalingRange = sensitivity.range
         }.store(in: &disposables)
 


### PR DESCRIPTION
* Match transcribed text color to designs
* Ensure audio session has the proper category before attempting to tap off the input node 
    - This fixes transcription not initializing on physical devices
* Define transcription locale as `en_US` for greater accuracy
* Prevent synthesized speech from being transcribed when the user chooses a response