### PR TITLE
Listening Mode refinements

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		30B979A524254CBC00309D7C /* WarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B979A424254CBC00309D7C /* WarningView.swift */; };
 		30B979B82425583E00309D7C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 30B979BA2425583E00309D7C /* InfoPlist.strings */; };
 		54D3C41723E37CD40061EF47 /* VocableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D3C41623E37CD40061EF47 /* VocableTests.swift */; };
-		64599429258933370010EEFF /* VocableCore in Frameworks */ = {isa = PBXBuildFile; productRef = 64599428258933370010EEFF /* VocableCore */; };
+		64599429258933370010EEFF /* VocableCore in Frameworks */ = {isa = PBXBuildFile; productRef = 64599428258933370010EEFF /* VocableCore */; settings = {ATTRIBUTES = (Required, ); }; };
 		64599431258938F50010EEFF /* ListeningResponseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64599430258938F50010EEFF /* ListeningResponseViewController.swift */; };
 		6459943E25895D9C0010EEFF /* SpeechRecognitionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6459943D25895D9C0010EEFF /* SpeechRecognitionController.swift */; };
 		64981D7C258A8014007EFA82 /* VocableChoicesModel.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 64981D7B258A8014007EFA82 /* VocableChoicesModel.mlmodel */; };
@@ -1384,7 +1384,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.4.0;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-w",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.willowtreeapps.eyespeakaac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.willowtreeapps.eyespeakaac";
@@ -1413,7 +1416,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.4.0;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-w",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.willowtreeapps.eyespeakaac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc com.willowtreeapps.eyespeakaac";
@@ -1610,7 +1616,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.4.0;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-w",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.willowtreeapps.eyespeakaac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.willowtreeapps.eyespeakaac";
@@ -1692,8 +1701,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/willowtreeapps/vocable-ios-spm.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "VocableCore",
         "repositoryURL": "https://github.com/willowtreeapps/vocable-ios-spm.git",
         "state": {
-          "branch": "main",
-          "revision": "ebd76c369a39b60c4cd9b9fd3f0ffc9b888f91b8",
-          "version": null
+          "branch": null,
+          "revision": "384aef4f5aea71d595877091229f9b3e3a4dec1c",
+          "version": "0.0.1"
         }
       }
     ]

--- a/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/willowtreeapps/vocable-ios-spm.git",
         "state": {
           "branch": null,
-          "revision": "384aef4f5aea71d595877091229f9b3e3a4dec1c",
-          "version": "0.0.1"
+          "revision": "ded8af923c2a7f6765117549677b8342123ea28a",
+          "version": "0.0.2"
         }
       }
     ]

--- a/Vocable/AppConfig.swift
+++ b/Vocable/AppConfig.swift
@@ -39,6 +39,13 @@ struct AppConfig {
     static var isListeningModeEnabled: Bool
 
     static var isListeningModeSupported: Bool {
+
+        // Listening mode is currently only supported for English
+        if Locale(identifier: activePreferredLanguageCode).languageCode != "en" {
+            return false
+        }
+
+        // ML models currently rely on CoreML features introduced in iOS 14
         if #available(iOS 14.0, *) {
             return true
         }

--- a/Vocable/AppConfig.swift
+++ b/Vocable/AppConfig.swift
@@ -35,8 +35,15 @@ struct AppConfig {
     @PublishedDefault(key: "isHotWordPermitted", defaultValue: true)
     static var isHotWordPermitted: Bool
 
-    @PublishedDefault(key: "isListeningModeEnabled", defaultValue: true)
+    @PublishedDefault(key: "isListeningModeEnabled", defaultValue: isListeningModeSupported)
     static var isListeningModeEnabled: Bool
+
+    static var isListeningModeSupported: Bool {
+        if #available(iOS 14.0, *) {
+            return true
+        }
+        return false
+    }
 
     static let defaultLanguageCode = "en"
     static var activePreferredLanguageCode: String {

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import CoreData
 import Combine
 import AVFoundation
-import VocableVoiceCore
+import VocableListenCore
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Vocable/Common/Views/EmptyStateView.swift
+++ b/Vocable/Common/Views/EmptyStateView.swift
@@ -32,73 +32,83 @@ class EmptyStateView: UIView {
         case recents
         case phraseCollection
         case listeningResponse
+        case speechServiceUnavailable
         case speechPermissionDenied
         case speechPermissionUndetermined
         case microphonePermissionDenied
         case microphonePermissionUndetermined
+        case listenModeFreeResponse
 
         var title: NSAttributedString {
+            let title: String
             switch self {
             case.recents:
-                let title = NSLocalizedString("recents_empty_state.header.title", comment: "Recents empty state title")
-                return NSAttributedString(string: title, attributes: [.font: UIFont.boldSystemFont(ofSize: 24), .foregroundColor: UIColor.defaultTextColor])
+                title = NSLocalizedString("recents_empty_state.header.title", comment: "Recents empty state title")
             case .phraseCollection:
-                let title = NSLocalizedString("empty_state.header.title", comment: "Empty state title")
-                return NSAttributedString(string: title)
+                title = NSLocalizedString("empty_state.header.title", comment: "Empty state title")
             case .microphonePermissionUndetermined, .microphonePermissionDenied:
-                #warning("Needs localization")
-                let title = "Microphone Access"
-                return NSAttributedString(string: title)
+                #warning("Needs localization & Final copy")
+                title = "Microphone Access"
             case .speechPermissionDenied, .speechPermissionUndetermined:
-                #warning("Needs localization")
-                let title = "Speech Recognition"
-                return NSAttributedString(string: title)
+                #warning("Needs localization & Final copy")
+                title = "Speech Recognition"
             case .listeningResponse:
-                #warning("Needs localization")
-                let title = "Listening..."
-                return NSAttributedString(string: title)
+                #warning("Needs localization & Final copy")
+                title = "Listening..."
+            case .listenModeFreeResponse:
+                #warning("Needs localization & Final copy")
+                title = "Sounds complicated"
+            case .speechServiceUnavailable:
+                #warning("Needs localization & Final copy")
+                title = "Speech services unavailable"
             }
+            return NSAttributedString(string: title, attributes: [.font: UIFont.boldSystemFont(ofSize: 24), .foregroundColor: UIColor.defaultTextColor])
         }
 
         var description: NSAttributedString? {
+            let value: String?
             switch self {
             case .recents:
-                let description = NSLocalizedString("recents_empty_state.body.title", comment: "Recents empty state description")
-                return NSAttributedString(string: description, attributes: [.foregroundColor: UIColor.defaultTextColor])
+                value = NSLocalizedString("recents_empty_state.body.title", comment: "Recents empty state description")
             case .microphonePermissionUndetermined:
-                #warning("Needs localization")
-                let description = "Vocable needs microphone access to enable Listening Mode. The button below presents an iOS permission dialog that Vocable's head tracking cannot interract with."
-                return NSAttributedString(string: description, attributes: [.foregroundColor: UIColor.defaultTextColor])
+                #warning("Needs localization & Final copy")
+                value = "Vocable needs microphone access to enable Listening Mode. The button below presents an iOS permission dialog that Vocable's head tracking cannot interract with."
             case .microphonePermissionDenied:
-                #warning("Needs localization")
-                let description = "Vocable needs to use the microphone to enable Listening Mode. Please enable microphone access in the system Settings app.\n\nYou can also disable Listening Mode to hide this category in Vocable's settings."
-                return NSAttributedString(string: description, attributes: [.foregroundColor: UIColor.defaultTextColor])
+                #warning("Needs localization & Final copy")
+                value = "Vocable needs to use the microphone to enable Listening Mode. Please enable microphone access in the system Settings app.\n\nYou can also disable Listening Mode to hide this category in Vocable's settings."
             case .speechPermissionUndetermined:
-                #warning("Needs localization")
-                let description = "Vocable needs to request speech permissions to enable Listening Mode. This will present an iOS permission dialog that Vocable's head tracking cannot interract with."
-                return NSAttributedString(string: description, attributes: [.foregroundColor: UIColor.defaultTextColor])
+                #warning("Needs localization & Final copy")
+                value = "Vocable needs to request speech permissions to enable Listening Mode. This will present an iOS permission dialog that Vocable's head tracking cannot interract with."
             case .speechPermissionDenied:
-                #warning("Needs localization")
-                let description = "Vocable needs speech recognition to enable Listening Mode. Please enable speech recognition in the system Settings app.\n\nYou can also disable Listening Mode to hide this category in Vocable's settings."
-                return NSAttributedString(string: description, attributes: [.foregroundColor: UIColor.defaultTextColor])
+                #warning("Needs localization & Final copy")
+                value = "Vocable needs speech recognition to enable Listening Mode. Please enable speech recognition in the system Settings app.\n\nYou can also disable Listening Mode to hide this category in Vocable's settings."
             case .listeningResponse:
-                #warning("Needs localization")
-                let description = "When in listening mode, if someone starts speaking, Vocable will try to show quick responses."
-                return NSAttributedString(string: description, attributes: [.foregroundColor: UIColor.defaultTextColor])
+                #warning("Needs localization & Final copy")
+                value = "When in listening mode, if someone starts speaking, Vocable will try to show quick responses."
+            case .listenModeFreeResponse:
+                #warning("Needs localization & Final copy")
+                value = "Not sure what to suggest. Please repeat or use the rest of Vocable to respond."
+            case .speechServiceUnavailable:
+                #warning("Needs localization & Final copy")
+                value = "Please try again later"
             default:
                 return nil
             }
+            if let description = value {
+                return NSAttributedString(string: description, attributes: [.foregroundColor: UIColor.defaultTextColor])
+            }
+            return nil
         }
 
         var buttonTitle: String? {
             switch self {
-            case .recents:
+            case .recents, .listenModeFreeResponse:
                 return nil
             case .microphonePermissionUndetermined, .speechPermissionUndetermined:
-                #warning("Needs localization")
+                #warning("Needs localization & Final copy")
                 return "Grant Access"
             case .microphonePermissionDenied, .speechPermissionDenied:
-                #warning("Needs localization")
+                #warning("Needs localization & Final copy")
                 return "Open Settings"
             default:
                 return NSLocalizedString("empty_state.button.title", comment: "Empty state Add Phrase button title")

--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -140,7 +140,14 @@ import Combine
     private func categoriesFetchRequest() -> NSFetchRequest<Category> {
         let request: NSFetchRequest<Category> = Category.fetchRequest()
         var predicate: NSPredicate = NSComparisonPredicate(\Category.isHidden, .equalTo, false)
-        if !AppConfig.isVoiceExperimentEnabled || !AppConfig.isListeningModeEnabled || !SpeechRecognitionController.shared.deviceSupportsSpeech {
+
+        let shouldRemoveListeningCategory = false
+        || !AppConfig.isListeningModeSupported
+        || !AppConfig.isVoiceExperimentEnabled
+        || !AppConfig.isListeningModeEnabled
+        || !SpeechRecognitionController.shared.deviceSupportsSpeech
+
+        if shouldRemoveListeningCategory {
             let notVoicePredicate = NSComparisonPredicate(\Category.identifier, .notEqualTo, Category.Identifier.listeningMode.rawValue)
             predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, notVoicePredicate])
         }

--- a/Vocable/Features/Root/RootViewController.swift
+++ b/Vocable/Features/Root/RootViewController.swift
@@ -82,7 +82,7 @@ import CoreData
             let vc = NumericCategoryContentViewController()
             utterancePublisher = vc.$lastUtterance
             viewController = vc
-        } else if category.identifier == Category.Identifier.listeningMode {
+        } else if #available(iOS 14.0, *), category.identifier == Category.Identifier.listeningMode {
             let vc = ListeningResponseViewController()
             vc.delegate = self
             utterancePublisher = vc.$lastUtterance

--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -67,7 +67,8 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
                 return AppConfig.showDebugOptions
             }
             if self == .listeningMode {
-                return AppConfig.isVoiceExperimentEnabled && SpeechRecognitionController.shared.deviceSupportsSpeech
+                return AppConfig.isVoiceExperimentEnabled && SpeechRecognitionController.shared.deviceSupportsSpeech &&
+                    AppConfig.isListeningModeSupported
             }
             return true
         }

--- a/Vocable/Features/Voice/AudioEngineController.swift
+++ b/Vocable/Features/Voice/AudioEngineController.swift
@@ -42,7 +42,7 @@ class AudioEngineController: NSObject, AVAudioPlayerDelegate {
         updateAudioSession()
     }
 
-    func dispatchInternalAsync(_ actions: @escaping () -> Void) {
+    private func dispatchInternalAsync(_ actions: @escaping () -> Void) {
         let isInternal = DispatchQueue.getSpecific(key: internalQueueKey) != nil
         if isInternal {
             actions()
@@ -51,7 +51,7 @@ class AudioEngineController: NSObject, AVAudioPlayerDelegate {
         }
     }
 
-    func dispatchInternalSync(_ actions: @escaping () throws -> Void) rethrows {
+    private func dispatchInternalSync(_ actions: @escaping () throws -> Void) rethrows {
         let isInternal = DispatchQueue.getSpecific(key: internalQueueKey) != nil
         if isInternal {
             try actions()

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -9,11 +9,13 @@
 import UIKit
 import Speech
 import Combine
+import VocableListenCore
 
 protocol ListeningResponseViewControllerDelegate: AnyObject {
     func didUpdateSpeechResponse(_ text: String?)
 }
 
+@available(iOS 14.0, *)
 final class ListeningResponseViewController: PagingCarouselViewController, AudioPermissionPromptPresenter, EmptyStateViewProvider {
 
     weak var delegate: ListeningResponseViewControllerDelegate?

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -18,16 +18,18 @@ protocol ListeningResponseViewControllerDelegate: AnyObject {
 @available(iOS 14.0, *)
 final class ListeningResponseViewController: PagingCarouselViewController, AudioPermissionPromptPresenter, EmptyStateViewProvider {
 
+    private enum Content {
+        case choices([String])
+        case empty(EmptyStateView.EmptyStateType)
+    }
+
     weak var delegate: ListeningResponseViewControllerDelegate?
 
     private let speechRecognizerController = SpeechRecognitionController.shared
     private var transcriptionCancellable: AnyCancellable?
     private var permissionsCancellable: AnyCancellable?
-    internal var isDisplayingAuthorizationPrompt = false {
-        didSet {
-            choices = []
-        }
-    }
+    private var classificationCancellable: AnyCancellable?
+    private var availabilityCancellable: AnyCancellable?
 
     private var desiredEmptyStateView: UIView? {
         didSet {
@@ -37,31 +39,43 @@ final class ListeningResponseViewController: PagingCarouselViewController, Audio
         }
     }
 
-    private let synthesizedSpeechQueue = DispatchQueue(label: "speech_synthesis_queue", qos: .userInitiated)
-    private let machineLearningQueue = DispatchQueue(label: "machine_learning_queue", qos: .userInitiated)
+    private var emptyState: EmptyStateView.EmptyStateType?
 
-    private let yesNoResponses = ["Yes", "No"]
-    private let quantityResponses = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]
+    private let synthesizedSpeechQueue = DispatchQueue(label: "speech_synthesis_queue", qos: .userInitiated)
+    let classifier = VLClassifier()
+
     private let feelingsResponses = ["Okay", "Good", "Bad"]
     private let prefixes = ["Would you like", "Do you want"]
 
-    @PublishedValue private(set) var lastUtterance: String?
-    private static let formatter = NumberFormatter()
-
-    private(set) var isNumberResponse: Bool = false
-    private(set) var choices: [String] = [] {
+    internal var isDisplayingAuthorizationPrompt = false {
         didSet {
-            var snapshot = NSDiffableDataSourceSnapshot<Int, String>()
-            snapshot.appendSections([0])
-            snapshot.appendItems(choices)
-            UIView.animate(withDuration: 0.5,
-                           delay: 0,
-                           usingSpringWithDamping: 0.8,
-                           initialSpringVelocity: 1.0,
-                           options: [],
-                           animations: { [weak self] in
-                                self?.diffableDataSource.apply(snapshot, animatingDifferences: false)
-                           }, completion: nil)
+            if speechRecognizerController.isAvailable {
+                content = .empty(.listeningResponse)
+            }
+        }
+    }
+
+    @PublishedValue private(set) var lastUtterance: String?
+
+    private var content: Content = .empty(.listeningResponse) {
+        didSet {
+            switch content {
+            case .choices(let choices):
+                var snapshot = NSDiffableDataSourceSnapshot<Int, String>()
+                snapshot.appendSections([0])
+                snapshot.appendItems(choices)
+                UIView.animate(withDuration: 0.5,
+                               delay: 0,
+                               usingSpringWithDamping: 0.8,
+                               initialSpringVelocity: 1.0,
+                               options: [],
+                               animations: { [weak self] in
+                                    self?.diffableDataSource.apply(snapshot, animatingDifferences: false)
+                               }, completion: nil)
+                desiredEmptyStateView = nil
+            case .empty(let emptyStateType):
+                desiredEmptyStateView = EmptyStateView(type: emptyStateType)
+            }
         }
     }
 
@@ -95,16 +109,59 @@ final class ListeningResponseViewController: PagingCarouselViewController, Audio
             transcriptionCancellable = speechRecognizerController.$transcription
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] newValue in
+                    guard let self = self else { return }
                     switch newValue {
                     case .partialTranscription(let transcription):
-                        self?.delegate?.didUpdateSpeechResponse(transcription)
-                        self?.setIsEmptyStateHidden(true)
+                        self.delegate?.didUpdateSpeechResponse(transcription)
                     case .finalTranscription(let transcription):
-                        self?.delegate?.didUpdateSpeechResponse(transcription)
-                        self?.classify(transcription: transcription)
-                        self?.setIsEmptyStateHidden(true)
+                        self.delegate?.didUpdateSpeechResponse(transcription)
+                        self.classifier.classify(transcription)
                     default:
-                        self?.setIsEmptyStateHidden(false)
+                        if self.speechRecognizerController.isListening {
+                            self.content = .empty(.listeningResponse)
+                        }
+                    }
+                }
+        }
+
+        if classificationCancellable == nil {
+            classificationCancellable = classifier.$classification
+                .removeDuplicates()
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] newValue in
+                    self?.updateResponses(for: newValue)
+                }
+        }
+
+        if availabilityCancellable == nil {
+            availabilityCancellable = speechRecognizerController.$isAvailable
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] isAvailable in
+                    guard let self = self else { return }
+                    if isAvailable {
+                        if case .choices = self.content {
+                            // no-op
+                        } else {
+                            self.content = .empty(.listeningResponse)
+                        }
+                    } else {
+                        if case .empty(let emptyKind) = self.content {
+                            switch emptyKind {
+                            case .speechServiceUnavailable:
+                                return
+                            case .speechPermissionDenied:
+                                return
+                            case .speechPermissionUndetermined:
+                                return
+                            case .microphonePermissionDenied:
+                                return
+                            case .microphonePermissionUndetermined:
+                                return
+                            default:
+                                break
+                            }
+                        }
+                        self.content = .empty(.speechServiceUnavailable)
                     }
                 }
         }
@@ -153,86 +210,73 @@ final class ListeningResponseViewController: PagingCarouselViewController, Audio
         }
     }
 
-    func setIsEmptyStateHidden(_ isHidden: Bool) {
-        if isHidden {
-            desiredEmptyStateView = nil
-        } else if desiredEmptyStateView == nil {
-            desiredEmptyStateView = EmptyStateView(type: .listeningResponse)
-        }
-    }
-
     func emptyStateView() -> UIView? {
         return desiredEmptyStateView
     }
 
     // MARK: ML Stubs
 
-    private func classify(transcription: String) {
+    private func updateResponses(for result: VLClassificationResult?) {
 
-        machineLearningQueue.async { [weak self] in
+        guard let result = result else {
+            content = .empty(.listeningResponse)
+            return
+        }
 
-            guard let self = self else { return }
+        switch result.result {
+        case .freeResponse:
+            updateForFreeResponse(result)
+        case .yesOrNo:
+            content = .choices(["Yes", "No"])
+        case .numerical:
+            content = .choices(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+        case .interval:
+            content = .choices(["1", "2", "3", "4", "5"])
+        @unknown default:
+            content = .empty(.listeningResponse)
+        }
+    }
 
-            let model = try! VocableChoicesModel(configuration: .init())
-            guard let prediction = try? model.prediction(text: transcription) else {
-                assertionFailure("Predictions failed...")
-                return
-            }
+    private func updateForFreeResponse(_ result: VLClassificationResult) {
 
-            //get choices
-            var sentence = transcription
+        // Placeholder to try and preserve this functionality from the
+        // demo model until the new model supports it
+        guard result.text.contains(" or ") else {
+            content = .empty(.listenModeFreeResponse)
+            return
+        }
 
-            // Sanitize the sentence by removing non key words
-            for prefix in self.prefixes {
-                if sentence.hasPrefix(prefix) {
-                    if let rangeToRemove = sentence.range(of: prefix) {
-                        sentence.removeSubrange(rangeToRemove)
-                    }
-                }
-            }
+        var sentence = result.text.trimmingCharacters(in: .whitespaces)
 
-            sentence = sentence.trimmingCharacters(in: .whitespaces)
-            var choicesArray = sentence.components(separatedBy: " or ")
-
-            choicesArray = choicesArray.map { (choice) -> String in
-                var sanitizedChoice = choice.trimmingCharacters(in: .whitespaces)
-                if sanitizedChoice.hasPrefix("a ") {
-                    if let rangeToRemove = sanitizedChoice.range(of: "a ") {
-                        sanitizedChoice.removeSubrange(rangeToRemove)
-                    }
-                }
-
-                if sanitizedChoice.hasSuffix("?") {
-                    if let rangeToRemove = sanitizedChoice.range(of: "?") {
-                        sanitizedChoice.removeSubrange(rangeToRemove)
-                    }
-                }
-
-                return sanitizedChoice
-            }
-
-            DispatchQueue.main.async {
-                self.choices.removeAll()
-
-                let label = prediction.label
-                if label == "boolean" {
-                    print("bool")
-                    self.isNumberResponse = false
-                    self.choices = self.yesNoResponses
-                } else if label == "quantity" {
-                    print("numbers")
-                    self.isNumberResponse = true
-                    self.choices = self.quantityResponses
-                } else if label == "feelings" {
-                    print("feels")
-                    self.isNumberResponse = false
-                    self.choices = self.feelingsResponses
-                } else if label == "choices" {
-                    print("choice -> \(choicesArray)")
-                    self.isNumberResponse = false
-                    self.choices = choicesArray
+        // Sanitize the sentence by removing non key words
+        for prefix in self.prefixes {
+            if sentence.hasPrefix(prefix) {
+                if let rangeToRemove = sentence.range(of: prefix) {
+                    sentence.removeSubrange(rangeToRemove)
                 }
             }
         }
+
+        sentence = sentence.trimmingCharacters(in: .whitespaces)
+
+        let operands = sentence.components(separatedBy: " or ")
+
+        let choices = operands.map { (choice) -> String in
+            var sanitizedChoice = choice.trimmingCharacters(in: .whitespaces)
+            if sanitizedChoice.hasPrefix("a ") {
+                if let rangeToRemove = sanitizedChoice.range(of: "a ") {
+                    sanitizedChoice.removeSubrange(rangeToRemove)
+                }
+            }
+
+            if sanitizedChoice.hasSuffix("?") {
+                if let rangeToRemove = sanitizedChoice.range(of: "?") {
+                    sanitizedChoice.removeSubrange(rangeToRemove)
+                }
+            }
+
+            return sanitizedChoice
+        }
+        content = .choices(choices)
     }
 }


### PR DESCRIPTION
* iOS 14 restriction, due to new ML model requirements
* English-only restriction for listening mode, since we've only trained on English
* Handle speech framework availability status for when the transcription service is unavailable
* Improve empty state management in response VC
* Improved transcription timer cancellation to help prevent an old timer from interfering with a new transcription before the new transcription has had a chance to extend the timer for its own transcription