### PR TITLE
#493 | Toast styling update 🍞 

### DIFF
--- a/Vocable/Common/ToastContainerViewController.swift
+++ b/Vocable/Common/ToastContainerViewController.swift
@@ -17,6 +17,7 @@ class ToastContainerViewController: UIViewController {
             updateWindowVisibility()
         }
     }
+
     private weak var warningView: UIView? {
         didSet {
             updateWindowVisibility()
@@ -39,48 +40,46 @@ class ToastContainerViewController: UIViewController {
     // In the future we should get away from manipulating the window here.
     func handlePhraseSaved(toastLabelText: String) {
         if phraseSavedView == nil {
-            let phraseSavedView = UINib(nibName: "ToastView", bundle: .main).instantiate(withOwner: nil, options: nil).first as! ToastView
+            let phraseSavedView = UINib(nibName: "ToastView", bundle: .main)
+                .instantiate(withOwner: nil, options: nil).first as! ToastView
             phraseSavedView.alpha = 0
             phraseSavedView.text = toastLabelText
-            self.phraseSavedView = phraseSavedView
             view.addSubview(phraseSavedView)
             phraseSavedView.translatesAutoresizingMaskIntoConstraints = false
-            
-            let horizontalPadding: CGFloat = [traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass].contains(.compact) ? 16 : 24
+
             NSLayoutConstraint.activate([
-                phraseSavedView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor),
-                phraseSavedView.leftAnchor.constraint(greaterThanOrEqualTo: view.leftAnchor,
-                                                      constant: horizontalPadding),
-                phraseSavedView.rightAnchor.constraint(lessThanOrEqualTo: view.rightAnchor,
-                                                       constant: horizontalPadding),
-                phraseSavedView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
+                phraseSavedView.widthAnchor.constraint(equalTo: view.readableContentGuide.widthAnchor, multiplier: 0.9),
                 phraseSavedView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
                 phraseSavedView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
             ])
+
+            self.phraseSavedView = phraseSavedView
         }
 
-         let fadeInOutDuration: TimeInterval = 0.5
-         let presentationDuration: TimeInterval = 4
+        let fadeInOutDuration: TimeInterval = 0.5
+        let presentationDuration: TimeInterval = 4
 
-         // Fade in
-         UIView.animate(withDuration: fadeInOutDuration,
-                        delay: 0,
-                        options: [.beginFromCurrentState, .curveEaseIn],
-                        animations: { self.phraseSavedView?.alpha = 1 },
-                        completion: { [weak self] entranceDidFinish in
+        // Fade in
+        UIView.animate(
+            withDuration: fadeInOutDuration,
+            delay: 0,
+            options: [.beginFromCurrentState, .curveEaseIn],
+            animations: { self.phraseSavedView?.alpha = 1 },
+            completion: { [weak self] entranceDidFinish in
 
-                         guard entranceDidFinish else { return }
+                guard entranceDidFinish else { return }
 
-                         // Fade out
-                         UIView.animate(withDuration: fadeInOutDuration,
-                                        delay: presentationDuration,
-                                        options: [.beginFromCurrentState, .curveEaseOut],
-                                        animations: { self?.phraseSavedView?.alpha = 0 },
-                                        completion: { dismissalDidFinish in
-                                         guard dismissalDidFinish else { return }
-                                         self?.phraseSavedView?.removeFromSuperview()
-                         })
-         })
+                // Fade out
+                UIView.animate(
+                    withDuration: fadeInOutDuration,
+                    delay: presentationDuration,
+                    options: [.beginFromCurrentState, .curveEaseOut],
+                    animations: { self?.phraseSavedView?.alpha = 0 },
+                    completion: { dismissalDidFinish in
+                        guard dismissalDidFinish else { return }
+                        self?.phraseSavedView?.removeFromSuperview()
+                    })
+            })
     }
     
     func handleWarning(with title: String?, shouldDisplay: Bool) {

--- a/Vocable/Common/ToastContainerViewController.swift
+++ b/Vocable/Common/ToastContainerViewController.swift
@@ -57,8 +57,8 @@ class ToastContainerViewController: UIViewController {
             self.phraseSavedView = phraseSavedView
         }
 
-        let fadeInOutDuration: TimeInterval = 0.5
-        let presentationDuration: TimeInterval = 4
+        let fadeInOutDuration: TimeInterval = 0.3
+        let presentationDuration: TimeInterval = 2
 
         // Fade in
         UIView.animate(

--- a/Vocable/Common/ToastContainerViewController.swift
+++ b/Vocable/Common/ToastContainerViewController.swift
@@ -48,7 +48,8 @@ class ToastContainerViewController: UIViewController {
             phraseSavedView.translatesAutoresizingMaskIntoConstraints = false
 
             NSLayoutConstraint.activate([
-                phraseSavedView.widthAnchor.constraint(equalTo: view.readableContentGuide.widthAnchor, multiplier: 0.9),
+                phraseSavedView.widthAnchor.constraint(lessThanOrEqualTo: view.readableContentGuide.widthAnchor, multiplier: 0.9),
+                phraseSavedView.heightAnchor.constraint(lessThanOrEqualTo: view.layoutMarginsGuide.heightAnchor),
                 phraseSavedView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
                 phraseSavedView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
             ])

--- a/Vocable/Common/Views/ToastView.swift
+++ b/Vocable/Common/Views/ToastView.swift
@@ -9,21 +9,10 @@
 import UIKit
 
 @IBDesignable
-class ToastView: BorderedView {
+class ToastView: UIView {
     
+    @IBOutlet private var iconView: UIImageView!
     @IBOutlet private var titleLabel: UILabel!
-    
-    override var bounds: CGRect {
-        didSet {
-            cornerRadius = bounds.height / 2
-        }
-    }
-
-    override var frame: CGRect {
-        didSet {
-            cornerRadius = frame.height / 2
-        }
-    }
     
     var text: String = "" {
         didSet {
@@ -31,9 +20,23 @@ class ToastView: BorderedView {
         }
     }
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        setContentHuggingPriority(.required, for: .vertical)
-        setContentHuggingPriority(.required, for: .horizontal)
+    init() {
+        super.init(frame: .zero)
+        commonInit()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        layer.cornerRadius = 30
+        layer.masksToBounds = true
     }
 }

--- a/Vocable/Common/Views/ToastView.xib
+++ b/Vocable/Common/Views/ToastView.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -10,46 +11,72 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="yiJ-Tr-Jim" userLabel="ToastView" customClass="ToastView" customModule="Vocable" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="387" height="108"/>
+            <rect key="frame" x="0.0" y="0.0" width="451" height="205"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="750" text="Saved to My Sayings" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="fEx-Zh-S4e">
-                    <rect key="frame" x="32" y="16" width="323" height="76"/>
-                    <fontDescription key="fontDescription" type="boldSystem" pointSize="48"/>
-                    <color key="textColor" name="DefaultFontColor"/>
-                    <nil key="highlightedColor"/>
-                    <variation key="widthClass=compact">
-                        <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
-                    </variation>
-                </label>
+                <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6o7-c4-Q9C">
+                    <rect key="frame" x="0.0" y="0.0" width="451" height="205"/>
+                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="FnF-1G-0bh">
+                        <rect key="frame" x="0.0" y="0.0" width="451" height="205"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="QaH-Bg-RM9">
+                                <rect key="frame" x="62.5" y="45" width="326.5" height="115"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="P6c-SV-8Wb">
+                                        <rect key="frame" x="139.5" y="3.5" width="47" height="44"/>
+                                        <color key="tintColor" name="DefaultFontColor"/>
+                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="41" weight="bold"/>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="750" text="Saved to My Sayings" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEx-Zh-S4e">
+                                        <rect key="frame" x="0.0" y="74" width="326.5" height="41"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="48"/>
+                                        <color key="textColor" name="DefaultFontColor"/>
+                                        <nil key="highlightedColor"/>
+                                        <variation key="heightClass=compact">
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
+                                        </variation>
+                                        <variation key="widthClass=compact">
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
+                                        </variation>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="QaH-Bg-RM9" secondAttribute="bottom" constant="45" id="GZL-1c-IuY"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QaH-Bg-RM9" secondAttribute="trailing" constant="20" id="K74-LG-PVG"/>
+                            <constraint firstItem="QaH-Bg-RM9" firstAttribute="centerX" secondItem="FnF-1G-0bh" secondAttribute="centerX" id="Mt7-aU-2wG"/>
+                            <constraint firstItem="QaH-Bg-RM9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="FnF-1G-0bh" secondAttribute="leading" constant="20" id="SYI-gc-ijH"/>
+                            <constraint firstItem="QaH-Bg-RM9" firstAttribute="top" secondItem="FnF-1G-0bh" secondAttribute="top" constant="45" id="g5Q-aF-rMC"/>
+                        </constraints>
+                    </view>
+                    <blurEffect style="systemUltraThinMaterialDark"/>
+                </visualEffectView>
             </subviews>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <accessibility key="accessibilityConfiguration" identifier="ToastView"/>
             <constraints>
-                <constraint firstAttribute="trailingMargin" secondItem="fEx-Zh-S4e" secondAttribute="trailing" id="GWB-Ur-efQ"/>
-                <constraint firstItem="fEx-Zh-S4e" firstAttribute="top" secondItem="yiJ-Tr-Jim" secondAttribute="topMargin" id="U0j-0K-NGR"/>
-                <constraint firstItem="fEx-Zh-S4e" firstAttribute="leading" secondItem="yiJ-Tr-Jim" secondAttribute="leadingMargin" id="eSP-vo-rwj"/>
-                <constraint firstAttribute="bottomMargin" secondItem="fEx-Zh-S4e" secondAttribute="bottom" id="jqx-on-aBa"/>
+                <constraint firstAttribute="trailing" secondItem="6o7-c4-Q9C" secondAttribute="trailing" id="Gz5-RM-xkm"/>
+                <constraint firstItem="6o7-c4-Q9C" firstAttribute="leading" secondItem="yiJ-Tr-Jim" secondAttribute="leading" id="OOC-d2-HmL"/>
+                <constraint firstAttribute="bottom" secondItem="6o7-c4-Q9C" secondAttribute="bottom" id="Xc6-Il-Svk"/>
+                <constraint firstItem="6o7-c4-Q9C" firstAttribute="top" secondItem="yiJ-Tr-Jim" secondAttribute="top" id="YPC-Bb-fn2"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <edgeInsets key="layoutMargins" top="28" left="48" bottom="28" right="48"/>
-            <userDefinedRuntimeAttributes>
-                <userDefinedRuntimeAttribute type="color" keyPath="fillColor">
-                    <color key="value" red="0.12549019610000001" green="0.10980392160000001" blue="0.35686274509999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                </userDefinedRuntimeAttribute>
-            </userDefinedRuntimeAttributes>
             <variation key="widthClass=compact">
                 <edgeInsets key="layoutMargins" top="16" left="32" bottom="16" right="32"/>
             </variation>
             <connections>
+                <outlet property="iconView" destination="P6c-SV-8Wb" id="B0m-3L-7T4"/>
                 <outlet property="titleLabel" destination="fEx-Zh-S4e" id="JWw-AS-4Jo"/>
             </connections>
-            <point key="canvasLocation" x="313.768115942029" y="110.49107142857143"/>
+            <point key="canvasLocation" x="165.94202898550725" y="134.26339285714286"/>
         </view>
     </objects>
     <resources>
+        <image name="checkmark" catalog="system" width="128" height="114"/>
         <namedColor name="DefaultFontColor">
             <color red="0.81599998474121094" green="0.93199998140335083" blue="0.91299998760223389" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Vocable/Common/Views/ToastView.xib
+++ b/Vocable/Common/Views/ToastView.xib
@@ -11,55 +11,72 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="yiJ-Tr-Jim" userLabel="ToastView" customClass="ToastView" customModule="Vocable" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="451" height="205"/>
+            <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6o7-c4-Q9C">
-                    <rect key="frame" x="0.0" y="0.0" width="451" height="205"/>
-                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="FnF-1G-0bh">
-                        <rect key="frame" x="0.0" y="0.0" width="451" height="205"/>
+                <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cEE-Xk-FQp">
+                    <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
+                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="bv8-xY-Cf7">
+                        <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="QaH-Bg-RM9">
-                                <rect key="frame" x="62.5" y="45" width="326.5" height="115"/>
-                                <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="P6c-SV-8Wb">
-                                        <rect key="frame" x="139.5" y="3.5" width="47" height="44"/>
-                                        <color key="tintColor" name="DefaultFontColor"/>
-                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="41" weight="bold"/>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="750" text="Saved to My Sayings" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEx-Zh-S4e">
-                                        <rect key="frame" x="0.0" y="74" width="326.5" height="41"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="48"/>
-                                        <color key="textColor" name="DefaultFontColor"/>
-                                        <nil key="highlightedColor"/>
-                                        <variation key="heightClass=compact">
-                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
-                                        </variation>
-                                        <variation key="widthClass=compact">
-                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
-                                        </variation>
-                                    </label>
-                                </subviews>
-                            </stackView>
+                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X50-j0-cP3">
+                                <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="7vX-tI-ZLi">
+                                    <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="QaH-Bg-RM9">
+                                            <rect key="frame" x="45" y="45" width="426" height="187"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="P6c-SV-8Wb">
+                                                    <rect key="frame" x="189.5" y="3.5" width="47" height="116"/>
+                                                    <color key="tintColor" name="DefaultFontColor"/>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="41" weight="bold"/>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="750" text="Saved to My Sayings" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEx-Zh-S4e">
+                                                    <rect key="frame" x="50" y="146" width="326.5" height="41"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="48"/>
+                                                    <color key="textColor" name="DefaultFontColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <variation key="heightClass=compact">
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
+                                                    </variation>
+                                                    <variation key="widthClass=compact">
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
+                                                    </variation>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="QaH-Bg-RM9" secondAttribute="trailing" constant="45" id="DOG-fr-DQZ"/>
+                                        <constraint firstItem="QaH-Bg-RM9" firstAttribute="leading" secondItem="7vX-tI-ZLi" secondAttribute="leading" constant="45" id="aJR-yl-3zi"/>
+                                        <constraint firstAttribute="bottom" secondItem="QaH-Bg-RM9" secondAttribute="bottom" constant="45" id="lkV-9V-u6w"/>
+                                        <constraint firstItem="QaH-Bg-RM9" firstAttribute="top" secondItem="7vX-tI-ZLi" secondAttribute="top" constant="45" id="y0k-15-zJn"/>
+                                    </constraints>
+                                </view>
+                                <vibrancyEffect>
+                                    <blurEffect style="prominent"/>
+                                </vibrancyEffect>
+                            </visualEffectView>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="QaH-Bg-RM9" secondAttribute="bottom" constant="45" id="GZL-1c-IuY"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QaH-Bg-RM9" secondAttribute="trailing" constant="20" id="K74-LG-PVG"/>
-                            <constraint firstItem="QaH-Bg-RM9" firstAttribute="centerX" secondItem="FnF-1G-0bh" secondAttribute="centerX" id="Mt7-aU-2wG"/>
-                            <constraint firstItem="QaH-Bg-RM9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="FnF-1G-0bh" secondAttribute="leading" constant="20" id="SYI-gc-ijH"/>
-                            <constraint firstItem="QaH-Bg-RM9" firstAttribute="top" secondItem="FnF-1G-0bh" secondAttribute="top" constant="45" id="g5Q-aF-rMC"/>
+                            <constraint firstItem="X50-j0-cP3" firstAttribute="top" secondItem="bv8-xY-Cf7" secondAttribute="top" id="bml-hd-eKd"/>
+                            <constraint firstItem="X50-j0-cP3" firstAttribute="leading" secondItem="bv8-xY-Cf7" secondAttribute="leading" id="fKF-5O-TED"/>
+                            <constraint firstAttribute="trailing" secondItem="X50-j0-cP3" secondAttribute="trailing" id="jNe-WD-NOa"/>
+                            <constraint firstAttribute="bottom" secondItem="X50-j0-cP3" secondAttribute="bottom" id="qY6-qj-5AK"/>
                         </constraints>
                     </view>
-                    <blurEffect style="systemUltraThinMaterialDark"/>
+                    <blurEffect style="systemThinMaterialLight"/>
                 </visualEffectView>
             </subviews>
             <accessibility key="accessibilityConfiguration" identifier="ToastView"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="6o7-c4-Q9C" secondAttribute="trailing" id="Gz5-RM-xkm"/>
-                <constraint firstItem="6o7-c4-Q9C" firstAttribute="leading" secondItem="yiJ-Tr-Jim" secondAttribute="leading" id="OOC-d2-HmL"/>
-                <constraint firstAttribute="bottom" secondItem="6o7-c4-Q9C" secondAttribute="bottom" id="Xc6-Il-Svk"/>
-                <constraint firstItem="6o7-c4-Q9C" firstAttribute="top" secondItem="yiJ-Tr-Jim" secondAttribute="top" id="YPC-Bb-fn2"/>
+                <constraint firstAttribute="trailing" secondItem="cEE-Xk-FQp" secondAttribute="trailing" id="1NA-c5-U6Z"/>
+                <constraint firstItem="cEE-Xk-FQp" firstAttribute="leading" secondItem="yiJ-Tr-Jim" secondAttribute="leading" id="N1n-i8-TRC"/>
+                <constraint firstAttribute="bottom" secondItem="cEE-Xk-FQp" secondAttribute="bottom" id="lxF-sq-TCM"/>
+                <constraint firstItem="cEE-Xk-FQp" firstAttribute="top" secondItem="yiJ-Tr-Jim" secondAttribute="top" id="pYu-Mg-Qc6"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
@@ -72,7 +89,7 @@
                 <outlet property="iconView" destination="P6c-SV-8Wb" id="B0m-3L-7T4"/>
                 <outlet property="titleLabel" destination="fEx-Zh-S4e" id="JWw-AS-4Jo"/>
             </connections>
-            <point key="canvasLocation" x="165.94202898550725" y="134.26339285714286"/>
+            <point key="canvasLocation" x="211.59420289855075" y="158.37053571428569"/>
         </view>
     </objects>
     <resources>

--- a/Vocable/Common/Views/ToastView.xib
+++ b/Vocable/Common/Views/ToastView.xib
@@ -11,61 +11,43 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="yiJ-Tr-Jim" userLabel="ToastView" customClass="ToastView" customModule="Vocable" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
+            <rect key="frame" x="0.0" y="0.0" width="498" height="301"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cEE-Xk-FQp">
-                    <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
-                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="bv8-xY-Cf7">
-                        <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
+                <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3n5-ul-tdD">
+                    <rect key="frame" x="0.0" y="0.0" width="498" height="301"/>
+                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="K5i-Tb-aju">
+                        <rect key="frame" x="0.0" y="0.0" width="498" height="301"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X50-j0-cP3">
-                                <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
-                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="7vX-tI-ZLi">
-                                    <rect key="frame" x="0.0" y="0.0" width="516" height="277"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <subviews>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="QaH-Bg-RM9">
-                                            <rect key="frame" x="45" y="45" width="426" height="187"/>
-                                            <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="P6c-SV-8Wb">
-                                                    <rect key="frame" x="189.5" y="3.5" width="47" height="116"/>
-                                                    <color key="tintColor" name="DefaultFontColor"/>
-                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="41" weight="bold"/>
-                                                </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="750" text="Saved to My Sayings" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEx-Zh-S4e">
-                                                    <rect key="frame" x="50" y="146" width="326.5" height="41"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="48"/>
-                                                    <color key="textColor" name="DefaultFontColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                    <variation key="heightClass=compact">
-                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
-                                                    </variation>
-                                                    <variation key="widthClass=compact">
-                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
-                                                    </variation>
-                                                </label>
-                                            </subviews>
-                                        </stackView>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstAttribute="trailing" secondItem="QaH-Bg-RM9" secondAttribute="trailing" constant="45" id="DOG-fr-DQZ"/>
-                                        <constraint firstItem="QaH-Bg-RM9" firstAttribute="leading" secondItem="7vX-tI-ZLi" secondAttribute="leading" constant="45" id="aJR-yl-3zi"/>
-                                        <constraint firstAttribute="bottom" secondItem="QaH-Bg-RM9" secondAttribute="bottom" constant="45" id="lkV-9V-u6w"/>
-                                        <constraint firstItem="QaH-Bg-RM9" firstAttribute="top" secondItem="7vX-tI-ZLi" secondAttribute="top" constant="45" id="y0k-15-zJn"/>
-                                    </constraints>
-                                </view>
-                                <vibrancyEffect>
-                                    <blurEffect style="prominent"/>
-                                </vibrancyEffect>
-                            </visualEffectView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="QaH-Bg-RM9">
+                                <rect key="frame" x="45" y="45" width="408" height="211"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="P6c-SV-8Wb">
+                                        <rect key="frame" x="180.5" y="3.5" width="47" height="140"/>
+                                        <color key="tintColor" name="Background"/>
+                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="41" weight="bold"/>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="750" text="Saved to My Sayings" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEx-Zh-S4e">
+                                        <rect key="frame" x="41" y="170" width="326.5" height="41"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="48"/>
+                                        <color key="textColor" name="Background"/>
+                                        <nil key="highlightedColor"/>
+                                        <variation key="heightClass=compact">
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
+                                        </variation>
+                                        <variation key="widthClass=compact">
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
+                                        </variation>
+                                    </label>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="X50-j0-cP3" firstAttribute="top" secondItem="bv8-xY-Cf7" secondAttribute="top" id="bml-hd-eKd"/>
-                            <constraint firstItem="X50-j0-cP3" firstAttribute="leading" secondItem="bv8-xY-Cf7" secondAttribute="leading" id="fKF-5O-TED"/>
-                            <constraint firstAttribute="trailing" secondItem="X50-j0-cP3" secondAttribute="trailing" id="jNe-WD-NOa"/>
-                            <constraint firstAttribute="bottom" secondItem="X50-j0-cP3" secondAttribute="bottom" id="qY6-qj-5AK"/>
+                            <constraint firstAttribute="trailing" secondItem="QaH-Bg-RM9" secondAttribute="trailing" constant="45" id="J0s-xh-rRF"/>
+                            <constraint firstItem="QaH-Bg-RM9" firstAttribute="leading" secondItem="K5i-Tb-aju" secondAttribute="leading" constant="45" id="Yx9-3A-IXp"/>
+                            <constraint firstItem="QaH-Bg-RM9" firstAttribute="top" secondItem="K5i-Tb-aju" secondAttribute="top" constant="45" id="sBv-LN-eaW"/>
+                            <constraint firstAttribute="bottom" secondItem="QaH-Bg-RM9" secondAttribute="bottom" constant="45" id="zVr-gy-Bd8"/>
                         </constraints>
                     </view>
                     <blurEffect style="systemThinMaterialLight"/>
@@ -73,10 +55,10 @@
             </subviews>
             <accessibility key="accessibilityConfiguration" identifier="ToastView"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="cEE-Xk-FQp" secondAttribute="trailing" id="1NA-c5-U6Z"/>
-                <constraint firstItem="cEE-Xk-FQp" firstAttribute="leading" secondItem="yiJ-Tr-Jim" secondAttribute="leading" id="N1n-i8-TRC"/>
-                <constraint firstAttribute="bottom" secondItem="cEE-Xk-FQp" secondAttribute="bottom" id="lxF-sq-TCM"/>
-                <constraint firstItem="cEE-Xk-FQp" firstAttribute="top" secondItem="yiJ-Tr-Jim" secondAttribute="top" id="pYu-Mg-Qc6"/>
+                <constraint firstAttribute="trailing" secondItem="3n5-ul-tdD" secondAttribute="trailing" id="F9f-5t-MSD"/>
+                <constraint firstItem="3n5-ul-tdD" firstAttribute="leading" secondItem="yiJ-Tr-Jim" secondAttribute="leading" id="VSp-52-I5s"/>
+                <constraint firstItem="3n5-ul-tdD" firstAttribute="top" secondItem="yiJ-Tr-Jim" secondAttribute="top" id="fgs-hm-2WT"/>
+                <constraint firstAttribute="bottom" secondItem="3n5-ul-tdD" secondAttribute="bottom" id="wpM-l0-JLC"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
@@ -89,13 +71,13 @@
                 <outlet property="iconView" destination="P6c-SV-8Wb" id="B0m-3L-7T4"/>
                 <outlet property="titleLabel" destination="fEx-Zh-S4e" id="JWw-AS-4Jo"/>
             </connections>
-            <point key="canvasLocation" x="211.59420289855075" y="158.37053571428569"/>
+            <point key="canvasLocation" x="28.985507246376812" y="142.29910714285714"/>
         </view>
     </objects>
     <resources>
         <image name="checkmark" catalog="system" width="128" height="114"/>
-        <namedColor name="DefaultFontColor">
-            <color red="0.81599998474121094" green="0.93199998140335083" blue="0.91299998760223389" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="Background">
+            <color red="0.12800000607967377" green="0.10899999737739563" blue="0.3580000102519989" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
Closes #493

# Description of Work

This PR updates the visual styling of the Toast to add a check mark icon and blur the background

## Screenshots
(Design subject to change)

<img width=300 src=https://user-images.githubusercontent.com/9791664/162049472-bbb2e387-f52e-4493-a7fb-3eb73e53b6ee.png>&nbsp;&nbsp;&nbsp;&nbsp;<img width=300 src=https://user-images.githubusercontent.com/9791664/162049474-4df501c6-b776-437a-a26e-5cdb4e0a9401.png>
<img width=700 src=https://user-images.githubusercontent.com/9791664/162049468-ec6f62de-36b2-4e0c-8b79-5f7c8d3c90e8.png>

