### PR TITLE
Update README for technical onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,10 @@ We love contributions! To get started, please see our [Contributing Guidelines](
 - iOS devices with TrueDepth camera
 
 ## Device Provisioning
-1. Run `fastlane` from the project command line.
-2. From the menu select the option for `Add devices via....`
-3. When prompted enter a `device name` and press enter. This can be any name.
-4. When prompted enter the `device UDID` and press enter. Found in `Xcode -> Window -> Devices and Simulators`
-5. When prompted enter a `eyespeakstore@willowtreeapps.com` for `username` and press enter.
-6. Fastlane might ask you to enter a username again, use `eyespeakstore@willowtreeapps.com`.
+
+External contributors will need to provision their device and sign Vocable to run on that device in a way that is convenient for them.
+
+Internal/WillowTree contributors can follow the steps outlined in the [Technical Onboarding](https://github.com/willowtreeapps/vocable-ios/wiki/WillowTree-Technical-Onboarding) page
 
 ## Credits
 Matt Kubota, Kyle Ohanian, Duncan Lewis, Ameir Al-Zoubi, and many more from [WillowTree](https://willowtreeapps.com/) 💙.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,7 +70,11 @@ platform :ios do
   end
 
   desc "Add devices via the command line to the device portal and regenerate the development provisioning profile with the device"
-  lane :register do
+  lane :wt_register_new_device do
+    
+    ensure_env_vars(
+      env_vars: ['APP_STORE_KEY_ID', 'APP_STORE_ISSUER_ID', 'APP_STORE_KEY_BASE64']
+    )
     
     app_store_connect_api_key(
       key_id: "#{ENV["APP_STORE_KEY_ID"]}",
@@ -86,6 +90,11 @@ platform :ios do
     device_hash[device_name] = device_udid
     register_devices(devices: device_hash)
     match(type:"development", force_for_new_devices: true)
+  end
+  
+  desc "Setup local development environment (WillowTree Internal)"
+  lane :wt_setup_build_environment do
+    match(type:"development", readonly: true)
   end
 
   desc "Integrate latest XLIFF files with project"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,13 +47,21 @@ Ad-hoc build
 
 AppStore build and upload to TestFlight
 
-### ios register
+### ios wt_register_new_device
 
 ```sh
-[bundle exec] fastlane ios register
+[bundle exec] fastlane ios wt_register_new_device
 ```
 
 Add devices via the command line to the device portal and regenerate the development provisioning profile with the device
+
+### ios wt_setup_build_environment
+
+```sh
+[bundle exec] fastlane ios wt_setup_build_environment
+```
+
+Setup local development environment (WillowTree Internal)
 
 ### ios xliffimport
 


### PR DESCRIPTION
* Slightly adjusts fastlane lanes for (hopefully) clearer onboarding. 
* Points at new wiki page on the subject:
https://github.com/willowtreeapps/vocable-ios/wiki/WillowTree-Technical-Onboarding

^ That wiki page will need some more love, but I think I covered most of it