### PR TITLE
Fix iOS 13 dyld crash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 12.2.0
+      xcode: 12.5.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -24,7 +24,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 12.2.0
+      xcode: 12.5.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
@@ -44,7 +44,7 @@ jobs:
 
   buildanddeploytotestflight:
     macos:
-      xcode: 12.2.0
+      xcode: 12.5.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: buildanddeploytotestflight
@@ -63,7 +63,7 @@ jobs:
           path: output
   export-localizations-for-crowdin:
     macos: 
-      xcode: 12.2.0
+      xcode: 12.5.0
     steps:
       - checkout
       - run: rm ~/.ssh/id_rsa || true
@@ -85,7 +85,7 @@ jobs:
             
   update-localizations-test-deploy:
     macos: 
-      xcode: 12.2.0
+      xcode: 12.5.0
     steps:
       - run: curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer -o AppleWWDRCAG3.cer
       - run: sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain AppleWWDRCAG3.cer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.0
+      xcode: 12.2.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -24,7 +24,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 12.5.0
+      xcode: 12.2.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
@@ -44,7 +44,7 @@ jobs:
 
   buildanddeploytotestflight:
     macos:
-      xcode: 12.5.0
+      xcode: 12.2.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: buildanddeploytotestflight
@@ -63,7 +63,7 @@ jobs:
           path: output
   export-localizations-for-crowdin:
     macos: 
-      xcode: 12.5.0
+      xcode: 12.2.0
     steps:
       - checkout
       - run: rm ~/.ssh/id_rsa || true
@@ -85,7 +85,7 @@ jobs:
             
   update-localizations-test-deploy:
     macos: 
-      xcode: 12.5.0
+      xcode: 12.2.0
     steps:
       - run: curl https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer -o AppleWWDRCAG3.cer
       - run: sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain AppleWWDRCAG3.cer

--- a/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vocable.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/willowtreeapps/vocable-ios-spm.git",
         "state": {
           "branch": null,
-          "revision": "a26f550b5752112e66b7b9bd4d9b5e5f288981eb",
-          "version": "0.0.8"
+          "revision": "666e9f56650705150043b004680710342d77854d",
+          "version": "0.0.9"
         }
       }
     ]

--- a/Vocable/Extensions/Cell+NibLoading.swift
+++ b/Vocable/Extensions/Cell+NibLoading.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol ReuseIdentifiable: class {
+protocol ReuseIdentifiable: AnyObject {
     static var reuseIdentifier: String { get }
 }
 

--- a/Vocable/Features/Settings/EditCategories/EditCategoryDetailTitleCollectionViewCell.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoryDetailTitleCollectionViewCell.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-protocol EditCategoryDetailsHeaderCollectionViewCellDelegate: class {
+protocol EditCategoryDetailsHeaderCollectionViewCellDelegate: AnyObject {
     func didTapEdit()
 }
 
-protocol EditCategoryDetailTitleCollectionViewCellDelegate: class {
+protocol EditCategoryDetailTitleCollectionViewCellDelegate: AnyObject {
     func didTapEdit()
 }
 


### PR DESCRIPTION
Linking against an XCFramework with a min deployment target of iOS 14 did not work as expected on iOS 13. The framework has been updated to support iOS 13.

Attempted to update to Xcode 12.5, but CircleCI does not have an image for it yet. Code changes were minimal so I'm keeping those.