### PR TITLE
#490 | Fixing Audio in Silent Mode 🔈 

### DIFF
--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -63,13 +63,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Warm up the speech engine to prevent lag on first invocation
         AVSpeechSynthesizer.shared.speak("", language: "en")
 
-        // Allows audio to be played in silent mode
-        do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio, options: .duckOthers)
-        } catch let error {
-            print("Failed to set audio category: \(error.localizedDescription)")
-        }
-
         application.isIdleTimerDisabled = true
 
         NotificationCenter.default.addObserver(self,

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -63,6 +63,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Warm up the speech engine to prevent lag on first invocation
         AVSpeechSynthesizer.shared.speak("", language: "en")
 
+        // Allows audio to be played in silent mode
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback)
+        } catch let error {
+            print("Failed to set audio category: \(error.localizedDescription)")
+        }
+
         application.isIdleTimerDisabled = true
 
         NotificationCenter.default.addObserver(self,

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -65,7 +65,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Allows audio to be played in silent mode
         do {
-            try AVAudioSession.sharedInstance().setCategory(.playback)
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio, options: .duckOthers)
         } catch let error {
             print("Failed to set audio category: \(error.localizedDescription)")
         }

--- a/Vocable/Features/Voice/SpeechRecognitionController.swift
+++ b/Vocable/Features/Voice/SpeechRecognitionController.swift
@@ -19,7 +19,7 @@ class SpeechRecognitionController: NSObject, SFSpeechRecognitionTaskDelegate, SF
 
     static let shared = SpeechRecognitionController()
 
-    private let audioController = AudioEngineController()
+    private let audioController = AudioEngineController.shared
 
     @Published private(set) var isAvailable: Bool = true
 


### PR DESCRIPTION
closes #490

# Description of Work
The audio was not playing in silent mode when tapping on phrases or reading out text. To fix this, the `AudioEngineCategory` is initialized as a property in `SpeechRecognitionController` so that the audio session category is initially set to `playback` to allow audio in silent mode. Also fixed issue where audio session wasn't switching back to `playback` after turning off listening mode.

---
