### PR TITLE
Re-enable CustomCategoriesTests - Refactor to leverage reset at launch

### DIFF
--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -61,6 +61,9 @@
                   Identifier = "CustomCategoriesTest">
                </Test>
                <Test
+                  Identifier = "CustomCategoriesTests/testPagination()">
+               </Test>
+               <Test
                   Identifier = "MainScreenTests/testCustonCategoryPagination()">
                </Test>
                <Test

--- a/VocableUITests/Tests/CustomCategoriesBaseTest.swift
+++ b/VocableUITests/Tests/CustomCategoriesBaseTest.swift
@@ -10,12 +10,10 @@ import XCTest
 
 class CustomCategoriesBaseTest: BaseTest {
     
-    private(set) var customCategoryName: String = ""
+    private(set) var customCategoryName: String = "Test"
     
     override func setUp() {
         super.setUp()
-        
-        setCustomCategory(name: "Hi", numOfRandomLetters: 3)
         
         // Create a custom category and open it
         settingsScreen.navigateToSettingsCategoryScreen()
@@ -23,11 +21,4 @@ class CustomCategoriesBaseTest: BaseTest {
         settingsScreen.openCategorySettings(category: customCategoryName)
     }
     
-    private func setCustomCategory(name: String, numOfRandomLetters: Int) {
-        customCategoryName = name + randomString(length: numOfRandomLetters)
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-    }
 }

--- a/VocableUITests/Tests/CustomCategoriesTests.swift
+++ b/VocableUITests/Tests/CustomCategoriesTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-class CustomCategoriesTest: CustomCategoriesBaseTest {
+class CustomCategoriesTests: CustomCategoriesBaseTest {
 
     func testAddNewPhrase() {
         let customPhrase = "dd"
@@ -25,8 +25,6 @@ class CustomCategoriesTest: CustomCategoriesBaseTest {
 
         settingsScreen.alertDiscardButton.tap()
         XCTAssertFalse(XCUIApplication().collectionViews.cells.otherElements.containing(.staticText, identifier: "A").element.exists)
-        settingsScreen.settingsPageNextButton.tap()
-        XCTAssertFalse(XCUIApplication().collectionViews.cells.otherElements.containing(.staticText, identifier: "A").element.exists)
 
         // Verify Phrase can be added if continuing edit.
         customCategoriesScreen.categoriesPageAddPhraseButton.tap()
@@ -42,7 +40,7 @@ class CustomCategoriesTest: CustomCategoriesBaseTest {
     }
 
     func testCustomPhraseEdit() {
-        let customPhrase = "Add" + randomString(length: 2)
+        let customPhrase = "Add"
         
         // Add our test phrase
         customCategoriesScreen.editCategoryPhrasesCell.tap()
@@ -58,8 +56,7 @@ class CustomCategoriesTest: CustomCategoriesBaseTest {
     }
     
     func testDeleteCustomPhrase() {
-        // This test builds off of the last test.
-        let customPhrase = "Delete" + randomString(length: 2)
+        let customPhrase = "Delete"
         
         // Add our test phrase
         customCategoriesScreen.editCategoryPhrasesCell.tap()
@@ -99,8 +96,9 @@ class CustomCategoriesTest: CustomCategoriesBaseTest {
         XCTAssertEqual(phraseQuery.count, 2, "Expected both phrases to be present")
     }
     
-    // TODO: Disabled for now. Moving it to a different test class as part of issue #405
-    // https://github.com/willowtreeapps/vocable-ios/issues/405
+    // TODO: Disabled for now. Moving it to a different test class as part of issue #405; tracked in issue #470
+    // https://github.com/willowtreeapps/vocable-ios/issues/470 -> Implementation
+    // https://github.com/willowtreeapps/vocable-ios/issues/405 -> Parent
     func testPagination() {
         let customCategoryThree = "Testc"
         let createdCustomCategory = ("9. "+customCategoryThree)


### PR DESCRIPTION
Closes https://github.com/willowtreeapps/vocable-ios/issues/511

# Description
At some point the CustomCategoriesTests.swift class became disabled for test runs. I have re-enabled the suite so that all of the tests we expect to run, will. 

I also took the time to refactor what we forgot to do earlier, around randomization. We no longer need to randomize the name of our categories because we implemented the reset feature w/in the app.

## Notes to Test
All tests should pass on iPhone and iPad.
