### PR TITLE
Test/500 fix keyboard test

### DIFF
--- a/Vocable/Common/Views/EmptyStateView.swift
+++ b/Vocable/Common/Views/EmptyStateView.swift
@@ -144,6 +144,7 @@ final class EmptyStateView: UIView {
             descriptionAttributedText = nil
         }
         button.setTitle(type.buttonTitle, for: .normal)
+        button.accessibilityIdentifier = "empty_state_addPhrase_button"
 
         commonInit()
     }

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -81,7 +81,7 @@ class MainScreen: BaseScreen {
         } while (!selectedCell.waitForExistence(timeout: 0.33))
     }
     
-    /// Assuming there is at least one page of phrases within a category, locate the cell containg the given phrase.
+    /// Assuming there is at least one page of phrases within a category, locate the cell containing the given phrase.
     func locatePhraseCell(phrase: String) -> XCUIElement {
         let predicate = NSPredicate(format: "label MATCHES %@", phrase)
         

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -24,6 +24,7 @@ class MainScreen: BaseScreen {
     let pageNumber = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
     let paginationLeftButton = XCUIApplication().buttons["bottomPagination.left_chevron"]
     let paginationRightButton = XCUIApplication().buttons["bottomPagination.right_chevron"]
+    let emptyStateAddPhraseButton = XCUIApplication().buttons["empty_state_addPhrase_button"]
     
     // Find the current selected category and return it as a CategoryTitleCellIdentifier
     var selectedCategoryCell: CategoryTitleCellIdentifier {
@@ -80,6 +81,7 @@ class MainScreen: BaseScreen {
         } while (!selectedCell.waitForExistence(timeout: 0.33))
     }
     
+    /// Assuming there is at least one page of phrases within a category, locate the cell containg the given phrase.
     func locatePhraseCell(phrase: String) -> XCUIElement {
         let predicate = NSPredicate(format: "label MATCHES %@", phrase)
         

--- a/VocableUITests/Tests/KeyboardScreenTests.swift
+++ b/VocableUITests/Tests/KeyboardScreenTests.swift
@@ -51,7 +51,8 @@ class KeyboardScreenTests: BaseTest {
         keyboardScreen.dismissKeyboardButton.tap()
         mainScreen.locateAndSelectDestinationCategory(.mySayings)
         
-        XCTAssertFalse(mainScreen.locatePhraseCell(phrase: testPhrase).exists, "Expected the phrase \(testPhrase) to be deleted from 'My Sayings'")
+        // We expect 'My Sayings' to be empty now.
+        XCTAssertTrue(mainScreen.emptyStateAddPhraseButton.exists, "Expected the phrase \(testPhrase) to be deleted from 'My Sayings'")
     }
      
 }


### PR DESCRIPTION
Closes issue #500 


# Description of Work
The new empty state for categories w/out phrases has caused some of our UI automation to fail. This fixes the failing test, testRemovePhraseFromMySayingsFromKeyboard(), by refactoring the test to expect the new 'Add Phrase' button that only exists for the empty state. Previously the test was looking for the "Page 1 of 1" pagination elements.


***Notes to Test***
KeyboardScreenTests should all pass on both iPad and iPhone.
