### PR TITLE
[CI] Attempt only exporting to Crowdin from develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,9 @@ workflows:
             branches:
               ignore: /crowdin.*/ 
       - export-localizations-for-crowdin:
+          filters:
+            branches:
+              only: develop
           requires:
             - build-and-test
       - buildanddeploytotestflight:


### PR DESCRIPTION
Experimental pipeline update to only export translations from the develop branch. Goal is to reduce noise and build failures for Crowdin PRs. More work may be needed.