### PR TITLE
Added identifier to category carousel cell element for automation.

### DIFF
--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -49,6 +49,7 @@ import Combine
         let category = self.frc.object(at: indexPath)
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryItemCollectionViewCell.reuseIdentifier, for: indexPath) as! CategoryItemCollectionViewCell
         cell.setup(title: category.name!)
+        cell.accessibilityIdentifier = ["category_title_cell", category.identifier].compactMap{$0}.joined(separator: "_")
         return cell
     }
 


### PR DESCRIPTION
https://github.com/willowtreeapps/vocable-ios/issues/405

# Description of Work
As part of the ongoing effort on existing automation, I am adding an identifier to the category carousel cell element. This will make it easier for us to discern between the category name and a phrase, or between two category cells on the screen at once (iPad).

Each category title cell will now have an identifier with prefix "category_title_cell" and a suffix that is the ID associated with the category, based on the values defined in `/presets.json`
