### PR TITLE
#531 | Fixing Disabled Color State

### DIFF
--- a/Vocable/Common/Views/GazeableButton.swift
+++ b/Vocable/Common/Views/GazeableButton.swift
@@ -122,6 +122,7 @@ class GazeableButton: UIButton {
         setFillColor(.cellSelectionColor, for: [.selected, .highlighted])
         setTitleColor(.collectionViewBackgroundColor, for: .selected)
         setTitleColor(.collectionViewBackgroundColor, for: [.selected, .highlighted])
+        setTitleColor(.white.withAlphaComponent(0.5), for: .disabled)
         titleLabel?.numberOfLines = 3
         contentEdgeInsets = .init(top: 8, left: 8, bottom: 8, right: 8)
         layoutMargins = .zero
@@ -192,6 +193,11 @@ class GazeableButton: UIButton {
             let disabledColor = color?.disabled(blending: backgroundColor ?? .orange)
             super.setTitleColor(disabledColor, for: disabledState)
         }
+    }
+
+    override func setAttributedTitle(_ title: NSAttributedString?, for state: UIControl.State) {
+        super.setAttributedTitle(title, for: state)
+        setTitleColor(titleColor(for: state), for: state)
     }
 
     private func updateSelectionAppearance() {

--- a/Vocable/Common/VocableListCell/VocableListContentConfiguration.swift
+++ b/Vocable/Common/VocableListCell/VocableListContentConfiguration.swift
@@ -62,8 +62,7 @@ struct VocableListContentConfiguration: UIContentConfiguration, Equatable {
         accessibilityLabel: String? = nil,
         primaryAction: @escaping () -> Void
     ) {
-        let attributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.white,
-                                                         .font: UIFont.systemFont(ofSize: 22, weight: .bold)]
+        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 22, weight: .bold)]
 
         let attributedText = NSAttributedString(string: title, attributes: attributes)
 

--- a/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
@@ -416,8 +416,7 @@ private extension NSAttributedString {
             .localizedStringWithFormat(" %@", buttonText)
 
         let attributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 22, weight: .bold),
-            .foregroundColor: UIColor.white
+            .font: UIFont.systemFont(ofSize: 22, weight: .bold)
         ]
 
         let text = NSMutableAttributedString(string: formatString, attributes: attributes)

--- a/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
+++ b/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
@@ -256,17 +256,13 @@ private extension EditPhrasesViewController {
     func phraseCellRegistration() ->
     UICollectionView.CellRegistration<VocableListCell, Phrase> {
         return .init { cell, _, phrase in
-            let attributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.white,
-                                                             .font: UIFont.systemFont(ofSize: 22, weight: .bold)]
-
-            let attributedText = NSAttributedString(string: phrase.utterance ?? "", attributes: attributes)
             let phraseIdentifier = phrase.objectID
 
             let deleteAction = VocableListCellAction.delete { [weak self] in
                 self?.presentDeletionPromptForPhrase(with: phraseIdentifier)
             }
 
-            cell.contentConfiguration = VocableListContentConfiguration(attributedText: attributedText,
+            cell.contentConfiguration = VocableListContentConfiguration(title: phrase.utterance ?? "",
                                                                         actions: [deleteAction],
                                                                         accessory: .disclosureIndicator()) { [weak self] in
                 self?.presentEditorForPhrase(with: phraseIdentifier)


### PR DESCRIPTION
closes #531

# Description of Work
Fixes a bug where title text color of the new configured cells weren't changing to a lower alpha color for its disabled state. The issue was resolved by not setting the foreground color for the attributed title & manually setting the title color after setting the attributed text in `GazeableButton`

Before:
<img src=https://user-images.githubusercontent.com/37670742/161619452-49bd081e-7e81-4d2f-811e-88e61b528762.png>

After:
<img src=https://user-images.githubusercontent.com/37670742/161618926-ad5e5291-69c9-4bf9-ba2d-a4b84e2cbf33.png>

---
