### PR TITLE
#465 Allow categories and phrases to be universally editable

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		6B5C490D245CB92700A4433C /* CategoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C490C245CB92700A4433C /* CategoryDetailViewController.swift */; };
 		6B5C490F2460627B00A4433C /* NumericCategoryContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C490E2460627A00A4433C /* NumericCategoryContentViewController.swift */; };
 		6B5C49112460AEF900A4433C /* RootEditTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C49102460AEF900A4433C /* RootEditTextViewController.swift */; };
+		6B5C73A727DFE61600004713 /* PredicateBuilders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C73A627DFE61600004713 /* PredicateBuilders.swift */; };
+		6B5C73A927DFE63600004713 /* NSPredicate+Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C73A827DFE63600004713 /* NSPredicate+Operators.swift */; };
 		6B6A4D9125B7609900A7F489 /* ListeningModeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6A4D9025B7609900A7F489 /* ListeningModeViewController.swift */; };
 		6B724A4D25E046BA0033891F /* SettingsFooterTextSupplementaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B724A4B25E046B90033891F /* SettingsFooterTextSupplementaryView.swift */; };
 		6B724A4E25E046BA0033891F /* SettingsFooterTextSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6B724A4C25E046B90033891F /* SettingsFooterTextSupplementaryView.xib */; };
@@ -249,6 +251,8 @@
 		6B5C490E2460627A00A4433C /* NumericCategoryContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericCategoryContentViewController.swift; sourceTree = "<group>"; };
 		6B5C49102460AEF900A4433C /* RootEditTextViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootEditTextViewController.swift; sourceTree = "<group>"; };
 		6B5C73A527DFACBA00004713 /* Phrases v4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Phrases v4.xcdatamodel"; sourceTree = "<group>"; };
+		6B5C73A627DFE61600004713 /* PredicateBuilders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredicateBuilders.swift; sourceTree = "<group>"; };
+		6B5C73A827DFE63600004713 /* NSPredicate+Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPredicate+Operators.swift"; sourceTree = "<group>"; };
 		6B6A4D9025B7609900A7F489 /* ListeningModeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningModeViewController.swift; sourceTree = "<group>"; };
 		6B724A4B25E046B90033891F /* SettingsFooterTextSupplementaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFooterTextSupplementaryView.swift; sourceTree = "<group>"; };
 		6B724A4C25E046B90033891F /* SettingsFooterTextSupplementaryView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsFooterTextSupplementaryView.xib; sourceTree = "<group>"; };
@@ -814,6 +818,8 @@
 				9DB58D4822666BC200E99C3B /* UIColor+AppExtensions.swift */,
 				B8DA9DF323F30BD200FEBE19 /* VectorUtils.swift */,
 				6B724AA225E9774E0033891F /* UIEdgeInsets+Operators.swift */,
+				6B5C73A627DFE61600004713 /* PredicateBuilders.swift */,
+				6B5C73A827DFE63600004713 /* NSPredicate+Operators.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1094,6 +1100,7 @@
 				6BB56BA82422AC2500EA787E /* ToastView.swift in Sources */,
 				64B3259B254B591D00023566 /* EditCategoryRemoveCollectionViewCell.swift in Sources */,
 				A9DFCC20242D020100136136 /* PublishedValue.swift in Sources */,
+				6B5C73A727DFE61600004713 /* PredicateBuilders.swift in Sources */,
 				A9C32CFF242271F3000EC6F7 /* Phrase+Helpers.swift in Sources */,
 				64981D7C258A8014007EFA82 /* VocableChoicesModel.mlmodel in Sources */,
 				64F49906245B40BC00348592 /* SettingsViewController.swift in Sources */,
@@ -1156,6 +1163,7 @@
 				6BE7E98C245A19F8007B01F2 /* UITraitCollection+Helpers.swift in Sources */,
 				718D7FAE2419546F00FDEF93 /* EditPhrasesCollectionViewCell.swift in Sources */,
 				A9299C7523F5FBEE00903AB6 /* KeyboardKeyCollectionViewCell.swift in Sources */,
+				6B5C73A927DFE63600004713 /* NSPredicate+Operators.swift in Sources */,
 				6B9DFA5B23E889DB0037673E /* UIHeadGazeViewController.swift in Sources */,
 				6BB56BAA2422B40300EA787E /* PublishedDefault.swift in Sources */,
 				6B823BCD23F4ADE30099F65E /* TunningWindow.swift in Sources */,

--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		6B5C490C245CB92700A4433C /* CategoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailViewController.swift; sourceTree = "<group>"; };
 		6B5C490E2460627A00A4433C /* NumericCategoryContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericCategoryContentViewController.swift; sourceTree = "<group>"; };
 		6B5C49102460AEF900A4433C /* RootEditTextViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootEditTextViewController.swift; sourceTree = "<group>"; };
+		6B5C73A527DFACBA00004713 /* Phrases v4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Phrases v4.xcdatamodel"; sourceTree = "<group>"; };
 		6B6A4D9025B7609900A7F489 /* ListeningModeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningModeViewController.swift; sourceTree = "<group>"; };
 		6B724A4B25E046B90033891F /* SettingsFooterTextSupplementaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFooterTextSupplementaryView.swift; sourceTree = "<group>"; };
 		6B724A4C25E046B90033891F /* SettingsFooterTextSupplementaryView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsFooterTextSupplementaryView.xib; sourceTree = "<group>"; };
@@ -1751,11 +1752,12 @@
 		6BFB18C024002C7B002C3515 /* Phrases.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				6B5C73A527DFACBA00004713 /* Phrases v4.xcdatamodel */,
 				6B1086712463102F00E729A8 /* Phrases v3.xcdatamodel */,
 				B8D55689242FE8B900B0F6FE /* Phrases v2.xcdatamodel */,
 				6BFB18C124002C7B002C3515 /* Phrases.xcdatamodel */,
 			);
-			currentVersion = 6B1086712463102F00E729A8 /* Phrases v3.xcdatamodel */;
+			currentVersion = 6B5C73A527DFACBA00004713 /* Phrases v4.xcdatamodel */;
 			path = Phrases.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -159,11 +159,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let request: NSFetchRequest<Phrase> = Phrase.fetchRequest()
         request.predicate = {
-            let identifiers = Set(presets.phrases.map { $0.id })
-            let isNotUserGenerated = NSComparisonPredicate(\Phrase.isUserGenerated, .equalTo, false)
-            let identifierInSet = NSComparisonPredicate(\Phrase.identifier, .in, identifiers)
-            let identifierNotInSet = NSCompoundPredicate(notPredicateWithSubpredicate: identifierInSet)
-            return NSCompoundPredicate(andPredicateWithSubpredicates: [isNotUserGenerated, identifierNotInSet])
+            let identifiers = Set(presets.phrases.map(\.id))
+            let isNotUserGenerated = !Predicate(\Phrase.isUserGenerated)
+            let identifierNotInSet = !Predicate(\Phrase.identifier, .in, identifiers)
+            return isNotUserGenerated && identifierNotInSet
         }()
 
         let results = try context.fetch(request)
@@ -177,10 +176,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let request: NSFetchRequest<Category> = Category.fetchRequest()
         request.predicate = {
             let identifiers = Set(presets.categories.map { $0.id })
-            let isNotUserGenerated = NSComparisonPredicate(\Category.isUserGenerated, .equalTo, false)
-            let identifierInSet = NSComparisonPredicate(\Category.identifier, .in, identifiers)
-            let identifierNotInSet = NSCompoundPredicate(notPredicateWithSubpredicate: identifierInSet)
-            return NSCompoundPredicate(andPredicateWithSubpredicates: [isNotUserGenerated, identifierNotInSet])
+            let isNotUserGenerated = !Predicate(\Category.isUserGenerated)
+            let identifierNotInSet = !Predicate(\Category.identifier, .in, identifiers)
+            return isNotUserGenerated && identifierNotInSet
         }()
 
         let results = try context.fetch(request)
@@ -195,10 +193,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // Legacy favorites category was .isUserGenerated = true with identifier = localized version
             // of "My Sayings." Going forward, all identifiers for Phrases/Categories are prefixed, so
             // we can use that to isolate the legacy category entry
-            let isUserGenerated = NSComparisonPredicate(\Category.isUserGenerated, .equalTo, true)
-            let identifierPrefixed = NSComparisonPredicate(\Category.identifier, .beginsWith, "user_")
-            let identifierNotPrefixed = NSCompoundPredicate(notPredicateWithSubpredicate: identifierPrefixed)
-            return NSCompoundPredicate(andPredicateWithSubpredicates: [isUserGenerated, identifierNotPrefixed])
+            let isUserGenerated = Predicate(\Category.isUserGenerated)
+            let identifierNotPrefixed = !Predicate(\Category.identifier, .beginsWith, "user_")
+            return isUserGenerated && identifierNotPrefixed
         }()
 
         let results = try context.fetch(request)

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -159,10 +159,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let request: NSFetchRequest<Phrase> = Phrase.fetchRequest()
         request.predicate = {
-            let identifiers = Set(presets.phrases.map(\.id))
+            let presetPhraseIdentifiers = Set(presets.phrases.map(\.id))
             let isNotUserGenerated = !Predicate(\Phrase.isUserGenerated)
-            let identifierNotInSet = !Predicate(\Phrase.identifier, .in, identifiers)
-            return isNotUserGenerated && identifierNotInSet
+            let isNotPresetPhrase = !Predicate(\Phrase.identifier, isContainedIn: presetPhraseIdentifiers)
+            return isNotUserGenerated && isNotPresetPhrase
         }()
 
         let results = try context.fetch(request)
@@ -175,10 +175,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let request: NSFetchRequest<Category> = Category.fetchRequest()
         request.predicate = {
-            let identifiers = Set(presets.categories.map { $0.id })
+            let presetCategoryIdentifiers = Set(presets.categories.map(\.id))
             let isNotUserGenerated = !Predicate(\Category.isUserGenerated)
-            let identifierNotInSet = !Predicate(\Category.identifier, .in, identifiers)
-            return isNotUserGenerated && identifierNotInSet
+            let isNotPresetCategory = !Predicate(\Category.identifier, isContainedIn: presetCategoryIdentifiers)
+            return isNotUserGenerated && isNotPresetCategory
         }()
 
         let results = try context.fetch(request)
@@ -193,9 +193,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // Legacy favorites category was .isUserGenerated = true with identifier = localized version
             // of "My Sayings." Going forward, all identifiers for Phrases/Categories are prefixed, so
             // we can use that to isolate the legacy category entry
-            let isUserGenerated = Predicate(\Category.isUserGenerated)
-            let identifierNotPrefixed = !Predicate(\Category.identifier, .beginsWith, "user_")
-            return isUserGenerated && identifierNotPrefixed
+            let isUserGeneratedCategory = Predicate(\Category.isUserGenerated)
+            let isNotUserPrefixed = !Predicate(\Category.identifier, beginsWith: "user_")
+            return isUserGeneratedCategory && isNotUserPrefixed
         }()
 
         let results = try context.fetch(request)

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -218,8 +218,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func updateDefaultCategories(in context: NSManagedObjectContext, withPresets presets: PresetData) throws {
         for presetCategory in presets.categories {
             let category = Category.fetchOrCreate(in: context, matching: presetCategory.id)
-            category.name = presetCategory.utterance
-            category.languageCode = presetCategory.languageCode
+            if !category.isUserRenamed {
+                category.name = presetCategory.utterance
+                category.languageCode = presetCategory.languageCode
+            }
             if category.isInserted {
                 category.isHidden = presetCategory.hidden
             }

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -227,9 +227,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         for presetPhrase in presets.phrases {
 
             let phrase = Phrase.fetchOrCreate(in: context, matching: presetPhrase.id)
-            phrase.utterance = presetPhrase.utterance
-            phrase.languageCode = presetPhrase.languageCode
-            
+            if !phrase.isUserRenamed {
+                phrase.utterance = presetPhrase.utterance
+                phrase.languageCode = presetPhrase.languageCode
+            }
             for identifier in presetPhrase.categoryIds {
                 if let category = Category.fetchObject(in: context, matching: identifier) {
                     phrase.category = category

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -208,8 +208,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         try updateDefaultCategories(in: context, withPresets: presets)
         try updateDefaultPhrases(in: context, withPresets: presets)
-        try updateCategoryForUserGeneratedPhrases(in: context)
-
     }
 
     private func updateDefaultCategories(in context: NSManagedObjectContext, withPresets presets: PresetData) throws {
@@ -238,22 +236,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     category.addToPhrases(phrase)
                 }
             }
-        }
-    }
-
-    private func updateCategoryForUserGeneratedPhrases(in context: NSManagedObjectContext) throws {
-        let mySayingsCategory = Category.fetch(.userFavorites, in: context)
-        let request: NSFetchRequest<Phrase> = Phrase.fetchRequest()
-
-        let firstPredicate = NSComparisonPredicate(\Phrase.isUserGenerated, .equalTo, true)
-        let secondPredicate = NSComparisonPredicate(\Phrase.category?.isUserGenerated, .equalTo, false)
-        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [firstPredicate, secondPredicate])
-
-        let phraseResults = try context.fetch(request)
-
-        for phrase in phraseResults {
-            phrase.category = mySayingsCategory
-            mySayingsCategory.addToPhrases(phrase)
         }
     }
 }

--- a/Vocable/CoreData/ModelObjectExtensions.swift
+++ b/Vocable/CoreData/ModelObjectExtensions.swift
@@ -47,5 +47,6 @@ extension Phrase: NSManagedObjectIdentifiable {
         setPrimitiveValue(Date(), forKey: #keyPath(creationDate))
         setPrimitiveValue(false, forKey: #keyPath(isUserGenerated))
         setPrimitiveValue(false, forKey: #keyPath(isUserRemoved))
+        setPrimitiveValue(false, forKey: #keyPath(isUserRenamed))
     }
 }

--- a/Vocable/CoreData/ModelObjectExtensions.swift
+++ b/Vocable/CoreData/ModelObjectExtensions.swift
@@ -16,6 +16,8 @@ extension Category: NSManagedObjectIdentifiable {
         setPrimitiveValue(Date(), forKey: #keyPath(creationDate))
         setPrimitiveValue(false, forKey: #keyPath(isUserGenerated))
         setPrimitiveValue(Int32.max, forKey: #keyPath(ordinal))
+        setPrimitiveValue(false, forKey: #keyPath(isUserRemoved))
+        setPrimitiveValue(false, forKey: #keyPath(isUserRenamed))
     }
 
     static func userFavoritesCategoryName() -> String {
@@ -44,5 +46,6 @@ extension Phrase: NSManagedObjectIdentifiable {
         super.awakeFromInsert()
         setPrimitiveValue(Date(), forKey: #keyPath(creationDate))
         setPrimitiveValue(false, forKey: #keyPath(isUserGenerated))
+        setPrimitiveValue(false, forKey: #keyPath(isUserRemoved))
     }
 }

--- a/Vocable/CoreData/NSManagedObject+Helpers.swift
+++ b/Vocable/CoreData/NSManagedObject+Helpers.swift
@@ -48,23 +48,3 @@ extension NSManagedObjectIdentifiable where Self: NSManagedObject {
     }
     
 }
-
-extension NSComparisonPredicate {
-    convenience init<A, B>(_ lhsKeyPath: KeyPath<A, B>, _ operationType: Operator, _ rhsValue: B) {
-        let lhs = NSExpression(forKeyPath: lhsKeyPath)
-        let rhs = NSExpression(forConstantValue: rhsValue)
-        self.init(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operationType)
-    }
-
-    convenience init<A, B, C: Collection>(_ lhsKeyPath: KeyPath<A, B>, _ operationType: Operator, _ rhsValue: C) where C.Element == B {
-        let lhs = NSExpression(forKeyPath: lhsKeyPath)
-        let rhs = NSExpression(forConstantValue: rhsValue)
-        self.init(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operationType)
-    }
-    
-    convenience init<A, B: NSFastEnumeration, C: NSObjectProtocol>(_ lhsKeyPath: KeyPath<A, B?>, _ operationType: Operator, _ rhsValue: C) {
-        let lhs = NSExpression(forKeyPath: lhsKeyPath)
-        let rhs = NSExpression(forConstantValue: rhsValue)
-        self.init(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operationType)
-    }
-}

--- a/Vocable/CoreData/Phrases.xcdatamodeld/.xccurrentversion
+++ b/Vocable/CoreData/Phrases.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Phrases v3.xcdatamodel</string>
+	<string>Phrases v4.xcdatamodel</string>
 </dict>
 </plist>

--- a/Vocable/CoreData/Phrases.xcdatamodeld/Phrases v4.xcdatamodel/contents
+++ b/Vocable/CoreData/Phrases.xcdatamodeld/Phrases v4.xcdatamodel/contents
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21D62" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Category" representedClassName="Category" syncable="YES" codeGenerationType="class">
+        <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="isHidden" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isUserGenerated" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isUserRemoved" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isUserRenamed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="languageCode" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="ordinal" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="phrases" toMany="YES" deletionRule="Cascade" destinationEntity="Phrase" inverseName="category" inverseEntity="Phrase"/>
+    </entity>
+    <entity name="Phrase" representedClassName="Phrase" syncable="YES" codeGenerationType="class">
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="isUserGenerated" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isUserRemoved" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="languageCode" optional="YES" attributeType="String"/>
+        <attribute name="lastSpokenDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="utterance" optional="YES" attributeType="String"/>
+        <relationship name="category" maxCount="1" deletionRule="Nullify" destinationEntity="Category" inverseName="phrases" inverseEntity="Category" elementID="categoryRelationship"/>
+    </entity>
+    <elements>
+        <element name="Category" positionX="-63" positionY="-18" width="128" height="179"/>
+        <element name="Phrase" positionX="-54" positionY="-9" width="128" height="149"/>
+    </elements>
+</model>

--- a/Vocable/CoreData/Phrases.xcdatamodeld/Phrases v4.xcdatamodel/contents
+++ b/Vocable/CoreData/Phrases.xcdatamodeld/Phrases v4.xcdatamodel/contents
@@ -17,6 +17,7 @@
         <attribute name="identifier" attributeType="String"/>
         <attribute name="isUserGenerated" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isUserRemoved" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isUserRenamed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="languageCode" optional="YES" attributeType="String"/>
         <attribute name="lastSpokenDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="utterance" optional="YES" attributeType="String"/>
@@ -24,6 +25,6 @@
     </entity>
     <elements>
         <element name="Category" positionX="-63" positionY="-18" width="128" height="179"/>
-        <element name="Phrase" positionX="-54" positionY="-9" width="128" height="149"/>
+        <element name="Phrase" positionX="-54" positionY="-9" width="128" height="164"/>
     </elements>
 </model>

--- a/Vocable/Extensions/Category+Helpers.swift
+++ b/Vocable/Extensions/Category+Helpers.swift
@@ -39,6 +39,26 @@ extension Category {
             guard let lhs = lhs else { return true }
             return rhs.rawValue != lhs
         }
+
+        fileprivate var allowsCustomPhrases: Bool {
+            switch self {
+            case .userFavorites:
+                return true
+            case .numPad, .recents, .listeningMode:
+                return false
+            }
+        }
+    }
+
+    var allowsCustomPhrases: Bool {
+        guard let categoryID = self.identifier else {
+            assertionFailure("No identifier present")
+            return false
+        }
+        if let specialIdentifier = Identifier(rawValue: categoryID) {
+            return specialIdentifier.allowsCustomPhrases
+        }
+        return true
     }
 
     static func fetch(_ identifier: Identifier, in context: NSManagedObjectContext) -> Category {

--- a/Vocable/Extensions/Category+Helpers.swift
+++ b/Vocable/Extensions/Category+Helpers.swift
@@ -82,6 +82,7 @@ extension Category {
     static func updateAllOrdinalValues(in context: NSManagedObjectContext) throws {
 
         let request: NSFetchRequest<Category> = Category.fetchRequest()
+        request.predicate = !Predicate(\Category.isUserRemoved)
         request.sortDescriptors = [
             NSSortDescriptor(keyPath: \Category.ordinal, ascending: true),
             NSSortDescriptor(keyPath: \Category.creationDate, ascending: true)

--- a/Vocable/Extensions/NSPredicate+Operators.swift
+++ b/Vocable/Extensions/NSPredicate+Operators.swift
@@ -10,23 +10,23 @@ import Foundation
 
 extension NSPredicate {
 
-    public static func && (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSPredicate {
+    static func && (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSPredicate {
         NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
     }
 
-    public static func || (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSPredicate {
+    static func || (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSPredicate {
         NSCompoundPredicate(orPredicateWithSubpredicates: [lhs, rhs])
     }
 
-    public static prefix func ! (_ lhs: NSPredicate) -> NSPredicate {
+    static prefix func ! (_ lhs: NSPredicate) -> NSPredicate {
         NSCompoundPredicate(notPredicateWithSubpredicate: lhs)
     }
 
-    public static func &= (_ lhs: inout NSPredicate, _ rhs: NSPredicate) {
+    static func &= (_ lhs: inout NSPredicate, _ rhs: NSPredicate) {
         lhs = NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
     }
 
-    public static func |= (_ lhs: inout NSPredicate, _ rhs: NSPredicate) {
+    static func |= (_ lhs: inout NSPredicate, _ rhs: NSPredicate) {
         lhs = NSCompoundPredicate(orPredicateWithSubpredicates: [lhs, rhs])
     }
 }

--- a/Vocable/Extensions/NSPredicate+Operators.swift
+++ b/Vocable/Extensions/NSPredicate+Operators.swift
@@ -1,0 +1,32 @@
+//
+//  NSPredicate+Operators.swift
+//  Vocable
+//
+//  Created by Chris Stroud on 3/14/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import Foundation
+
+extension NSPredicate {
+
+    public static func && (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSCompoundPredicate {
+        NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
+    }
+
+    public static func || (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSCompoundPredicate {
+        NSCompoundPredicate(orPredicateWithSubpredicates: [lhs, rhs])
+    }
+
+    public static prefix func ! (_ lhs: NSPredicate) -> NSPredicate {
+        NSCompoundPredicate(notPredicateWithSubpredicate: lhs)
+    }
+
+    public static func &= (_ lhs: inout NSPredicate, _ rhs: NSPredicate) {
+        lhs = NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
+    }
+
+    public static func |= (_ lhs: inout NSPredicate, _ rhs: NSPredicate) {
+        lhs = NSCompoundPredicate(orPredicateWithSubpredicates: [lhs, rhs])
+    }
+}

--- a/Vocable/Extensions/NSPredicate+Operators.swift
+++ b/Vocable/Extensions/NSPredicate+Operators.swift
@@ -10,11 +10,11 @@ import Foundation
 
 extension NSPredicate {
 
-    public static func && (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSCompoundPredicate {
+    public static func && (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSPredicate {
         NSCompoundPredicate(andPredicateWithSubpredicates: [lhs, rhs])
     }
 
-    public static func || (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSCompoundPredicate {
+    public static func || (_ lhs: NSPredicate, _ rhs: NSPredicate) -> NSPredicate {
         NSCompoundPredicate(orPredicateWithSubpredicates: [lhs, rhs])
     }
 

--- a/Vocable/Extensions/PredicateBuilders.swift
+++ b/Vocable/Extensions/PredicateBuilders.swift
@@ -1,0 +1,177 @@
+//
+//  NSComparisonPredicate+KeyPath.swift
+//  Vocable
+//
+//  Created by Chris Stroud on 3/14/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import Foundation
+
+typealias PredicateOperator = NSComparisonPredicate.Operator
+
+/// Constructs an `NSPredicate` where the given `KeyPath` must equal `true`
+///
+/// - Parameter lhs: `KeyPath` with a `Bool`value that is used for comparison
+/// - Returns: `NSPredicate`
+func Predicate<A>(_ lhs: KeyPath<A, Bool>) -> NSPredicate {
+    Predicate(lhs, equalTo: true)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` must equal the given value
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value must equal `rhs`
+///   - rhs: value which `lhs` must equal
+/// - Returns: `NSPredicate`
+func Predicate<A, B>(_ lhs: KeyPath<A, B>, equalTo rhs: B) -> NSPredicate {
+    Predicate(lhs, .equalTo, rhs)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` must not equal the given value
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value must not equal `rhs`
+///   - rhs: value which `lhs` must not equal
+/// - Returns: `NSPredicate`
+func Predicate<A, B>(_ lhs: KeyPath<A, B>, notEqualTo rhs: B) -> NSPredicate {
+    Predicate(lhs, .notEqualTo, rhs)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` is compared to the given value using the provided operation
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value must not equal `rhs`
+///   - rhs: value which `lhs` will be compared against
+///   - operation: the method of comparison
+/// - Returns: `NSPredicate`
+func Predicate<A, B>(_ lhs: KeyPath<A, B>, _ operation: PredicateOperator, _ rhs: B) -> NSPredicate {
+    let lhs = NSExpression(forKeyPath: lhs)
+    let rhs = NSExpression(forConstantValue: rhs)
+    return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` must equal the given value
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value must equal `rhs`
+///   - rhs: optional value which `lhs` must equal
+/// - Returns: `NSPredicate`
+func Predicate<A, B>(_ lhs: KeyPath<A, B?>, equalTo rhs: B?) -> NSPredicate {
+    Predicate(lhs, .equalTo, rhs)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` must not equal the given value
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose optional value must not equal `rhs`
+///   - rhs: optional value which `lhs` must not equal
+/// - Returns: `NSPredicate`
+func Predicate<A, B>(_ lhs: KeyPath<A, B?>, notEqualTo rhs: B?) -> NSPredicate {
+    Predicate(lhs, .notEqualTo, rhs)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` is compared to the given value using the provided operation
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose optional value must not equal `rhs`
+///   - rhs: optional value which `lhs` will be compared against
+///   - operation: the method of comparison
+/// - Returns: `NSPredicate`
+func Predicate<A, B>(_ lhs: KeyPath<A, B?>, _ operation: PredicateOperator, _ rhs: B?) -> NSPredicate {
+    let lhs = NSExpression(forKeyPath: lhs)
+    let rhs = NSExpression(forConstantValue: rhs)
+    return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` must  equal the given value. The `rawValue` of the rhs value is used for comparison.
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose optional value must equal the raw value of `rhs`
+///   - rhs: `RawRepresentable` value which `lhs` must equal
+/// - Returns: `NSPredicate`
+func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C>, equalTo rhs: B) -> NSPredicate where B.RawValue == C {
+    Predicate(lhs, .equalTo, rhs)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` must  equal the given value. The `rawValue` of the rhs value is used for comparison.
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose optional value must equal the raw value of `rhs`
+///   - rhs: optional `RawRepresentable` value which `lhs` must equal
+/// - Returns: `NSPredicate`
+func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C?>, equalTo rhs: B?) -> NSPredicate where B.RawValue == C {
+    Predicate(lhs, .equalTo, rhs)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` must  not equal the given value. The `rawValue` of the rhs value is used for comparison.
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value must equal the raw value of `rhs`
+///   - rhs: `RawRepresentable` value which `lhs` must equal
+/// - Returns: `NSPredicate`
+func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C>, notEqualTo rhs: B) -> NSPredicate where B.RawValue == C {
+    Predicate(lhs, .notEqualTo, rhs)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` must not equal the given value. The `rawValue` of the rhs value is used for comparison.
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose optional value must not equal `rhs`
+///   - rhs: optional `RawRepresentable` value which `lhs` will be compared against
+/// - Returns: `NSPredicate`
+func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C?>, notEqualTo rhs: B?) -> NSPredicate where B.RawValue == C {
+    Predicate(lhs, .notEqualTo, rhs)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` is compared to the given `RawRepresentable`'s raw value using the provided operation
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value is compared against `rhs`
+///   - rhs: `RawRepresentable` value which `lhs` will be compared against
+///   - operation: the method of comparison
+/// - Returns: `NSPredicate`
+func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C>, _ operation: PredicateOperator, _ rhs: B) -> NSPredicate where B.RawValue == C {
+    let lhs = NSExpression(forKeyPath: lhs)
+    let rhs = NSExpression(forConstantValue: rhs.rawValue)
+    return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` is compared to the given `RawRepresentable`'s raw value using the provided operation
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose optional value is compared against `rhs`
+///   - rhs: optional `RawRepresentable` value which `lhs` will be compared against
+///   - operation: the method of comparison
+/// - Returns: `NSPredicate`
+func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C?>, _ operation: PredicateOperator, _ rhs: B?) -> NSPredicate where B.RawValue == C {
+    let lhs = NSExpression(forKeyPath: lhs)
+    let rhs = NSExpression(forConstantValue: rhs?.rawValue)
+    return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` is compared to the given `Collection` using the provided operation
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value is compared against `rhs`
+///   - rhs: `Collection` which `lhs` will be compared against
+///   - operation: the method of comparison
+/// - Returns: `NSPredicate`
+func Predicate<A, B, C: Collection>(_ lhs: KeyPath<A, B>, _ operation: PredicateOperator, _ rhs: C) -> NSPredicate where C.Element == B {
+    let lhs = NSExpression(forKeyPath: lhs)
+    let rhs = NSExpression(forConstantValue: rhs)
+    return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
+}
+
+/// Constructs an `NSPredicate` where the given `KeyPath` is compared to the given `Collection` using the provided operation
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value is compared against `rhs`
+///   - rhs: `Collection` which `lhs` will be compared against
+///   - operation: the method of comparison
+/// - Returns: `NSPredicate`
+func Predicate<A, B: NSFastEnumeration, C: NSObjectProtocol>(_ lhs: KeyPath<A, B?>, _ operation: PredicateOperator, _ rhs: C) -> NSPredicate {
+    let lhs = NSExpression(forKeyPath: lhs)
+    let rhs = NSExpression(forConstantValue: rhs)
+    return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
+}

--- a/Vocable/Extensions/PredicateBuilders.swift
+++ b/Vocable/Extensions/PredicateBuilders.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-typealias PredicateOperator = NSComparisonPredicate.Operator
+private typealias PredicateOperator = NSComparisonPredicate.Operator
 
 /// Constructs an `NSPredicate` where the given `KeyPath` must equal `true`
 ///
@@ -45,7 +45,7 @@ func Predicate<A, B>(_ lhs: KeyPath<A, B>, notEqualTo rhs: B) -> NSPredicate {
 ///   - rhs: value which `lhs` will be compared against
 ///   - operation: the method of comparison
 /// - Returns: `NSPredicate`
-func Predicate<A, B>(_ lhs: KeyPath<A, B>, _ operation: PredicateOperator, _ rhs: B) -> NSPredicate {
+private func Predicate<A, B>(_ lhs: KeyPath<A, B>, _ operation: PredicateOperator, _ rhs: B) -> NSPredicate {
     let lhs = NSExpression(forKeyPath: lhs)
     let rhs = NSExpression(forConstantValue: rhs)
     return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
@@ -78,7 +78,7 @@ func Predicate<A, B>(_ lhs: KeyPath<A, B?>, notEqualTo rhs: B?) -> NSPredicate {
 ///   - rhs: optional value which `lhs` will be compared against
 ///   - operation: the method of comparison
 /// - Returns: `NSPredicate`
-func Predicate<A, B>(_ lhs: KeyPath<A, B?>, _ operation: PredicateOperator, _ rhs: B?) -> NSPredicate {
+private func Predicate<A, B>(_ lhs: KeyPath<A, B?>, _ operation: PredicateOperator, _ rhs: B?) -> NSPredicate {
     let lhs = NSExpression(forKeyPath: lhs)
     let rhs = NSExpression(forConstantValue: rhs)
     return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
@@ -131,7 +131,7 @@ func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C?>, notEqualTo rhs:
 ///   - rhs: `RawRepresentable` value which `lhs` will be compared against
 ///   - operation: the method of comparison
 /// - Returns: `NSPredicate`
-func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C>, _ operation: PredicateOperator, _ rhs: B) -> NSPredicate where B.RawValue == C {
+private func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C>, _ operation: PredicateOperator, _ rhs: B) -> NSPredicate where B.RawValue == C {
     let lhs = NSExpression(forKeyPath: lhs)
     let rhs = NSExpression(forConstantValue: rhs.rawValue)
     return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
@@ -144,7 +144,7 @@ func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C>, _ operation: Pre
 ///   - rhs: optional `RawRepresentable` value which `lhs` will be compared against
 ///   - operation: the method of comparison
 /// - Returns: `NSPredicate`
-func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C?>, _ operation: PredicateOperator, _ rhs: B?) -> NSPredicate where B.RawValue == C {
+private func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C?>, _ operation: PredicateOperator, _ rhs: B?) -> NSPredicate where B.RawValue == C {
     let lhs = NSExpression(forKeyPath: lhs)
     let rhs = NSExpression(forConstantValue: rhs?.rawValue)
     return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
@@ -157,7 +157,7 @@ func Predicate<A, B: RawRepresentable, C>(_ lhs: KeyPath<A, C?>, _ operation: Pr
 ///   - rhs: `Collection` which `lhs` will be compared against
 ///   - operation: the method of comparison
 /// - Returns: `NSPredicate`
-func Predicate<A, B, C: Collection>(_ lhs: KeyPath<A, B>, _ operation: PredicateOperator, _ rhs: C) -> NSPredicate where C.Element == B {
+private func Predicate<A, B, C: Collection>(_ lhs: KeyPath<A, B>, _ operation: PredicateOperator, _ rhs: C) -> NSPredicate where C.Element == B {
     let lhs = NSExpression(forKeyPath: lhs)
     let rhs = NSExpression(forConstantValue: rhs)
     return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
@@ -170,8 +170,28 @@ func Predicate<A, B, C: Collection>(_ lhs: KeyPath<A, B>, _ operation: Predicate
 ///   - rhs: `Collection` which `lhs` will be compared against
 ///   - operation: the method of comparison
 /// - Returns: `NSPredicate`
-func Predicate<A, B: NSFastEnumeration, C: NSObjectProtocol>(_ lhs: KeyPath<A, B?>, _ operation: PredicateOperator, _ rhs: C) -> NSPredicate {
+private func Predicate<A, B: NSFastEnumeration, C: NSObjectProtocol>(_ lhs: KeyPath<A, B?>, _ operation: PredicateOperator, _ rhs: C) -> NSPredicate {
     let lhs = NSExpression(forKeyPath: lhs)
     let rhs = NSExpression(forConstantValue: rhs)
     return NSComparisonPredicate(leftExpression: lhs, rightExpression: rhs, modifier: .direct, type: operation)
+}
+
+/// Constructs an `NSPredicate` where the value at the given `KeyPath` must be contained in the provided `Collection`
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value must be contained by `rhs`
+///   - rhs: `Collection` which must contain `lhs` to evaluate `true`
+/// - Returns: `NSPredicate`
+func Predicate<A, B, C: Collection>(_ lhs: KeyPath<A, B>, isContainedIn rhs: C) -> NSPredicate where C.Element == B {
+    return Predicate(lhs, .in, rhs)
+}
+
+/// Constructs an `NSPredicate` where the string value at the given `KeyPath` must begin with the provided value
+///
+/// - Parameters:
+///   - lhs: `KeyPath` whose value is must begin with `rhs`
+///   - rhs: `String` which `lhs` must begin with
+/// - Returns: `NSPredicate`
+func Predicate<A>(_ lhs: KeyPath<A, String?>, beginsWith rhs: String) -> NSPredicate {
+    return Predicate(lhs, .beginsWith, rhs)
 }

--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -15,7 +15,7 @@ import Combine
 
     static func fetchInitialCategoryID() -> NSManagedObjectID {
         let ctx = NSPersistentContainer.shared.viewContext
-        let predicate = !Predicate(\Category.isHidden)
+        let predicate = !Predicate(\Category.isHidden) && !Predicate(\Category.isUserRemoved)
         let sort = [NSSortDescriptor(keyPath: \Category.ordinal, ascending: true)]
         let categories = Category.fetchAll(in: ctx, matching: predicate, sortDescriptors: sort)
         return categories[0].objectID

--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -137,7 +137,7 @@ import Combine
 
     private func categoriesFetchRequest() -> NSFetchRequest<Category> {
         let request: NSFetchRequest<Category> = Category.fetchRequest()
-        var predicate = !Predicate(\Category.isHidden)
+        var predicate = !Predicate(\Category.isHidden) && !Predicate(\Category.isUserRemoved)
 
         let shouldRemoveListeningCategory = false
         || !AppConfig.isListeningModeSupported

--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -15,17 +15,15 @@ import Combine
 
     static func fetchInitialCategoryID() -> NSManagedObjectID {
         let ctx = NSPersistentContainer.shared.viewContext
-        let predicate = NSComparisonPredicate(\Category.isHidden, .equalTo, false)
+        let predicate = !Predicate(\Category.isHidden)
         let sort = [NSSortDescriptor(keyPath: \Category.ordinal, ascending: true)]
-        let categories = Category.fetchAll(in: ctx,
-                          matching: predicate,
-                          sortDescriptors: sort)
+        let categories = Category.fetchAll(in: ctx, matching: predicate, sortDescriptors: sort)
         return categories[0].objectID
     }
 
     static func fetchVoiceCategoryID() -> NSManagedObjectID {
         let ctx = NSPersistentContainer.shared.viewContext
-        let predicate = NSComparisonPredicate(\Category.identifier, .equalTo, Category.Identifier.listeningMode.rawValue)
+        let predicate = Predicate(\Category.identifier, equalTo: Category.Identifier.listeningMode)
         let categories = Category.fetchAll(in: ctx, matching: predicate)
         return categories[0].objectID
     }
@@ -139,7 +137,7 @@ import Combine
 
     private func categoriesFetchRequest() -> NSFetchRequest<Category> {
         let request: NSFetchRequest<Category> = Category.fetchRequest()
-        var predicate: NSPredicate = NSComparisonPredicate(\Category.isHidden, .equalTo, false)
+        var predicate = !Predicate(\Category.isHidden)
 
         let shouldRemoveListeningCategory = false
         || !AppConfig.isListeningModeSupported
@@ -148,8 +146,7 @@ import Combine
         || !SpeechRecognitionController.shared.deviceSupportsSpeech
 
         if shouldRemoveListeningCategory {
-            let notVoicePredicate = NSComparisonPredicate(\Category.identifier, .notEqualTo, Category.Identifier.listeningMode.rawValue)
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, notVoicePredicate])
+            predicate &= Predicate(\Category.identifier, notEqualTo: Category.Identifier.listeningMode)
         }
         request.predicate = predicate
         request.sortDescriptors = [NSSortDescriptor(keyPath: \Category.ordinal, ascending: true)]

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -29,21 +29,23 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
     private lazy var fetchRequest: NSFetchRequest<Phrase> = {
         let request: NSFetchRequest<Phrase> = Phrase.fetchRequest()
 
+        var predicate = !Predicate(\Phrase.isUserRemoved)
         if category.identifier == Category.Identifier.recents {
-            request.predicate = NSComparisonPredicate(\Phrase.lastSpokenDate, .notEqualTo, nil)
+            predicate &= Predicate(\Phrase.lastSpokenDate, notEqualTo: nil)
             request.sortDescriptors = [NSSortDescriptor(keyPath: \Phrase.lastSpokenDate, ascending: false)]
             request.fetchLimit = 9
         } else {
-            request.predicate = NSComparisonPredicate(\Phrase.category, .equalTo, self.category)
+            predicate &= Predicate(\Phrase.category, equalTo: self.category)
             request.sortDescriptors = [NSSortDescriptor(keyPath: \Phrase.creationDate, ascending: false)]
         }
+        request.predicate = predicate
         return request
     }()
 
     private lazy var frc = NSFetchedResultsController<Phrase>(fetchRequest: self.fetchRequest,
-                                                                                 managedObjectContext: NSPersistentContainer.shared.viewContext,
-                                                                                 sectionNameKeyPath: nil,
-                                                                                 cacheName: nil)
+                                                              managedObjectContext: NSPersistentContainer.shared.viewContext,
+                                                              sectionNameKeyPath: nil,
+                                                              cacheName: nil)
 
     convenience init(category: Category) {
         self.init(nibName: nil, bundle: nil)

--- a/Vocable/Features/Root/RootEditTextViewController.swift
+++ b/Vocable/Features/Root/RootEditTextViewController.swift
@@ -18,7 +18,7 @@ class RootEditTextViewController: EditTextViewController {
         let button = GazeableButton()
         button.setImage(UIImage(systemName: "star"), for: .normal)
         button.accessibilityIdentifier = "keyboard.favoriteButton"
-        button.addTarget(self, action: #selector(favoriteButtonSelected), for: .primaryActionTriggered)
+        button.addTarget(RootEditTextViewController.self, action: #selector(favoriteButtonSelected), for: .primaryActionTriggered)
         return button
     }()
 

--- a/Vocable/Features/Root/RootEditTextViewController.swift
+++ b/Vocable/Features/Root/RootEditTextViewController.swift
@@ -54,14 +54,13 @@ class RootEditTextViewController: EditTextViewController {
         }
         self.favoriteButton.isEnabled = true
         let userFavorites = Category.userFavoritesCategory()
+
+        var predicate = Predicate(\Phrase.category, equalTo: userFavorites)
+        predicate &= Predicate(\Phrase.isUserGenerated)
+        predicate &= Predicate(\Phrase.utterance, equalTo: text)
+
         let fetchRequest: NSFetchRequest<Phrase> = Phrase.fetchRequest()
-        fetchRequest.predicate = {
-            let categoryPredicate = NSComparisonPredicate(\Phrase.category, .equalTo, userFavorites)
-            let userGenerated = NSComparisonPredicate(\Phrase.isUserGenerated, .equalTo, true)
-            let textMatches = NSComparisonPredicate(\Phrase.utterance, .equalTo, text)
-            let subpredicates = [categoryPredicate, userGenerated, textMatches]
-            return NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
-        }()
+        fetchRequest.predicate = predicate
         fetchRequest.fetchLimit = 1
         let results = (try? NSPersistentContainer.shared.viewContext.fetch(fetchRequest)) ?? []
         self.currentPhrase = results.first

--- a/Vocable/Features/Root/RootEditTextViewController.swift
+++ b/Vocable/Features/Root/RootEditTextViewController.swift
@@ -18,7 +18,6 @@ class RootEditTextViewController: EditTextViewController {
         let button = GazeableButton()
         button.setImage(UIImage(systemName: "star"), for: .normal)
         button.accessibilityIdentifier = "keyboard.favoriteButton"
-        button.addTarget(RootEditTextViewController.self, action: #selector(favoriteButtonSelected), for: .primaryActionTriggered)
         return button
     }()
 
@@ -34,6 +33,9 @@ class RootEditTextViewController: EditTextViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        favoriteButton.addTarget(self, action: #selector(favoriteButtonSelected), for: .primaryActionTriggered)
+
         shouldWarnOnDismiss = false
         navigationBar.rightButton = favoriteButton
         $text.receive(on: DispatchQueue.main).sink { [weak self] newText in

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
@@ -36,6 +36,7 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
 
     private lazy var fetchRequest: NSFetchRequest<Category> = {
         let request: NSFetchRequest<Category> = Category.fetchRequest()
+        request.predicate = !Predicate(\Category.isUserRemoved)
         request.sortDescriptors = [NSSortDescriptor(keyPath: \Category.isHidden, ascending: true),
         NSSortDescriptor(keyPath: \Category.ordinal, ascending: true),
         NSSortDescriptor(keyPath: \Category.creationDate, ascending: true)]

--- a/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
@@ -291,6 +291,9 @@ final class EditCategoryDetailViewController: VocableCollectionViewController, E
         } else {
             category.isUserRemoved = true
         }
+
+        try? Category.updateAllOrdinalValues(in: context)
+
         if saveContext() {
             self.navigationController?.popViewController(animated: true)
         }

--- a/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
@@ -224,12 +224,10 @@ final class EditCategoryDetailViewController: VocableCollectionViewController, E
         switch selectedItem {
         case .titleEditView:
             return true
-        case .showCategoryToggle:
+        case .showCategoryToggle, .removeCategory:
             return (category.identifier != .userFavorites)
         case .addPhrase:
-            return true
-        case .removeCategory:
-            return (category.identifier != .userFavorites)
+            return category.allowsCustomPhrases
         }
     }
 

--- a/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
@@ -318,7 +318,6 @@ final class EditCategoryDetailViewController: VocableCollectionViewController, E
     // MARK: EditCategoryDetailTitleCollectionViewCellDelegate
 
     func didTapEdit() {
-
         guard let categoryIdentifier = category.identifier else {
             assertionFailure("Category has no identifier")
             return

--- a/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
+++ b/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
@@ -32,7 +32,7 @@ final class EditPhrasesViewController: PagingCarouselViewController, NSFetchedRe
 
     private lazy var fetchRequest: NSFetchRequest<Phrase> = {
         let request: NSFetchRequest<Phrase> = Phrase.fetchRequest()
-        request.predicate = NSComparisonPredicate(\Phrase.category, .equalTo, category)
+        request.predicate = Predicate(\Phrase.category, equalTo: category) && !Predicate(\Phrase.isUserRemoved)
         request.sortDescriptors = [NSSortDescriptor(keyPath: \Phrase.creationDate, ascending: false)]
         return request
     }()

--- a/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
+++ b/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
@@ -217,11 +217,6 @@ final class EditPhrasesViewController: PagingCarouselViewController, NSFetchedRe
             return
         }
 
-        guard let categoryIdentifier = category.identifier else {
-            assertionFailure("Category has no identifier")
-            return
-        }
-
         let initialValue = phrase.utterance ?? ""
 
         let vc = EditTextViewController()
@@ -237,18 +232,9 @@ final class EditPhrasesViewController: PagingCarouselViewController, NSFetchedRe
             if originalPhrase.isUserGenerated {
                 originalPhrase.utterance = newText
             } else {
-
-                // If the phrase is not user generated, swap in a custom phrase and hide the old one
-                guard let originalCategory = Category.fetchObject(in: context, matching: categoryIdentifier) else {
-                    assertionFailure("Could not locate original category for phrase swap")
-                    return
-                }
-
-                let newPhrase = Phrase.create(withUserEntry: newText, category: originalCategory, in: context)
-                newPhrase.lastSpokenDate = originalPhrase.lastSpokenDate
-                newPhrase.languageCode = originalPhrase.languageCode
-                newPhrase.creationDate = originalPhrase.creationDate
-                originalPhrase.isUserRemoved = true
+                let textDidChange = (newText != initialValue)
+                originalPhrase.utterance = newText
+                originalPhrase.isUserRenamed = originalPhrase.isUserRenamed || textDidChange
             }
 
             do {

--- a/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
+++ b/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
@@ -189,7 +189,12 @@ final class EditPhrasesViewController: PagingCarouselViewController, NSFetchedRe
         let safeIndexPath = dataSourceProxy.indexPath(fromMappedIndexPath: indexPath)
         let phrase = self.fetchResultsController.object(at: safeIndexPath)
         let context = NSPersistentContainer.shared.viewContext
-        context.delete(phrase)
+
+        if phrase.isUserGenerated {
+            context.delete(phrase)
+        } else {
+            phrase.isUserRemoved = true
+        }
 
         do {
             try context.save()


### PR DESCRIPTION
Closes #465

# Description of Work

### Functionally
If the category or phrase is a preset, it can be renamed and deleted just like their user-defined counterparts
- Renaming means marking them as "user-renamed" so that subsequent updates of the presets don't overwrite the user's entry
- During "deletion" the category or phrase is marked as "user-removed" so that subsequent updates to the presets don't recreate the removed entity. We simply suppress it from showing in the UI at all.
- User-generated categories and phrases are still permanently deleted because there is no consequence for that

### Code changes
- I felt that the way Core Data predicates were being handled was getting a bit terse, so I made some lightweight global functions and operators to make dealing with them more readable and concise. I steered away from making anything too fancy (I hope), so hopefully these strike a nice balance.

## Notes to Test 
- This does not change the UI from previous builds beyond enabling/disabling buttons
- The "My Sayings" category is still a special case that is not deletable 
- We should do some testing to ensure we upgrade gracefully from the App Store version of the app
   - Specifically the "My Sayings" category migration
