### PR TITLE
[WIP] Update fastfile to skip 2FA

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,7 @@ default_platform :ios
 platform :ios do
   before_all do
     ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "60"
+    ENV["SPACESHIP_SKIP_2FA_UPGRADE"]="1"
     setup_circle_ci
   end
 


### PR DESCRIPTION
Updating Fastlane did not resolve CircleCI deployment issues, but hopefully this will allow TestFlight deployments again