### PR TITLE
BugFix 481 | Update empty state string

### DIFF
--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -140,7 +140,7 @@
 
 "recents_empty_state.body.title" = "Start using Vocable to see your most recently used phrases here.";
 
-"empty_state.header.title" = "This category has no phrases yet";
+"empty_state.header.title" = "You don't have any phrases saved yet.";
 
 "empty_state.button.title" = "Add Phrase";
 


### PR DESCRIPTION
closes #481 

# Description of Work
We were trying to test out Crowdin.  We updated the English string in Crowdin but that did not update the english string in the app.  Crowdin now has the updated string but develop has the old string.  

Updating the string in xcode manually to harmonize it.

---
