### PR TITLE
#487 | Fixing Animation Bug Switching Between Categories 🐛 

### DIFF
--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -206,7 +206,7 @@ import Combine
             }
 
             self.collectionView(self.collectionView, didSelectItemAt: newPath)
-            self.collectionView.scrollToNearestSelectedIndexPathOrCurrentPageBoundary(animated: true)
+            self.collectionView.scrollToNearestSelectedIndexPathOrCurrentPageBoundary(animated: false)
         })
     }
 

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -111,7 +111,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
         }
 
         if pageCountBefore < 2, pageCountAfter > 1 {
-            collectionView.scrollToMiddleSection(animated: true)
+            collectionView.scrollToMiddleSection(animated: false)
         }
     }
 


### PR DESCRIPTION
closes #487

# Description of Work
Fixes issue where categories with multiple pages animate horizontally multiple times when transitioning to a new category. This issue was fixed by disabling animations when offsetting to the middle section every time the data source changes for infinite scroll purposes.

---
