### PR TITLE
Fixed Settings Screen Tests

### DIFF
--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -78,6 +78,9 @@
                <Test
                   Identifier = "SettingsScreenTests/testAddCustomCategory()">
                </Test>
+               <Test
+                  Identifier = "SettingsScreenTests/testReorder()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -75,9 +75,6 @@
                <Test
                   Identifier = "SettingsScreenTests/testAddCustomCategory()">
                </Test>
-               <Test
-                  Identifier = "SettingsScreenTests/testHideShowToggle()">
-               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
+++ b/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
@@ -264,6 +264,7 @@ final class GazeableAlertViewController: UIViewController, UIViewControllerTrans
         containerStackView.addArrangedSubview(actionButtonStackView)
 
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
+        messageLabel.accessibilityIdentifier = "alert_message"
         titleContainerView.addSubview(messageLabel)
 
         NSLayoutConstraint.activate([

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -14,6 +14,8 @@ import XCTest
 
 class BaseScreen {
     let paginationLabel = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
+    let alertMessageLabel = XCUIApplication().staticTexts["alert_message"]
+    let emptyStateAddPhraseButton = XCUIApplication().buttons["empty_state_addPhrase_button"]
     
     /// From Pagination: the current page (X) being viewed from the "Page X of Y" pagination label.
     var currentPageNumber: Int {

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -24,7 +24,6 @@ class MainScreen: BaseScreen {
     let pageNumber = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
     let paginationLeftButton = XCUIApplication().buttons["bottomPagination.left_chevron"]
     let paginationRightButton = XCUIApplication().buttons["bottomPagination.right_chevron"]
-    let emptyStateAddPhraseButton = XCUIApplication().buttons["empty_state_addPhrase_button"]
     
     // Find the current selected category and return it as a CategoryTitleCellIdentifier
     var selectedCategoryCell: CategoryTitleCellIdentifier {

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -36,9 +36,10 @@ class SettingsScreen: BaseScreen {
     }
     
     func locateCategoryCell(_ category: String) -> XCUIElementQuery {
+        let predicate = NSPredicate(format: "label CONTAINS %@", category)
         // Loop through each page to find our category
         for _ in 1...totalPageCount {
-            if categoryCellQuery(category).element.exists{
+            if cells.staticTexts.containing(predicate).element.exists{
                 break
             } else {
                 settingsPageNextButton.tap()

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -3,7 +3,8 @@
 //  VocableUITests
 //
 //  Created by Kevin Stechler on 5/19/20.
-//  Copyright © 2020 WillowTree. All rights reserved.
+//  Updated by Canan Arikan and Rudy Salas on 03/28/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
 //
 
 import XCTest
@@ -17,39 +18,50 @@ class SettingsScreen: BaseScreen {
     let leaveCategoriesButton = XCUIApplication().buttons["Left"]
     let exitSettingsButton = XCUIApplication().buttons["settings.dismissButton"]
     let otherElements = XCUIApplication().collectionViews.cells.otherElements
+    let cells = XCUIApplication().cells
     let settingsPageNextButton = XCUIApplication().buttons["bottomPagination.right_chevron"]
-    let settingsPageCategoryUpButton = "go up"
-    let settingsPageCategoryDownButton = "go down"
-    let settingsPageCategoryHideButton = "hide"
-    let settingsPageCategoryShowButton = "show"
+    let categoryUpButton = "go up"
+    let categoryDownButton = "go down"
+    let categoryForwardButton = "Forward"
+    let showCategorySwitch = XCUIApplication().switches["show_category_toggle"]
+    let hideCategorySwitch = "hide"
+    let categoryShowButton = "show"
     let settingsPageAddCategoryButton = XCUIApplication().buttons["settingsCategory.addCategoryButton"]
     let alertContinueButton = XCUIApplication().buttons["Continue Editing"]
     let alertDiscardButton = XCUIApplication().buttons["Discard"]
     let alertDeleteButton = XCUIApplication().buttons["Delete"]
 
     func openCategorySettings(category: String) {
-        var cellLabel = ""
-        let predicate = NSPredicate(format: "label CONTAINS %@", category)
-        
+        locateCategoryCell(category).buttons[categoryForwardButton].tap()
+    }
+    
+    func locateCategoryCell(_ category: String) -> XCUIElementQuery {
         // Loop through each page to find our category
         for _ in 1...totalPageCount {
-            if otherElements.staticTexts.containing(predicate).element.exists {
-                cellLabel = otherElements.staticTexts.containing(predicate).element.label
-                otherElements.containing(.staticText, identifier: cellLabel).buttons["Forward"].tap()
+            if categoryCellQuery(category).element.exists{
                 break
             } else {
                 settingsPageNextButton.tap()
             }
         }
+        
+        return categoryCellQuery(category)
+    }
+    
+    func categoryCellQuery(_ category: String) -> XCUIElementQuery {
+        let predicate = NSPredicate(format: "label CONTAINS %@", category)
+        let cellLabel = cells.staticTexts.containing(predicate).element.label
+        
+        return XCUIApplication().cells.containing(.staticText, identifier: cellLabel)
     }
     
     func toggleHideShowCategory(category: String, toggle: String) {
         var toggleLabel = ""
         switch toggle {
         case "Hide":
-            toggleLabel = settingsPageCategoryHideButton
+            toggleLabel = hideCategorySwitch
         case "Show":
-            toggleLabel = settingsPageCategoryShowButton
+            toggleLabel = categoryShowButton
         default:
             break
         }

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -49,7 +49,7 @@ class SettingsScreen: BaseScreen {
         return categoryCellQuery(category)
     }
     
-    func categoryCellQuery(_ category: String) -> XCUIElementQuery {
+    private func categoryCellQuery(_ category: String) -> XCUIElementQuery {
         let predicate = NSPredicate(format: "label CONTAINS %@", category)
         let cellLabel = cells.staticTexts.containing(predicate).element.label
         

--- a/VocableUITests/Tests/CustomCategoriesTests.swift
+++ b/VocableUITests/Tests/CustomCategoriesTests.swift
@@ -13,6 +13,7 @@ class CustomCategoriesTests: CustomCategoriesBaseTest {
     func testAddNewPhrase() {
         let customPhrase = "dd"
         let confirmationAlert = "Are you sure? Going back before saving will clear any edits made."
+        let areYouSureAlert = NSPredicate(format: "label CONTAINS %@", confirmationAlert)
         
         // Navigate to our test category (created in the base class setup() method)
         customCategoriesScreen.editCategoryPhrasesCell.tap()
@@ -21,7 +22,7 @@ class CustomCategoriesTests: CustomCategoriesBaseTest {
         // Verify Phrase is not added if edits are discarded
         keyboardScreen.typeText("A")
         keyboardScreen.dismissKeyboardButton.tap()
-        XCTAssertEqual(XCUIApplication().staticTexts.element(boundBy: 1).label, confirmationAlert)
+        XCTAssertTrue(XCUIApplication().staticTexts.containing(areYouSureAlert).element.exists)
 
         settingsScreen.alertDiscardButton.tap()
         XCTAssertFalse(XCUIApplication().collectionViews.cells.otherElements.containing(.staticText, identifier: "A").element.exists)
@@ -30,7 +31,7 @@ class CustomCategoriesTests: CustomCategoriesBaseTest {
         customCategoriesScreen.categoriesPageAddPhraseButton.tap()
         keyboardScreen.typeText("A")
         keyboardScreen.dismissKeyboardButton.tap()
-        XCTAssertEqual(XCUIApplication().staticTexts.element(boundBy: 1).label, confirmationAlert)
+        XCTAssertTrue(XCUIApplication().staticTexts.containing(areYouSureAlert).element.exists)
         settingsScreen.alertContinueButton.tap()
 
         keyboardScreen.typeText(customPhrase)
@@ -49,14 +50,15 @@ class CustomCategoriesTests: CustomCategoriesBaseTest {
         keyboardScreen.checkmarkAddButton.tap()
         
         // Edit the phrase
-        customCategoriesScreen.categoriesPageEditPhraseButton.tap()
+        // TODO: Refactor customCategoriesScreen.categoriesPageEditPhraseButton after Category List UI updates: issue #492 ... need identifiers?
+        XCUIApplication().buttons[customPhrase].tap()
         keyboardScreen.typeText("test")
         keyboardScreen.checkmarkAddButton.tap()
         XCTAssert(mainScreen.isTextDisplayed(customPhrase+"test"), "Expected the phrase \(customPhrase+"test") to be displayed")
     }
     
     func testDeleteCustomPhrase() {
-        let customPhrase = "Delete"
+        let customPhrase = "Test"
         
         // Add our test phrase
         customCategoriesScreen.editCategoryPhrasesCell.tap()
@@ -65,10 +67,10 @@ class CustomCategoriesTests: CustomCategoriesBaseTest {
         keyboardScreen.checkmarkAddButton.tap()
         
         // Confirm that our phrase to-be-deleted has been created
-        // TODO: MAKE A isTextDisplayed HELPER METHOD THAT IS AGNOSTIC OF SCREEN...each screen class has its own?
         XCTAssert(mainScreen.isTextDisplayed(customPhrase), "Expected the phrase \(customPhrase) to be displayed")
         
-        customCategoriesScreen.categoriesPageDeletePhraseButton.tap()
+        // TODO: customCategoriesScreen.categoriesPageDeletePhraseButton after Category List UI updates: issue #492 ... need identifiers?
+        XCUIApplication().buttons["trash"].tap()
         settingsScreen.alertDeleteButton.tap()
         XCTAssertFalse(mainScreen.isTextDisplayed(customPhrase), "Expected the phrase \(customPhrase) to not be displayed")
     }

--- a/VocableUITests/Tests/CustomCategoriesTests.swift
+++ b/VocableUITests/Tests/CustomCategoriesTests.swift
@@ -12,9 +12,7 @@ class CustomCategoriesTests: CustomCategoriesBaseTest {
 
     func testAddNewPhrase() {
         let customPhrase = "dd"
-        let confirmationAlert = "Are you sure? Going back before saving will clear any edits made."
-        let areYouSureAlert = NSPredicate(format: "label CONTAINS %@", confirmationAlert)
-        
+                
         // Navigate to our test category (created in the base class setup() method)
         customCategoriesScreen.editCategoryPhrasesCell.tap()
         customCategoriesScreen.categoriesPageAddPhraseButton.tap()
@@ -22,16 +20,16 @@ class CustomCategoriesTests: CustomCategoriesBaseTest {
         // Verify Phrase is not added if edits are discarded
         keyboardScreen.typeText("A")
         keyboardScreen.dismissKeyboardButton.tap()
-        XCTAssertTrue(XCUIApplication().staticTexts.containing(areYouSureAlert).element.exists)
+        XCTAssertTrue(keyboardScreen.alertMessageLabel.exists)
 
         settingsScreen.alertDiscardButton.tap()
-        XCTAssertFalse(XCUIApplication().collectionViews.cells.otherElements.containing(.staticText, identifier: "A").element.exists)
+        XCTAssertTrue(customCategoriesScreen.emptyStateAddPhraseButton.exists)
 
         // Verify Phrase can be added if continuing edit.
         customCategoriesScreen.categoriesPageAddPhraseButton.tap()
         keyboardScreen.typeText("A")
         keyboardScreen.dismissKeyboardButton.tap()
-        XCTAssertTrue(XCUIApplication().staticTexts.containing(areYouSureAlert).element.exists)
+        XCTAssertTrue(keyboardScreen.alertMessageLabel.exists)
         settingsScreen.alertContinueButton.tap()
 
         keyboardScreen.typeText(customPhrase)

--- a/VocableUITests/Tests/SettingsScreenTests.swift
+++ b/VocableUITests/Tests/SettingsScreenTests.swift
@@ -3,7 +3,8 @@
 //  VocableUITests
 //
 //  Created by Sashank Patel on 8/24/20.
-//  Copyright © 2020 WillowTree. All rights reserved.
+//  Updated by Canan Arikan and Rudy Salas on 03/28/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
 //
 
 import XCTest
@@ -11,35 +12,30 @@ import XCTest
 class SettingsScreenTests: BaseTest {
 
     func testHideShowToggle() {
-        let generalCategoryText = "1. General"
-        let hiddenGeneralCategoryText = "General"
+        let category = "Environment"
 
         settingsScreen.navigateToSettingsCategoryScreen()
+        XCTAssertTrue(settingsScreen.locateCategoryCell(category).element.exists)
 
-        // Verify the category is not numbered when hidden and correct button states are shown.
+        // Verify that when the category is hidden, up and down buttons are disabled.
+        settingsScreen.openCategorySettings(category: category)
+        settingsScreen.showCategorySwitch.tap()
+        settingsScreen.leaveCategoryDetailButton.tap()
+       
+        XCTAssertTrue(settingsScreen.locateCategoryCell(category).element.exists)
+        XCTAssertFalse(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryUpButton].isEnabled)
+        XCTAssertFalse(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryDownButton].isEnabled)
+        XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].isEnabled)
 
-        XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: generalCategoryText).element.exists)
-
-        settingsScreen.toggleHideShowCategory(category: generalCategoryText, toggle: "Hide")
-        XCTAssertFalse(settingsScreen.otherElements.containing(.staticText, identifier: generalCategoryText).element.exists)
-
-        settingsScreen.navigateToCategory(category: hiddenGeneralCategoryText)
-
-        XCTAssertFalse(settingsScreen.otherElements.containing(.staticText, identifier: hiddenGeneralCategoryText).buttons[settingsScreen.settingsPageCategoryUpButton].isEnabled)
-        XCTAssertFalse(settingsScreen.otherElements.containing(.staticText, identifier: hiddenGeneralCategoryText).buttons[settingsScreen.settingsPageCategoryDownButton].isEnabled)
-        XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: hiddenGeneralCategoryText).buttons[settingsScreen.settingsPageCategoryShowButton].isEnabled)
-
-        // Verify category goes back to original spot when shown.
-
-        settingsScreen.toggleHideShowCategory(category: hiddenGeneralCategoryText, toggle: "Show")
-        XCTAssertFalse(settingsScreen.otherElements.containing(.staticText, identifier: hiddenGeneralCategoryText).element.exists)
-
-        settingsScreen.navigateToCategory(category: generalCategoryText)
-        settingsScreen.settingsPageNextButton.tap()
-
-        XCTAssertFalse(settingsScreen.otherElements.containing(.staticText, identifier: generalCategoryText).buttons[settingsScreen.settingsPageCategoryUpButton].isEnabled)
-        XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: generalCategoryText).buttons[settingsScreen.settingsPageCategoryDownButton].isEnabled)
-        XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: generalCategoryText).buttons[settingsScreen.settingsPageCategoryHideButton].isEnabled)
+        // Verify that when the category is shown, up and down buttons are enabled.
+        settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].tap()
+        settingsScreen.showCategorySwitch.tap()
+        settingsScreen.leaveCategoryDetailButton.tap()
+        
+        XCTAssertTrue(settingsScreen.locateCategoryCell(category).element.exists)
+        XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryUpButton].isEnabled)
+        XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryDownButton].isEnabled)
+        XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].isEnabled)
     }
 
     func testReorder() {
@@ -54,12 +50,12 @@ class SettingsScreenTests: BaseTest {
         XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: generalCategoryText).element.exists)
         XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: basicNeedsCategoryText).element.exists)
 
-        settingsScreen.otherElements.containing(.staticText, identifier: generalCategoryText).buttons[settingsScreen.settingsPageCategoryDownButton].tap()
+        settingsScreen.otherElements.containing(.staticText, identifier: generalCategoryText).buttons[settingsScreen.categoryDownButton].tap()
         
         XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: expectedGeneralCategoryText).element.exists)
         XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: expectedbasicNeedsCategoryText).element.exists)
         
-        settingsScreen.otherElements.containing(.staticText, identifier: expectedGeneralCategoryText).buttons[settingsScreen.settingsPageCategoryUpButton].tap()
+        settingsScreen.otherElements.containing(.staticText, identifier: expectedGeneralCategoryText).buttons[settingsScreen.categoryUpButton].tap()
         
         XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: generalCategoryText).element.exists)
         XCTAssert(settingsScreen.otherElements.containing(.staticText, identifier: basicNeedsCategoryText).element.exists)

--- a/VocableUITests/Tests/SettingsScreenTests.swift
+++ b/VocableUITests/Tests/SettingsScreenTests.swift
@@ -22,20 +22,20 @@ class SettingsScreenTests: BaseTest {
         settingsScreen.showCategorySwitch.tap()
         settingsScreen.leaveCategoryDetailButton.tap()
         
-        settingsScreen.locateCategoryCell(category)
-        XCTAssertFalse(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryUpButton].isEnabled)
-        XCTAssertFalse(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryDownButton].isEnabled)
-        XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].isEnabled)
+        let hiddenCategory = settingsScreen.locateCategoryCell(category)
+        XCTAssertFalse(hiddenCategory.buttons[settingsScreen.categoryUpButton].isEnabled)
+        XCTAssertFalse(hiddenCategory.buttons[settingsScreen.categoryDownButton].isEnabled)
+        XCTAssertTrue(hiddenCategory.buttons[settingsScreen.categoryForwardButton].isEnabled)
 
         // Verify that when the category is shown, up and down buttons are enabled.
         settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].tap()
         settingsScreen.showCategorySwitch.tap()
         settingsScreen.leaveCategoryDetailButton.tap()
         
-        settingsScreen.locateCategoryCell(category)
-        XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryUpButton].isEnabled)
-        XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryDownButton].isEnabled)
-        XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].isEnabled)
+        let shownCategory = settingsScreen.locateCategoryCell(category)
+        XCTAssertTrue(shownCategory.buttons[settingsScreen.categoryUpButton].isEnabled)
+        XCTAssertTrue(shownCategory.buttons[settingsScreen.categoryDownButton].isEnabled)
+        XCTAssertTrue(shownCategory.buttons[settingsScreen.categoryForwardButton].isEnabled)
     }
 
     // We are disabling this test for now, it will be updated after the issue is completed: https://github.com/willowtreeapps/vocable-ios/issues/492

--- a/VocableUITests/Tests/SettingsScreenTests.swift
+++ b/VocableUITests/Tests/SettingsScreenTests.swift
@@ -21,8 +21,8 @@ class SettingsScreenTests: BaseTest {
         settingsScreen.openCategorySettings(category: category)
         settingsScreen.showCategorySwitch.tap()
         settingsScreen.leaveCategoryDetailButton.tap()
-       
-        XCTAssertTrue(settingsScreen.locateCategoryCell(category).element.exists)
+        
+        settingsScreen.locateCategoryCell(category)
         XCTAssertFalse(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryUpButton].isEnabled)
         XCTAssertFalse(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryDownButton].isEnabled)
         XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].isEnabled)
@@ -32,7 +32,7 @@ class SettingsScreenTests: BaseTest {
         settingsScreen.showCategorySwitch.tap()
         settingsScreen.leaveCategoryDetailButton.tap()
         
-        XCTAssertTrue(settingsScreen.locateCategoryCell(category).element.exists)
+        settingsScreen.locateCategoryCell(category)
         XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryUpButton].isEnabled)
         XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryDownButton].isEnabled)
         XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].isEnabled)

--- a/VocableUITests/Tests/SettingsScreenTests.swift
+++ b/VocableUITests/Tests/SettingsScreenTests.swift
@@ -38,6 +38,7 @@ class SettingsScreenTests: BaseTest {
         XCTAssertTrue(settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].isEnabled)
     }
 
+    // We are disabling this test for now, it will be updated after the issue is completed: https://github.com/willowtreeapps/vocable-ios/issues/492
     func testReorder() {
         let generalCategoryText = "1. General"
         let basicNeedsCategoryText = "2. Basic Needs"
@@ -62,6 +63,7 @@ class SettingsScreenTests: BaseTest {
 
     }
 
+    // We are disabling this test for now, it will be fixed and moved to Custom Categories Tests: https://github.com/willowtreeapps/vocable-ios/issues/514
     func testAddCustomCategory() {
 
         let customCategory = "ddingcustomcategorytest"


### PR DESCRIPTION
testHideShowToggle is fixed, closes #480 
The parent issue to #480 is #405 

# Description of Work
Fixed broken settings screen test. This is part of the effort to unlink the chained tests.
