### PR TITLE
Fix failing tests on PR branch for 492

### DIFF
--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -32,7 +32,7 @@ class SettingsScreen: BaseScreen {
     let alertDeleteButton = XCUIApplication().buttons["Delete"]
 
     func openCategorySettings(category: String) {
-        locateCategoryCell(category).buttons[categoryForwardButton].tap()
+        locateCategoryCell(category).staticTexts[category].tap()
     }
     
     func locateCategoryCell(_ category: String) -> XCUIElementQuery {

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -20,8 +20,8 @@ class SettingsScreen: BaseScreen {
     let otherElements = XCUIApplication().collectionViews.cells.otherElements
     let cells = XCUIApplication().cells
     let settingsPageNextButton = XCUIApplication().buttons["bottomPagination.right_chevron"]
-    let categoryUpButton = "go up"
-    let categoryDownButton = "go down"
+    let categoryUpButton = "chevron.up"
+    let categoryDownButton = "chevron.down"
     let categoryForwardButton = "Forward"
     let showCategorySwitch = XCUIApplication().switches["show_category_toggle"]
     let hideCategorySwitch = "hide"

--- a/VocableUITests/Tests/CustomCategoriesTests.swift
+++ b/VocableUITests/Tests/CustomCategoriesTests.swift
@@ -70,7 +70,7 @@ class CustomCategoriesTests: CustomCategoriesBaseTest {
         // TODO: customCategoriesScreen.categoriesPageDeletePhraseButton after Category List UI updates: issue #492 ... need identifiers?
         XCUIApplication().buttons["trash"].tap()
         settingsScreen.alertDeleteButton.tap()
-        XCTAssertFalse(mainScreen.isTextDisplayed(customPhrase), "Expected the phrase \(customPhrase) to not be displayed")
+        XCTAssertTrue(customCategoriesScreen.emptyStateAddPhraseButton.exists, "Expected the phrase \(customPhrase) to not be displayed")
     }
     
     func testCanAddDuplicatePhrasesToCategories() {

--- a/VocableUITests/Tests/SettingsScreenTests.swift
+++ b/VocableUITests/Tests/SettingsScreenTests.swift
@@ -25,17 +25,17 @@ class SettingsScreenTests: BaseTest {
         let hiddenCategory = settingsScreen.locateCategoryCell(category)
         XCTAssertFalse(hiddenCategory.buttons[settingsScreen.categoryUpButton].isEnabled)
         XCTAssertFalse(hiddenCategory.buttons[settingsScreen.categoryDownButton].isEnabled)
-        XCTAssertTrue(hiddenCategory.buttons[settingsScreen.categoryForwardButton].isEnabled)
+        XCTAssertTrue(hiddenCategory.element.isEnabled)
 
         // Verify that when the category is shown, up and down buttons are enabled.
-        settingsScreen.locateCategoryCell(category).buttons[settingsScreen.categoryForwardButton].tap()
+        settingsScreen.openCategorySettings(category: category)
         settingsScreen.showCategorySwitch.tap()
         settingsScreen.leaveCategoryDetailButton.tap()
         
         let shownCategory = settingsScreen.locateCategoryCell(category)
         XCTAssertTrue(shownCategory.buttons[settingsScreen.categoryUpButton].isEnabled)
         XCTAssertTrue(shownCategory.buttons[settingsScreen.categoryDownButton].isEnabled)
-        XCTAssertTrue(shownCategory.buttons[settingsScreen.categoryForwardButton].isEnabled)
+        XCTAssertTrue(shownCategory.element.isEnabled)
     }
 
     // We are disabling this test for now, it will be updated after the issue is completed: https://github.com/willowtreeapps/vocable-ios/issues/492


### PR DESCRIPTION
# Description
Fixing failing tests on 'Edit Categories Redesign' PR branch: #508 

All of this work is associated with https://github.com/willowtreeapps/vocable-ios/issues/492

The only things changed were the queries to locate and interact with the category cells, and a category's up/down buttons. Everything else is from current `develop` which was not in the PR branch at the time. So this branch will bring PR 508's branch up-to-date with `develop`.

## Notes to Test
SettingsScreenTests `testReorder()` and `testAddCustomCategory()` are expected to be disabled. The only tests that should run are:
**CustomCategoriesTests**
    - _testAddNewPhrase()
    - testCustomPhraseEdit()
    - testDeleteCustomPhrase()
    - testCanAddDuplicatePhrasesToCategories()_
**KeyboardScreenTests**
    - _testKeyboardOutputIsDisplayed()
    - testAddPhraseToMySayingsFromKeyboard()
    - testRemovePhraseFromMySayingsFromKeyboard()_ 
**SettingsScreenTests**
    - _testHideShowToggle()_
**MainScreenTests**
    - _testRecentScreen_ShowsPressedButtons()
    - testDefaultSayingsInGeneralCategoryExist()
    - testWhenTappingPhrase_ThenThatPhraseDisplaysOnOutputLabel()
    - testWhenTapping123Phrase_ThenThatPhraseDisplaysOnOutputLabel()_

