### PR TITLE
Listen mode numerical responses

### DIFF
--- a/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/willowtreeapps/vocable-ios-spm.git",
         "state": {
           "branch": null,
-          "revision": "f8946a6e3cc4b677319e751d3861c3b9280f1fb6",
-          "version": "0.0.7"
+          "revision": "a26f550b5752112e66b7b9bd4d9b5e5f288981eb",
+          "version": "0.0.8"
         }
       }
     ]

--- a/Vocable/Features/Root/NumericCategoryContentViewController.swift
+++ b/Vocable/Features/Root/NumericCategoryContentViewController.swift
@@ -8,10 +8,13 @@
 
 import UIKit
 import AVFoundation
+import Combine
 
 class NumericCategoryContentViewController: PagingCarouselViewController {
 
     @PublishedValue private(set) var lastUtterance: String?
+
+    var disposables = Set<AnyCancellable>()
 
     private static let formatter = NumberFormatter()
 


### PR DESCRIPTION
* Integrates a new model version that supports numerical questions (e.g. “How many …”)
* Resets the transcription when navigating away from the listening category to increase clarity