### PR TITLE
Unlink chained UI tests: CustomCategoriesTests

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		30B979B82425583E00309D7C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 30B979BA2425583E00309D7C /* InfoPlist.strings */; };
 		54D3C41723E37CD40061EF47 /* VocableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D3C41623E37CD40061EF47 /* VocableTests.swift */; };
 		620DD31927DA90F1003B01A0 /* CustomCategoriesBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620DD31827DA90F1003B01A0 /* CustomCategoriesBaseTest.swift */; };
+		628B35C227DF9C6B00299312 /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628B35C127DF9C6B00299312 /* BaseScreen.swift */; };
 		64599429258933370010EEFF /* VocableCore in Frameworks */ = {isa = PBXBuildFile; productRef = 64599428258933370010EEFF /* VocableCore */; settings = {ATTRIBUTES = (Required, ); }; };
 		64599431258938F50010EEFF /* ListeningResponseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64599430258938F50010EEFF /* ListeningResponseViewController.swift */; };
 		6459943E25895D9C0010EEFF /* SpeechRecognitionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6459943D25895D9C0010EEFF /* SpeechRecognitionController.swift */; };
@@ -214,6 +215,7 @@
 		54D3C41623E37CD40061EF47 /* VocableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableTests.swift; sourceTree = "<group>"; };
 		54D3C41823E37CD40061EF47 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		620DD31827DA90F1003B01A0 /* CustomCategoriesBaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCategoriesBaseTest.swift; sourceTree = "<group>"; };
+		628B35C127DF9C6B00299312 /* BaseScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseScreen.swift; sourceTree = "<group>"; };
 		64599430258938F50010EEFF /* ListeningResponseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningResponseViewController.swift; sourceTree = "<group>"; };
 		6459943D25895D9C0010EEFF /* SpeechRecognitionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionController.swift; sourceTree = "<group>"; };
 		64981D7B258A8014007EFA82 /* VocableChoicesModel.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = VocableChoicesModel.mlmodel; sourceTree = "<group>"; };
@@ -470,6 +472,7 @@
 				17D4162D245C6FF600FD81CD /* KeyboardScreen.swift */,
 				17F29478247419DD00A05434 /* SettingsScreen.swift */,
 				CE12277724F58706008F7866 /* CustomCategoriesScreen.swift */,
+				628B35C127DF9C6B00299312 /* BaseScreen.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -1187,6 +1190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE12277824F58706008F7866 /* CustomCategoriesScreen.swift in Sources */,
+				628B35C227DF9C6B00299312 /* BaseScreen.swift in Sources */,
 				17D4162C245C6FE800FD81CD /* KeyboardScreenTests.swift in Sources */,
 				17D4162E245C6FF600FD81CD /* KeyboardScreen.swift in Sources */,
 				CE1406A224F3E8AD00C26225 /* SettingsScreenTests.swift in Sources */,

--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		30B979A524254CBC00309D7C /* WarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B979A424254CBC00309D7C /* WarningView.swift */; };
 		30B979B82425583E00309D7C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 30B979BA2425583E00309D7C /* InfoPlist.strings */; };
 		54D3C41723E37CD40061EF47 /* VocableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D3C41623E37CD40061EF47 /* VocableTests.swift */; };
+		620DD31927DA90F1003B01A0 /* CustomCategoriesBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620DD31827DA90F1003B01A0 /* CustomCategoriesBaseTest.swift */; };
 		64599429258933370010EEFF /* VocableCore in Frameworks */ = {isa = PBXBuildFile; productRef = 64599428258933370010EEFF /* VocableCore */; settings = {ATTRIBUTES = (Required, ); }; };
 		64599431258938F50010EEFF /* ListeningResponseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64599430258938F50010EEFF /* ListeningResponseViewController.swift */; };
 		6459943E25895D9C0010EEFF /* SpeechRecognitionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6459943D25895D9C0010EEFF /* SpeechRecognitionController.swift */; };
@@ -212,6 +213,7 @@
 		54D3C41423E37CD40061EF47 /* VocableTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VocableTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		54D3C41623E37CD40061EF47 /* VocableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableTests.swift; sourceTree = "<group>"; };
 		54D3C41823E37CD40061EF47 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		620DD31827DA90F1003B01A0 /* CustomCategoriesBaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCategoriesBaseTest.swift; sourceTree = "<group>"; };
 		64599430258938F50010EEFF /* ListeningResponseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningResponseViewController.swift; sourceTree = "<group>"; };
 		6459943D25895D9C0010EEFF /* SpeechRecognitionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionController.swift; sourceTree = "<group>"; };
 		64981D7B258A8014007EFA82 /* VocableChoicesModel.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = VocableChoicesModel.mlmodel; sourceTree = "<group>"; };
@@ -480,6 +482,7 @@
 				17D4162B245C6FE800FD81CD /* KeyboardScreenTests.swift */,
 				CE12277524F586CB008F7866 /* CustomCategoriesTests.swift */,
 				CE1406A124F3E8AD00C26225 /* SettingsScreenTests.swift */,
+				620DD31827DA90F1003B01A0 /* CustomCategoriesBaseTest.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1188,6 +1191,7 @@
 				17D4162E245C6FF600FD81CD /* KeyboardScreen.swift in Sources */,
 				CE1406A224F3E8AD00C26225 /* SettingsScreenTests.swift in Sources */,
 				17793C2E24574CB500758BC0 /* MainScreenTests.swift in Sources */,
+				620DD31927DA90F1003B01A0 /* CustomCategoriesBaseTest.swift in Sources */,
 				CE12277624F586CB008F7866 /* CustomCategoriesTests.swift in Sources */,
 				17793C2B24574B2800758BC0 /* MainScreen.swift in Sources */,
 				17F29479247419DD00A05434 /* SettingsScreen.swift in Sources */,

--- a/Vocable.xcodeproj/xcshareddata/xcschemes/AdHoc.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/AdHoc.xcscheme
@@ -67,6 +67,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "CustomCategoriesTest/testPagination()">
+               </Test>
+               <Test
                   Identifier = "MainScreenTests/testCustonCategoryPagination()">
                </Test>
                <Test

--- a/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
@@ -45,6 +45,7 @@ final class EditCategoryDetailViewController: VocableCollectionViewController, E
             let button = GazeableButton()
             button.setImage(UIImage(systemName: "arrow.left"), for: .normal)
             button.addTarget(self, action: #selector(handleBackButton(_:)), for: .primaryActionTriggered)
+            button.accessibilityIdentifier = "navigationBar.backButton"
             return button
         }()
     }
@@ -167,6 +168,10 @@ final class EditCategoryDetailViewController: VocableCollectionViewController, E
             if !category.isUserGenerated {
                 cell.editButton.isEnabled = false
             }
+            
+            // Assign identifiers for automation
+            cell.accessibilityIdentifier = "category_title"
+            cell.editButton.accessibilityIdentifier = "category_title_edit_button"
 
             return cell
 
@@ -179,6 +184,10 @@ final class EditCategoryDetailViewController: VocableCollectionViewController, E
                 cell.showCategorySwitch.isOn = !category.isHidden
                 cell.showCategorySwitch.isEnabled = (category.identifier != .userFavorites)
             }
+            
+            // Assign an identifier for automation
+            cell.showCategorySwitch.accessibilityIdentifier = "show_category_toggle"
+            
             return cell
 
         case .addPhrase:
@@ -186,12 +195,20 @@ final class EditCategoryDetailViewController: VocableCollectionViewController, E
             let title = NSLocalizedString("Edit Phrases", comment: "Edit Phrases")
             cell.setup(title: title, image: UIImage(systemName: "chevron.right"))
             cell.isEnabled = shouldEnableItem(at: indexPath)
+            
+            // Assign an identifier for automation
+            cell.accessibilityIdentifier = "edit_phrases_cell"
+            
             return cell
 
         case .removeCategory:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditCategoryRemoveCollectionViewCell.reuseIdentifier, for: indexPath) as! EditCategoryRemoveCollectionViewCell
             cell.isEnabled = shouldEnableItem(at: indexPath)
             cell.textLabel.text = NSLocalizedString("category_editor.detail.button.remove_category.title", comment: "Remove category button label within the category detail screen.")
+            
+            // Assign an identifier for automation
+            cell.accessibilityIdentifier = "remove_category_cell"
+            
             return cell
         }
     }

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -15,6 +15,26 @@ import XCTest
 class BaseScreen {
     let paginationLabel = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
     
+    /// From Pagination: the current page (X) being viewed from the "Page X of Y" pagination label.
+    var currentPageNumber: Int {
+        // Define a regex pattern with named matching group, 'current', for reference
+        let pattern = #"(?<current>\d)+ .+ (\d)+"#
+        
+        let pageNumber = getNamedGroupInRegexPatternFromText(namedGroup: "current", regexPattern: pattern, text: paginationLabel.label)
+        
+        return Int(pageNumber)!
+    }
+    
+    /// From Pagination: the total number of pages (Y) from the "Page X of Y" pagination label.
+    var totalPageCount: Int {
+        // Define a regex pattern with named matching group, 'total', for reference
+        let pattern = #"(\d)+ .+ (?<total>\d)+"#
+        
+        let pageCount = getNamedGroupInRegexPatternFromText(namedGroup: "total", regexPattern: pattern, text: paginationLabel.label)
+        
+        return Int(pageCount)!
+    }
+    
     /**
      This method extracts a substring from text, that matches the named group within a defined regex pattern.
      
@@ -26,7 +46,7 @@ class BaseScreen {
     private func getNamedGroupInRegexPatternFromText(namedGroup: String, regexPattern: String, text: String) -> String {
         var matchingText = ""
         let regex = try! NSRegularExpression(pattern: regexPattern)
-        let range = NSRange(location: 0, length: text.count) // Used for the NSRegularExpression
+        let range = NSRange(text.startIndex..<text.endIndex, in: text) // Used for the NSRegularExpression
         
         // Find a match to the regex pattern...
         if let match = regex.firstMatch(in: text, options: [], range: range) {
@@ -38,24 +58,6 @@ class BaseScreen {
         }
         
         return matchingText
-    }
-    
-    /// For Pagination: retrieve the current page (X) being viewed
-    /// from the "Page X of Y" pagination label.
-    func getCurrentPage() -> String {
-        // Define a regex pattern with named matching group, 'current', for reference
-        let pattern = #"(?<current>\d)+ of (\d)+"#
-        
-        return getNamedGroupInRegexPatternFromText(namedGroup: "current", regexPattern: pattern, text: paginationLabel.label)
-    }
-    
-    /// For Pagination: retrieve the total number of pages (Y) from the
-    ///  "Page X of Y" pagination label.
-    func getTotalNumOfPages() -> String {
-        // Define a regex pattern with named matching group, 'total', for reference
-        let pattern = #"(\d)+ of (?<total>\d)+"#
-        
-        return getNamedGroupInRegexPatternFromText(namedGroup: "total", regexPattern: pattern, text: paginationLabel.label)
     }
     
 }

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -13,51 +13,49 @@ import Foundation
 import XCTest
 
 class BaseScreen {
-    // Define a regex pattern with named matching groups, 'current' and 'total', for reference
-    let paginationRegexPattern = #"(?<current>\d)+ of (?<total>\d)+"#
-    
     let paginationLabel = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
+    
+    /**
+     This method extracts a substring from  text, that matches the named group within a defined regex pattern.
+     
+     For regex pattern #"Find (?\<groupdName\>\w)+ please"#, the \<groupName\> is matched from 'Find help please'
+     to return 'help'
+     
+     Documentaion: https://nshipster.com/swift-regular-expressions/
+    */
+    private func getNamedGroupInRegexPatternFromText(namedGroup: String, regexPattern: String, fromText: String) -> String {
+        var matchingText = ""
+        let regex = try! NSRegularExpression(pattern: regexPattern)
+        let range = NSRange(location: 0, length: fromText.count) // Used for the NSRegularExpression
+        
+        // Find a match to the regex pattern...
+        if let match = regex.firstMatch(in: fromText, options: [], range: range) {
+            // Within the match to the regex pattern, extract the matching group by its name
+            let resultingMatch = match.range(withName: namedGroup)
+
+            // Extract the Substring (as a String) of the found match from the range returned by regex.firstMatch
+            matchingText = String(fromText[Range(resultingMatch, in: fromText)!])
+        }
+        
+        return matchingText
+    }
     
     /// For Pagination: retrieve the current page (X) being viewed
     /// from the "Page X of Y" pagination label.
     func getCurrentPage() -> String {
-        var currentPage = ""
-        let fullLabel = paginationLabel.label
+        // Define a regex pattern with named matching group, 'current', for reference
+        let pattern = #"(?<current>\d)+ of (\d)+"#
         
-        let regex = try! NSRegularExpression(pattern: paginationRegexPattern)
-        let range = NSRange(location: 0, length: fullLabel.count) // Used for the NSRegularExpression
-        
-        // Find a match to the regex pattern...
-        if let match = regex.firstMatch(in: fullLabel, options: [], range: range) {
-            // Within the match to the regex pattern, extract the matching group by its name
-            let resultingMatch = match.range(withName: "current")
-
-            // Extract the Substring (as a String) of the found match from the range returned by regex.firstMatch
-            currentPage = String(fullLabel[Range(resultingMatch, in: fullLabel)!])
-        }
-        
-        return currentPage
+        return getNamedGroupInRegexPatternFromText(namedGroup: "current", regexPattern: pattern, fromText: paginationLabel.label)
     }
     
     /// For Pagination: retrieve the total number of pages (Y) from the
     ///  "Page X of Y" pagination label.
     func getTotalNumOfPages() -> String {
-        var totalPages = ""
-        let fullLabel = paginationLabel.label
+        // Define a regex pattern with named matching group, 'total', for reference
+        let pattern = #"(\d)+ of (?<total>\d)+"#
         
-        let regex = try! NSRegularExpression(pattern: paginationRegexPattern)
-        let range = NSRange(location: 0, length: fullLabel.count) // Used for the NSRegularExpression
-        
-        // Find a match to the regex pattern...
-        if let match = regex.firstMatch(in: fullLabel, options: [], range: range) {
-            // Within the match to the regex pattern, extract the matching group by its name
-            let resultingMatch = match.range(withName: "total")
-
-            // Extract the Substring (as a String) of the found match from the range returned by regex.firstMatch
-            totalPages = String(fullLabel[Range(resultingMatch, in: fullLabel)!])
-        }
-        
-        return totalPages
+        return getNamedGroupInRegexPatternFromText(namedGroup: "total", regexPattern: pattern, fromText: paginationLabel.label)
     }
     
 }

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -1,0 +1,63 @@
+//
+//  BaseScreen.swift
+//  VocableUITests
+//
+//  Base screen Class used for common utility methods, to share among
+//  all other screen Classes.
+//
+//  Created by Rudy Salas on 3/14/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+class BaseScreen {
+    // Define a regex pattern with named matching groups, 'current' and 'total', for reference
+    let paginationRegexPattern = #"(?<current>\d)+ of (?<total>\d)+"#
+    
+    let paginationLabel = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
+    
+    /// For Pagination: retrieve the current page (X) being viewed
+    /// from the "Page X of Y" pagination label.
+    func getCurrentPage() -> String {
+        var currentPage = ""
+        let fullLabel = paginationLabel.label
+        
+        let regex = try! NSRegularExpression(pattern: paginationRegexPattern)
+        let range = NSRange(location: 0, length: fullLabel.count) // Used for the NSRegularExpression
+        
+        // Find a match to the regex pattern...
+        if let match = regex.firstMatch(in: fullLabel, options: [], range: range) {
+            // Within the match to the regex pattern, extract the matching group by its name
+            let resultingMatch = match.range(withName: "current")
+
+            // Extract the Substring (as a String) of the found match from the range returned by regex.firstMatch
+            currentPage = String(fullLabel[Range(resultingMatch, in: fullLabel)!])
+        }
+        
+        return currentPage
+    }
+    
+    /// For Pagination: retrieve the total number of pages (Y) from the
+    ///  "Page X of Y" pagination label.
+    func getTotalNumOfPages() -> String {
+        var totalPages = ""
+        let fullLabel = paginationLabel.label
+        
+        let regex = try! NSRegularExpression(pattern: paginationRegexPattern)
+        let range = NSRange(location: 0, length: fullLabel.count) // Used for the NSRegularExpression
+        
+        // Find a match to the regex pattern...
+        if let match = regex.firstMatch(in: fullLabel, options: [], range: range) {
+            // Within the match to the regex pattern, extract the matching group by its name
+            let resultingMatch = match.range(withName: "total")
+
+            // Extract the Substring (as a String) of the found match from the range returned by regex.firstMatch
+            totalPages = String(fullLabel[Range(resultingMatch, in: fullLabel)!])
+        }
+        
+        return totalPages
+    }
+    
+}

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -16,25 +16,25 @@ class BaseScreen {
     let paginationLabel = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
     
     /**
-     This method extracts a substring from  text, that matches the named group within a defined regex pattern.
+     This method extracts a substring from text, that matches the named group within a defined regex pattern.
      
      For regex pattern #"Find (?\<groupdName\>\w)+ please"#, the \<groupName\> is matched from 'Find help please'
      to return 'help'
      
      Documentaion: https://nshipster.com/swift-regular-expressions/
     */
-    private func getNamedGroupInRegexPatternFromText(namedGroup: String, regexPattern: String, fromText: String) -> String {
+    private func getNamedGroupInRegexPatternFromText(namedGroup: String, regexPattern: String, text: String) -> String {
         var matchingText = ""
         let regex = try! NSRegularExpression(pattern: regexPattern)
-        let range = NSRange(location: 0, length: fromText.count) // Used for the NSRegularExpression
+        let range = NSRange(location: 0, length: text.count) // Used for the NSRegularExpression
         
         // Find a match to the regex pattern...
-        if let match = regex.firstMatch(in: fromText, options: [], range: range) {
+        if let match = regex.firstMatch(in: text, options: [], range: range) {
             // Within the match to the regex pattern, extract the matching group by its name
             let resultingMatch = match.range(withName: namedGroup)
 
             // Extract the Substring (as a String) of the found match from the range returned by regex.firstMatch
-            matchingText = String(fromText[Range(resultingMatch, in: fromText)!])
+            matchingText = String(text[Range(resultingMatch, in: text)!])
         }
         
         return matchingText
@@ -46,7 +46,7 @@ class BaseScreen {
         // Define a regex pattern with named matching group, 'current', for reference
         let pattern = #"(?<current>\d)+ of (\d)+"#
         
-        return getNamedGroupInRegexPatternFromText(namedGroup: "current", regexPattern: pattern, fromText: paginationLabel.label)
+        return getNamedGroupInRegexPatternFromText(namedGroup: "current", regexPattern: pattern, text: paginationLabel.label)
     }
     
     /// For Pagination: retrieve the total number of pages (Y) from the
@@ -55,7 +55,7 @@ class BaseScreen {
         // Define a regex pattern with named matching group, 'total', for reference
         let pattern = #"(\d)+ of (?<total>\d)+"#
         
-        return getNamedGroupInRegexPatternFromText(namedGroup: "total", regexPattern: pattern, fromText: paginationLabel.label)
+        return getNamedGroupInRegexPatternFromText(namedGroup: "total", regexPattern: pattern, text: paginationLabel.label)
     }
     
 }

--- a/VocableUITests/Screens/CustomCategoriesScreen.swift
+++ b/VocableUITests/Screens/CustomCategoriesScreen.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-class CustomCategoriesScreen {
+class CustomCategoriesScreen: BaseScreen {
 
     let settingsScreen = SettingsScreen()
     let keyboardScreen = KeyboardScreen()

--- a/VocableUITests/Screens/CustomCategoriesScreen.swift
+++ b/VocableUITests/Screens/CustomCategoriesScreen.swift
@@ -15,7 +15,7 @@ class CustomCategoriesScreen: BaseScreen {
     let mainScreen = MainScreen()
     
     let categoriesPageAddPhraseButton = XCUIApplication().buttons["settingsCategory.addPhraseButton"]
-    let editCategoryPhrasesCell = XCUIApplication().cells.containing(.staticText, identifier: "Edit Phrases").element
+    let editCategoryPhrasesCell = XCUIApplication().cells["edit_phrases_cell"]
     let categoriesPageEditPhraseButton = XCUIApplication().buttons["categoryPhrase.editButton"]
     let categoriesPageDeletePhraseButton = XCUIApplication().buttons["categoryPhrase.deleteButton"]
 

--- a/VocableUITests/Screens/CustomCategoriesScreen.swift
+++ b/VocableUITests/Screens/CustomCategoriesScreen.swift
@@ -15,6 +15,7 @@ class CustomCategoriesScreen {
     let mainScreen = MainScreen()
     
     let categoriesPageAddPhraseButton = XCUIApplication().buttons["settingsCategory.addPhraseButton"]
+    let editCategoryPhrasesCell = XCUIApplication().cells.containing(.staticText, identifier: "Edit Phrases").element
     let categoriesPageEditPhraseButton = XCUIApplication().buttons["categoryPhrase.editButton"]
     let categoriesPageDeletePhraseButton = XCUIApplication().buttons["categoryPhrase.deleteButton"]
 

--- a/VocableUITests/Screens/KeyboardScreen.swift
+++ b/VocableUITests/Screens/KeyboardScreen.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-class KeyboardScreen {
+class KeyboardScreen: BaseScreen {
     private let app = XCUIApplication()
     
     let keyboardTextView = XCUIApplication().textViews["keyboard.textView"]

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-class MainScreen {
+class MainScreen: BaseScreen {
     private let app = XCUIApplication()
     
     var defaultCategories = ["General", "Basic Needs", "Personal Care", "Conversation", "Environment", "123", "My Sayings", "Recents", "Listen"]

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -28,11 +28,15 @@ class SettingsScreen {
     let alertDeleteButton = XCUIApplication().buttons["Delete"]
 
     func openCategorySettings(category: String) {
-        if otherElements.containing(.staticText, identifier: category).element.exists {
-            otherElements.containing(.staticText, identifier: category).buttons["Forward"].tap()
+        var cellLabel = ""
+        let predicate = NSPredicate(format: "label CONTAINS %@", category)
+        if otherElements.staticTexts.containing(predicate).element.exists {
+            cellLabel = otherElements.staticTexts.containing(predicate).element.label
+            otherElements.containing(.staticText, identifier: cellLabel).buttons["Forward"].tap()
         } else {
+            // TODO: Ensure we avoid an infinite loop by refactoring this
             settingsPageNextButton.tap()
-            otherElements.containing(.staticText, identifier: category).buttons["Forward"].tap()
+            openCategorySettings(category: category)
         }
     }
     
@@ -72,7 +76,9 @@ class SettingsScreen {
     }
     
     func navigateToSettingsCategoryScreen() {
+        mainScreen.settingsButton.waitForExistence(timeout: 2)
         mainScreen.settingsButton.tap()
+        categoriesButton.waitForExistence(timeout: 2)
         categoriesButton.tap()
     }
     

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-class SettingsScreen {
+class SettingsScreen: BaseScreen {
     let mainScreen = MainScreen()
     let keyboardScreen = KeyboardScreen()
     
@@ -30,13 +30,17 @@ class SettingsScreen {
     func openCategorySettings(category: String) {
         var cellLabel = ""
         let predicate = NSPredicate(format: "label CONTAINS %@", category)
-        if otherElements.staticTexts.containing(predicate).element.exists {
-            cellLabel = otherElements.staticTexts.containing(predicate).element.label
-            otherElements.containing(.staticText, identifier: cellLabel).buttons["Forward"].tap()
-        } else {
-            // TODO: Ensure we avoid an infinite loop by refactoring this
-            settingsPageNextButton.tap()
-            openCategorySettings(category: category)
+        
+        // Loop through each page to find our category
+        let totalNumOfPages = Int(getTotalNumOfPages())!
+        for _ in 1...totalNumOfPages {
+            if otherElements.staticTexts.containing(predicate).element.exists {
+                cellLabel = otherElements.staticTexts.containing(predicate).element.label
+                otherElements.containing(.staticText, identifier: cellLabel).buttons["Forward"].tap()
+                break
+            } else {
+                settingsPageNextButton.tap()
+            }
         }
     }
     
@@ -76,9 +80,9 @@ class SettingsScreen {
     }
     
     func navigateToSettingsCategoryScreen() {
-        mainScreen.settingsButton.waitForExistence(timeout: 2)
+        _ = mainScreen.settingsButton.waitForExistence(timeout: 2)
         mainScreen.settingsButton.tap()
-        categoriesButton.waitForExistence(timeout: 2)
+        _ = categoriesButton.waitForExistence(timeout: 2)
         categoriesButton.tap()
     }
     

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -32,8 +32,7 @@ class SettingsScreen: BaseScreen {
         let predicate = NSPredicate(format: "label CONTAINS %@", category)
         
         // Loop through each page to find our category
-        let totalNumOfPages = Int(getTotalNumOfPages())!
-        for _ in 1...totalNumOfPages {
+        for _ in 1...totalPageCount {
             if otherElements.staticTexts.containing(predicate).element.exists {
                 cellLabel = otherElements.staticTexts.containing(predicate).element.label
                 otherElements.containing(.staticText, identifier: cellLabel).buttons["Forward"].tap()

--- a/VocableUITests/Tests/BaseTest.swift
+++ b/VocableUITests/Tests/BaseTest.swift
@@ -39,4 +39,9 @@ class BaseTest: XCTestCase {
         attachment.lifetime = .deleteOnSuccess
         add(attachment)
     }
+    
+    func randomString(length: Int) -> String {
+        let letters = "abcdefghijklmnopqrstuvwxyz"
+        return String((0..<length).map { _ in letters.randomElement()! })
+    }
 }

--- a/VocableUITests/Tests/CustomCategoriesBaseTest.swift
+++ b/VocableUITests/Tests/CustomCategoriesBaseTest.swift
@@ -1,0 +1,34 @@
+//
+//  CustomCategoriesBaseTest.swift
+//  VocableUITests
+//
+//  Created by Rudy Salas on 3/10/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import XCTest
+
+class CustomCategoriesBaseTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+        XCUIApplication().launch()
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+}

--- a/VocableUITests/Tests/CustomCategoriesBaseTest.swift
+++ b/VocableUITests/Tests/CustomCategoriesBaseTest.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class CustomCategoriesBaseTest: BaseTest {
     
-    var customCategory: String = ""
+    private(set) var customCategoryName: String = ""
     
     override func setUp() {
         super.setUp()
@@ -19,12 +19,12 @@ class CustomCategoriesBaseTest: BaseTest {
         
         // Create a custom category and open it
         settingsScreen.navigateToSettingsCategoryScreen()
-        customCategoriesScreen.createCustomCategory(categoryName: customCategory)
-        settingsScreen.openCategorySettings(category: customCategory)
+        customCategoriesScreen.createCustomCategory(categoryName: customCategoryName)
+        settingsScreen.openCategorySettings(category: customCategoryName)
     }
     
-    func setCustomCategory(name: String, numOfRandomLetters: Int) {
-        customCategory = name + randomString(length: numOfRandomLetters).lowercased()
+    private func setCustomCategory(name: String, numOfRandomLetters: Int) {
+        customCategoryName = name + randomString(length: numOfRandomLetters)
     }
     
     override func tearDown() {

--- a/VocableUITests/Tests/CustomCategoriesBaseTest.swift
+++ b/VocableUITests/Tests/CustomCategoriesBaseTest.swift
@@ -8,27 +8,26 @@
 
 import XCTest
 
-class CustomCategoriesBaseTest: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-        XCUIApplication().launch()
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+class CustomCategoriesBaseTest: BaseTest {
+    
+    var customCategory: String = ""
+    
+    override func setUp() {
+        super.setUp()
+        
+        setCustomCategory(name: "Hi", numOfRandomLetters: 3)
+        
+        // Create a custom category and open it
+        settingsScreen.navigateToSettingsCategoryScreen()
+        customCategoriesScreen.createCustomCategory(categoryName: customCategory)
+        settingsScreen.openCategorySettings(category: customCategory)
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    
+    func setCustomCategory(name: String, numOfRandomLetters: Int) {
+        customCategory = name + randomString(length: numOfRandomLetters).lowercased()
     }
-
-    func testExample() throws {
-        // Use recording to get started writing UI tests.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    
+    override func tearDown() {
+        super.tearDown()
     }
-
 }

--- a/VocableUITests/Tests/CustomCategoriesTests.swift
+++ b/VocableUITests/Tests/CustomCategoriesTests.swift
@@ -41,7 +41,6 @@ class CustomCategoriesTest: CustomCategoriesBaseTest {
         XCTAssert(mainScreen.isTextDisplayed("A"+customPhrase), "Expected the phrase \("A"+customPhrase) to be displayed")
     }
 
-    // TODO: WE MAY WANT TO PULL THIS OUT OF THE TEST SUITE; ADD TO ITS OWN. THIS TEST EDITS THE PHRASE, INSTEAD OF THE CATEGORY
     func testCustomPhraseEdit() {
         let customPhrase = "Add" + randomString(length: 2)
         
@@ -100,7 +99,8 @@ class CustomCategoriesTest: CustomCategoriesBaseTest {
         XCTAssertEqual(phraseQuery.count, 2, "Expected both phrases to be present")
     }
     
-    // TODO: Re-Enable this test and fix it or move it to a different test class
+    // TODO: Disabled for now. Moving it to a different test class as part of issue #405
+    // https://github.com/willowtreeapps/vocable-ios/issues/405
     func testPagination() {
         let customCategoryThree = "Testc"
         let createdCustomCategory = ("9. "+customCategoryThree)

--- a/VocableUITests/Tests/CustomCategoriesTests.swift
+++ b/VocableUITests/Tests/CustomCategoriesTests.swift
@@ -8,18 +8,14 @@
 
 import XCTest
 
-class CustomCategoriesTest: BaseTest {
-    let customCategory = "Createnewcategory"
+class CustomCategoriesTest: CustomCategoriesBaseTest {
 
     func testAddNewPhrase() {
-        let customPhrase = "ddingcustomcategoryphrasetest"
+        let customPhrase = "dd"
         let confirmationAlert = "Are you sure? Going back before saving will clear any edits made."
-        let createdCustomCategory = ("9. "+customCategory)
         
-        // Add a new Category and navigate into it
-        settingsScreen.navigateToSettingsCategoryScreen()
-        customCategoriesScreen.createCustomCategory(categoryName: customCategory)
-        settingsScreen.openCategorySettings(category: createdCustomCategory)
+        // Navigate to our test category (created in the base class setup() method)
+        customCategoriesScreen.editCategoryPhrasesCell.tap()
         customCategoriesScreen.categoriesPageAddPhraseButton.tap()
 
         // Verify Phrase is not added if edits are discarded
@@ -45,14 +41,15 @@ class CustomCategoriesTest: BaseTest {
         XCTAssert(mainScreen.isTextDisplayed("A"+customPhrase), "Expected the phrase \("A"+customPhrase) to be displayed")
     }
 
+    // TODO: WE MAY WANT TO PULL THIS OUT OF THE TEST SUITE; ADD TO ITS OWN. THIS TEST EDITS THE PHRASE, INSTEAD OF THE CATEGORY
     func testCustomPhraseEdit() {
-        // This test builds off of the last test.
-        let customPhrase = "Addingcustomcategoryphrasetest"
-        let createdCustomCategory = ("9. "+customCategory)
-
-        // Navigate to Custom Category
-        settingsScreen.navigateToSettingsCategoryScreen()
-        settingsScreen.openCategorySettings(category: createdCustomCategory)
+        let customPhrase = "Add" + randomString(length: 2)
+        
+        // Add our test phrase
+        customCategoriesScreen.editCategoryPhrasesCell.tap()
+        customCategoriesScreen.categoriesPageAddPhraseButton.tap()
+        keyboardScreen.typeText(customPhrase)
+        keyboardScreen.checkmarkAddButton.tap()
         
         // Edit the phrase
         customCategoriesScreen.categoriesPageEditPhraseButton.tap()
@@ -63,63 +60,47 @@ class CustomCategoriesTest: BaseTest {
     
     func testDeleteCustomPhrase() {
         // This test builds off of the last test.
-        let customPhrase = "Test"
-        let createdCustomCategory = ("9. "+customCategory)
-
-        // Navigate to custom category
-        settingsScreen.navigateToSettingsCategoryScreen()
-        settingsScreen.openCategorySettings(category: createdCustomCategory)
+        let customPhrase = "Delete" + randomString(length: 2)
+        
+        // Add our test phrase
+        customCategoriesScreen.editCategoryPhrasesCell.tap()
+        customCategoriesScreen.categoriesPageAddPhraseButton.tap()
+        keyboardScreen.typeText(customPhrase)
+        keyboardScreen.checkmarkAddButton.tap()
+        
+        // Confirm that our phrase to-be-deleted has been created
+        // TODO: MAKE A isTextDisplayed HELPER METHOD THAT IS AGNOSTIC OF SCREEN...each screen class has its own?
+        XCTAssert(mainScreen.isTextDisplayed(customPhrase), "Expected the phrase \(customPhrase) to be displayed")
         
         customCategoriesScreen.categoriesPageDeletePhraseButton.tap()
         settingsScreen.alertDeleteButton.tap()
         XCTAssertFalse(mainScreen.isTextDisplayed(customPhrase), "Expected the phrase \(customPhrase) to not be displayed")
     }
     
-    func testDuplicatePhrasesInDifferentCategories() {
-        // This test builds off of the last test.
+    func testCanAddDuplicatePhrasesToCategories() {
+        let testPhrase = "Testa"
 
-        let createdCustomCategory = ("9. "+customCategory)
-        let customCategoryTwo = "Testb"
-        let customPhrase = "Testa"
-
-        // Test Setup
-        settingsScreen.navigateToSettingsCategoryScreen()
-        settingsScreen.openCategorySettings(category: createdCustomCategory)
+        // Add our first test phrase
+        customCategoriesScreen.editCategoryPhrasesCell.tap()
         customCategoriesScreen.categoriesPageAddPhraseButton.tap()
-        keyboardScreen.typeText(customPhrase)
+        keyboardScreen.typeText(testPhrase)
         keyboardScreen.checkmarkAddButton.tap()
-        settingsScreen.leaveCategoryDetailButton.tap()
+        
+        // Assert that our phrase was added
+        XCTAssertTrue(mainScreen.isTextDisplayed(testPhrase), "Expected our first phrase to be added to category.")
 
-        // Navigate to Settings and create a custom category
-        customCategoriesScreen.createCustomCategory(categoryName: customCategoryTwo)
-        
-        // Add an existing custom phrase
-        settingsScreen.openCategorySettings(category: "10. "+customCategoryTwo)
+        // Add the same phrase again to the same category
         customCategoriesScreen.categoriesPageAddPhraseButton.tap()
-        keyboardScreen.typeText(customPhrase)
+        keyboardScreen.typeText(testPhrase)
         keyboardScreen.checkmarkAddButton.tap()
         
-        // Edit first phrase.
-        settingsScreen.leaveCategoryDetailButton.tap()
-        settingsScreen.openCategorySettings(category: createdCustomCategory)
-        customCategoriesScreen.categoriesPageEditPhraseButton.tap()
-        keyboardScreen.typeText("Two")
-        keyboardScreen.checkmarkAddButton.tap()
-        
-        XCTAssert(mainScreen.isTextDisplayed(customPhrase+"two"), "Expected the phrase \(customPhrase+"two") to be displayed")
-        
-        // Go back to the other category
-        settingsScreen.leaveCategoryDetailButton.tap()
-        settingsScreen.openCategorySettings(category: "10. "+customCategoryTwo)
-        XCTAssert(mainScreen.isTextDisplayed(customPhrase), "Expected the phrase \(customPhrase) to be displayed")
-        
-        // Cleanup: Hide categories for now until delete feature is implemented so Automation tests pass:
-        settingsScreen.leaveCategoryDetailButton.tap()
-        settingsScreen.toggleHideShowCategory(category: "9. "+customCategory, toggle: "Hide")
-        settingsScreen.toggleHideShowCategory(category: "9. "+customCategoryTwo, toggle: "Hide")
-        
+        // Assert that now we have two cells containing the same phrase
+        let phrasePredicate = NSPredicate(format: "label MATCHES %@", testPhrase)
+        let phraseQuery = XCUIApplication().staticTexts.containing(phrasePredicate)
+        XCTAssertEqual(phraseQuery.count, 2, "Expected both phrases to be present")
     }
     
+    // TODO: Re-Enable this test and fix it or move it to a different test class
     func testPagination() {
         let customCategoryThree = "Testc"
         let createdCustomCategory = ("9. "+customCategoryThree)


### PR DESCRIPTION
This PR closes #464 

The parent issue to #464 is #405

# Description of Work
Unlinked the tests defined in CustomCategoriesTests by creating a new base test Class for them; CustomCategoriesBaseTest. This new Class sets up a random custom category at the onset of each test.

Other work included refactors to the existing tests to account for new/changed flows and corrections to element queries.

------

## Notes to Test
All tests in CustomCategoriesTests should pass now. There is one test we left disabled. There is a sub-task in parent ticket #405 for addressing this test, and those like it.
