### PR TITLE
Hotword Enhancements

### DIFF
--- a/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/willowtreeapps/vocable-ios-spm.git",
         "state": {
           "branch": null,
-          "revision": "370884ab10a13a3e27e53badcf35071a2b7039e8",
-          "version": "0.0.5"
+          "revision": "f8946a6e3cc4b677319e751d3861c3b9280f1fb6",
+          "version": "0.0.7"
         }
       }
     ]

--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -111,7 +111,7 @@
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -71,6 +71,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         _ = SpeechRecognitionController.shared
 
+        AppConfig.$isListeningModeEnabled
+            .removeDuplicates()
+            .sink { isEnabled in
+                if #available(iOS 14.0, *), isEnabled {
+                    VLClassifier.prepare()
+                }
+            }.store(in: &disposables)
+
         return true
     }
 

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -191,6 +191,8 @@ final class ListeningResponseViewController: VocableViewController {
 
         transcriptionCancellable = speechRecognizerController.$transcription
             .dropFirst()
+            .debounce(for: .seconds(0.08), scheduler: DispatchQueue.main)
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newValue in
                 guard let self = self else { return }

--- a/Vocable/Features/Voice/SpeechRecognitionController.swift
+++ b/Vocable/Features/Voice/SpeechRecognitionController.swift
@@ -75,7 +75,7 @@ class SpeechRecognitionController: NSObject, SFSpeechRecognitionTaskDelegate, SF
     // ASR hears what it hears, this regex is just trying to catch common errors
     private let hotWordFirstComponentRegex = "(hey|he|she|a|i)"
     private lazy var hotWordPartialMatchRegex = "^\\s*\(hotWordFirstComponentRegex)\\s*$"
-    private lazy var hotWordRegex = "(\(hotWordFirstComponentRegex) (voc|book|fuck)able)|(revocable)"
+    private lazy var hotWordRegex = "(\(hotWordFirstComponentRegex) (voc|book|fuck)able)|((re|in)vocable)"
     private let hotWordIntendedPhrase = "hey vocable"
 
     private var hotWordEnabledCancellable: AnyCancellable?

--- a/Vocable/Features/Voice/SpeechRecognitionController.swift
+++ b/Vocable/Features/Voice/SpeechRecognitionController.swift
@@ -51,7 +51,7 @@ class SpeechRecognitionController: NSObject, SFSpeechRecognitionTaskDelegate, SF
         }
     }
 
-    enum TranscriptionResult {
+    enum TranscriptionResult: Equatable {
         case none
         case hotWord
         case partialTranscription(String)
@@ -410,7 +410,7 @@ class SpeechRecognitionController: NSObject, SFSpeechRecognitionTaskDelegate, SF
     // Called for all recognitions, including non-final hypothesis
     func speechRecognitionTask(_ task: SFSpeechRecognitionTask, didHypothesizeTranscription transcription: SFTranscription) {
 
-        cancelTimer(reason: "New hypothesis")
+        cancelTimer(reason: "New hypothesis \"\(transcription.formattedString)\"")
 
         var containsHotWord = false
         let transcription = normalizedTranscription(from: transcription.formattedString, containedHotWord: &containsHotWord)


### PR DESCRIPTION
Attempts to fix a few hotword-related issues:
* Invocation of the hotword would sometimes have a preceding syllable (usually something like a stray 'I'), which would be caused by any slight hesitation leading into the "hey." Rather than simply performing a find/replace on the hotword, this change will cause anything preceding the hotword to be removed from the transcription. This should be a safe change since the hotword is meant to be an antecedent to the actual phrase the speaker intends to be transcribed.
* ASR can be finicky, so this attempts to make hotword recognition more flexible by using a regex to encapsulate common ASR mistakes
* If the listen category was already selected, sometimes ASR would successfully hear "hey vocable" and strip it out, but it would leave "hey" as the transcription. This was because we didn't recognize partial transcriptions as being potential hotword candidates in intermediate transcriptions ("hey" shows up before "hey vocable"). This change now ensures that the regex for the first word that ASR _might_ hear is excluded from transcriptions until a subsequent utterance follows up with another word to ensure the transcription is _not_ the hotword.