### PR TITLE
#538, #539, & #540 | Add Phrase Cell Button ➕ 

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		A920A4AF23EA1BD300CF5B08 /* LegacyLayoutSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A920A4AE23EA1BD300CF5B08 /* LegacyLayoutSupport.swift */; };
 		A9299C7523F5FBEE00903AB6 /* KeyboardKeyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9299C7423F5FBEE00903AB6 /* KeyboardKeyCollectionViewCell.swift */; };
 		A9299C7723F5FC6F00903AB6 /* KeyboardKeyCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A9299C7623F5FC6F00903AB6 /* KeyboardKeyCollectionViewCell.xib */; };
+		A93E46F7280614680081D544 /* NSDiffableDataSourceSnapshot+Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93E46F6280614670081D544 /* NSDiffableDataSourceSnapshot+Map.swift */; };
 		A93E9403244E00A6008B61D2 /* UICollectionView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93E9402244E00A5008B61D2 /* UICollectionView+Helpers.swift */; };
 		A93E94052450EEC8008B61D2 /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93E94042450EEC8008B61D2 /* KeyboardViewController.swift */; };
 		A944D0052405AE8C00F3863E /* GazeableButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A944D0042405AE8C00F3863E /* GazeableButton.swift */; };
@@ -371,6 +372,7 @@
 		A920A4AE23EA1BD300CF5B08 /* LegacyLayoutSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyLayoutSupport.swift; sourceTree = "<group>"; };
 		A9299C7423F5FBEE00903AB6 /* KeyboardKeyCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardKeyCollectionViewCell.swift; sourceTree = "<group>"; };
 		A9299C7623F5FC6F00903AB6 /* KeyboardKeyCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = KeyboardKeyCollectionViewCell.xib; sourceTree = "<group>"; };
+		A93E46F6280614670081D544 /* NSDiffableDataSourceSnapshot+Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDiffableDataSourceSnapshot+Map.swift"; sourceTree = "<group>"; };
 		A93E9402244E00A5008B61D2 /* UICollectionView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Helpers.swift"; sourceTree = "<group>"; };
 		A93E94042450EEC8008B61D2 /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
 		A944D0042405AE8C00F3863E /* GazeableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GazeableButton.swift; sourceTree = "<group>"; };
@@ -888,6 +890,7 @@
 				6B5C73A827DFE63600004713 /* NSPredicate+Operators.swift */,
 				4E014DA927EA53BC00561FC8 /* NSRange+.swift */,
 				4E8A303B27EBB95C000177B1 /* BidirectionalCollection+.swift */,
+				A93E46F6280614670081D544 /* NSDiffableDataSourceSnapshot+Map.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1170,6 +1173,7 @@
 				6B9DFA6423E889DB0037673E /* UIHeadGazeRecognizer.swift in Sources */,
 				64A220BB2452171C0014EA80 /* RootViewController.swift in Sources */,
 				A961605027F6383B00CE2F72 /* FreeResponseTextEditorConfigurationProvider.swift in Sources */,
+				A93E46F7280614680081D544 /* NSDiffableDataSourceSnapshot+Map.swift in Sources */,
 				6B17CD8023EA045D0050BCB8 /* ViewControllerWrapperView.swift in Sources */,
 				B8DA9DF223F30BAF00FEBE19 /* Cell+NibLoading.swift in Sources */,
 				6BB56BA82422AC2500EA787E /* ToastView.swift in Sources */,

--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -172,6 +172,8 @@
 		A9DFCC20242D020100136136 /* PublishedValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFCC1F242D020100136136 /* PublishedValue.swift */; };
 		A9E665A7241A785F00FE577A /* CarouselGridCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E665A6241A785F00FE577A /* CarouselGridCollectionViewController.swift */; };
 		A9F56FC824365BE8008162B6 /* SpeakFunctionKeyboardKeyCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A9F56FC724365BE8008162B6 /* SpeakFunctionKeyboardKeyCollectionViewCell.xib */; };
+		A9FD68A528008AD3006ABA3F /* AddPhraseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FD68A428008AD3006ABA3F /* AddPhraseCollectionViewCell.swift */; };
+		A9FD68A728009646006ABA3F /* AttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FD68A628009646006ABA3F /* AttributedString+Helpers.swift */; };
 		B838200F23F4B011005A79CD /* VocableCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B838200E23F4B011005A79CD /* VocableCollectionViewCell.swift */; };
 		B879831523E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */; };
 		B8DA9DE823EB833200FEBE19 /* BorderedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA9DE723EB833200FEBE19 /* BorderedView.swift */; };
@@ -403,6 +405,8 @@
 		A9DFCC1F242D020100136136 /* PublishedValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedValue.swift; sourceTree = "<group>"; };
 		A9E665A6241A785F00FE577A /* CarouselGridCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselGridCollectionViewController.swift; sourceTree = "<group>"; };
 		A9F56FC724365BE8008162B6 /* SpeakFunctionKeyboardKeyCollectionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SpeakFunctionKeyboardKeyCollectionViewCell.xib; sourceTree = "<group>"; };
+		A9FD68A428008AD3006ABA3F /* AddPhraseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhraseCollectionViewCell.swift; sourceTree = "<group>"; };
+		A9FD68A628009646006ABA3F /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
 		B838200E23F4B011005A79CD /* VocableCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableCollectionViewCell.swift; sourceTree = "<group>"; };
 		B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetItemCollectionViewCell.swift; sourceTree = "<group>"; };
 		B8D55689242FE8B900B0F6FE /* Phrases v2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Phrases v2.xcdatamodel"; sourceTree = "<group>"; };
@@ -836,6 +840,7 @@
 				A91525412447541200B9B815 /* TextEditorViewController.swift */,
 				6BE7E9832459D328007B01F2 /* PagingCarouselViewController.swift */,
 				B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */,
+				A9FD68A428008AD3006ABA3F /* AddPhraseCollectionViewCell.swift */,
 				6BB56BA92422B40200EA787E /* PublishedDefault.swift */,
 				A9DFCC1F242D020100136136 /* PublishedValue.swift */,
 				7192E40A242E6562008E4A0A /* ToastContainerViewController.swift */,
@@ -847,6 +852,7 @@
 				6B5C743F27E8CBBE00004713 /* VocableListCell */,
 				A91030B727E3C4FD00281C97 /* NSLayoutConstraint+Priority.swift */,
 				6B05020527F3516F000CFE5A /* CategoryReordering */,
+				A9FD68A628009646006ABA3F /* AttributedString+Helpers.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1199,6 +1205,7 @@
 				6B1C7F3223F5BB5200BB3FD9 /* HeadGazeTrackingInterpolator.swift in Sources */,
 				64D04A58242951C00006962D /* GazeableAlertPresentationController.swift in Sources */,
 				64599431258938F50010EEFF /* ListeningResponseViewController.swift in Sources */,
+				A9FD68A728009646006ABA3F /* AttributedString+Helpers.swift in Sources */,
 				6BD84F9D2604F8F600D4CD3E /* ListenModeDebugView.swift in Sources */,
 				6B8A6E3324536085004B5220 /* UIHeadGazeCursorWindow.swift in Sources */,
 				6B0501FE27EBA471000CFE5A /* VocableListCellAction.swift in Sources */,
@@ -1254,6 +1261,7 @@
 				6B5C490B245B73F700A4433C /* CategoriesCarouselViewController.swift in Sources */,
 				A90D790527F205E90032254E /* VocableListCellPrimaryButton.swift in Sources */,
 				A98E8A2323F1DBDF00BF1F22 /* SettingsFooterCollectionViewCell.swift in Sources */,
+				A9FD68A528008AD3006ABA3F /* AddPhraseCollectionViewCell.swift in Sources */,
 				A9CF2AF9242D4F0A005633A7 /* SensitivityCollectionViewCell.swift in Sources */,
 				6BE7E9842459D328007B01F2 /* PagingCarouselViewController.swift in Sources */,
 				6B9DFA6223E889DB0037673E /* UIVirtualCursorView.swift in Sources */,

--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -173,7 +173,7 @@
 		A9E665A7241A785F00FE577A /* CarouselGridCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E665A6241A785F00FE577A /* CarouselGridCollectionViewController.swift */; };
 		A9F56FC824365BE8008162B6 /* SpeakFunctionKeyboardKeyCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A9F56FC724365BE8008162B6 /* SpeakFunctionKeyboardKeyCollectionViewCell.xib */; };
 		A9FD68A528008AD3006ABA3F /* AddPhraseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FD68A428008AD3006ABA3F /* AddPhraseCollectionViewCell.swift */; };
-		A9FD68A728009646006ABA3F /* AttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FD68A628009646006ABA3F /* AttributedString+Helpers.swift */; };
+		A9FD68A728009646006ABA3F /* NSAttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FD68A628009646006ABA3F /* NSAttributedString+Helpers.swift */; };
 		B838200F23F4B011005A79CD /* VocableCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B838200E23F4B011005A79CD /* VocableCollectionViewCell.swift */; };
 		B879831523E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */; };
 		B8DA9DE823EB833200FEBE19 /* BorderedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA9DE723EB833200FEBE19 /* BorderedView.swift */; };
@@ -406,7 +406,7 @@
 		A9E665A6241A785F00FE577A /* CarouselGridCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselGridCollectionViewController.swift; sourceTree = "<group>"; };
 		A9F56FC724365BE8008162B6 /* SpeakFunctionKeyboardKeyCollectionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SpeakFunctionKeyboardKeyCollectionViewCell.xib; sourceTree = "<group>"; };
 		A9FD68A428008AD3006ABA3F /* AddPhraseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhraseCollectionViewCell.swift; sourceTree = "<group>"; };
-		A9FD68A628009646006ABA3F /* AttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Helpers.swift"; sourceTree = "<group>"; };
+		A9FD68A628009646006ABA3F /* NSAttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Helpers.swift"; sourceTree = "<group>"; };
 		B838200E23F4B011005A79CD /* VocableCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableCollectionViewCell.swift; sourceTree = "<group>"; };
 		B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetItemCollectionViewCell.swift; sourceTree = "<group>"; };
 		B8D55689242FE8B900B0F6FE /* Phrases v2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Phrases v2.xcdatamodel"; sourceTree = "<group>"; };
@@ -852,7 +852,7 @@
 				6B5C743F27E8CBBE00004713 /* VocableListCell */,
 				A91030B727E3C4FD00281C97 /* NSLayoutConstraint+Priority.swift */,
 				6B05020527F3516F000CFE5A /* CategoryReordering */,
-				A9FD68A628009646006ABA3F /* AttributedString+Helpers.swift */,
+				A9FD68A628009646006ABA3F /* NSAttributedString+Helpers.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1205,7 +1205,7 @@
 				6B1C7F3223F5BB5200BB3FD9 /* HeadGazeTrackingInterpolator.swift in Sources */,
 				64D04A58242951C00006962D /* GazeableAlertPresentationController.swift in Sources */,
 				64599431258938F50010EEFF /* ListeningResponseViewController.swift in Sources */,
-				A9FD68A728009646006ABA3F /* AttributedString+Helpers.swift in Sources */,
+				A9FD68A728009646006ABA3F /* NSAttributedString+Helpers.swift in Sources */,
 				6BD84F9D2604F8F600D4CD3E /* ListenModeDebugView.swift in Sources */,
 				6B8A6E3324536085004B5220 /* UIHeadGazeCursorWindow.swift in Sources */,
 				6B0501FE27EBA471000CFE5A /* VocableListCellAction.swift in Sources */,

--- a/Vocable/Common/AddPhraseCollectionViewCell.swift
+++ b/Vocable/Common/AddPhraseCollectionViewCell.swift
@@ -26,6 +26,8 @@ class AddPhraseCollectionViewCell: PresetItemCollectionViewCell {
     private func commonInit() {
         contentView.preservesSuperviewLayoutMargins = true
 
+        fillColor = .collectionViewBackgroundColor
+
         textLabel.numberOfLines = 1
         setup(title: NSLocalizedString("preset.category.add.phrase.title", comment: "Add phrase button title"),
               with: UIImage(systemName: "plus"))
@@ -38,31 +40,17 @@ class AddPhraseCollectionViewCell: PresetItemCollectionViewCell {
         if isHighlighted && !isSelected {
             borderedView.borderColor = .cellBorderHighlightColor
         } else if isSelected {
-            borderedView.borderColor = .collectionViewBackgroundColor
+            borderedView.borderColor = .cellSelectionColor
         } else {
             borderedView.borderColor = .categoryBackgroundColor
         }
 
         borderedView.backgroundColor = .collectionViewBackgroundColor
-        borderedView.fillColor = .collectionViewBackgroundColor
-        borderedView.borderWidth = borderWidth
+        borderedView.borderWidth = isSelected ? 0 : borderWidth
         borderedView.isOpaque = true
         borderedView.cornerRadius = cornerRadius
         borderedView.borderDashPattern = [6, 6]
 
         layoutMargins = .init(uniform: cornerRadius + borderWidth)
-    }
-}
-
-private extension NSAttributedString {
-    static var addPhraseTitle: NSAttributedString {
-        let text = NSLocalizedString("preset.category.add.phrase.title", comment: "Add phrase button title")
-        let image = UIImage(systemName: "plus")!
-        let font: UIFont = (UITraitCollection.current.horizontalSizeClass == .regular
-                            && UITraitCollection.current.verticalSizeClass == .regular)
-                            ? UIFont.systemFont(ofSize: 28, weight: .bold)
-                            : UIFont.systemFont(ofSize: 22, weight: .bold)
-        let attributes: [NSAttributedString.Key: Any] = [.font: font]
-        return NSAttributedString.imageAttachedString(for: text, with: image, attributes: attributes)
     }
 }

--- a/Vocable/Common/AddPhraseCollectionViewCell.swift
+++ b/Vocable/Common/AddPhraseCollectionViewCell.swift
@@ -16,12 +16,16 @@ class AddPhraseCollectionViewCell: VocableCollectionViewCell {
     override func updateContentViews() {
         super.updateContentViews()
 
-        dashedBorderView.strokeColor = isHighlighted ? nil : UIColor.categoryBackgroundColor.cgColor
+        if isHighlighted && !isSelected {
+            dashedBorderView.strokeColor = UIColor.cellBorderHighlightColor.cgColor
+        } else if isSelected {
+            dashedBorderView.strokeColor = nil
+        } else {
+            dashedBorderView.strokeColor = UIColor.categoryBackgroundColor.cgColor
+        }
 
         textLabel.textColor = isSelected ? .selectedTextColor : .defaultTextColor
-        textLabel.backgroundColor = .clear
-        textLabel.isOpaque = true
-        textLabel.font = UIFont.systemFont(ofSize: 28, weight: .bold)
+        dashedBorderView.fillColor = isSelected ? UIColor.cellSelectionColor.cgColor : nil
     }
 
     override init(frame: CGRect) {
@@ -38,20 +42,15 @@ class AddPhraseCollectionViewCell: VocableCollectionViewCell {
 
         contentView.preservesSuperviewLayoutMargins = true
 
-        fillColor = .clear
+        borderedView.isHidden = true
 
         dashedBorderView.strokeColor = UIColor.categoryBackgroundColor.cgColor
-        dashedBorderView.lineDashPattern = [8, 6]
-        dashedBorderView.frame = bounds
+        dashedBorderView.lineDashPattern = [6, 6]
         dashedBorderView.fillColor = nil
         dashedBorderView.lineWidth = 6
-        dashedBorderView.path = UIBezierPath(roundedRect: bounds, cornerRadius: 8).cgPath
-        layer.addSublayer(dashedBorderView)
+        contentView.layer.addSublayer(dashedBorderView)
 
-        let text = NSLocalizedString("preset.category.add.phrase.title", comment: "Add phrase button title")
-        let image = UIImage(systemName: "plus")!
-        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 22, weight: .bold)]
-        textLabel.attributedText = NSAttributedString.imageAttachedString(for: text, with: image, attributes: attributes)
+        textLabel.attributedText = .addPhraseTitle
         textLabel.textAlignment = .center
         textLabel.numberOfLines = 0
         textLabel.adjustsFontSizeToFitWidth = true
@@ -77,6 +76,12 @@ class AddPhraseCollectionViewCell: VocableCollectionViewCell {
         updateContentViews()
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        dashedBorderView.frame = bounds
+        dashedBorderView.path = UIBezierPath(roundedRect: bounds, cornerRadius: 8).cgPath
+    }
+
     func setup(title: String) {
         textLabel.text = title
         updateContentViews()
@@ -92,5 +97,14 @@ class AddPhraseCollectionViewCell: VocableCollectionViewCell {
 
         textLabel.attributedText = attributedString
         updateContentViews()
+    }
+}
+
+private extension NSAttributedString {
+    static var addPhraseTitle: NSAttributedString {
+        let text = NSLocalizedString("preset.category.add.phrase.title", comment: "Add phrase button title")
+        let image = UIImage(systemName: "plus")!
+        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 22, weight: .bold)]
+        return NSAttributedString.imageAttachedString(for: text, with: image, attributes: attributes)
     }
 }

--- a/Vocable/Common/AddPhraseCollectionViewCell.swift
+++ b/Vocable/Common/AddPhraseCollectionViewCell.swift
@@ -9,24 +9,9 @@
 import UIKit
 
 class AddPhraseCollectionViewCell: VocableCollectionViewCell {
-    let textLabel = UILabel(frame: .zero)
+    private let textLabel = UILabel(frame: .zero)
 
-    let dashedBorderView = CAShapeLayer()
-
-    override func updateContentViews() {
-        super.updateContentViews()
-
-        if isHighlighted && !isSelected {
-            dashedBorderView.strokeColor = UIColor.cellBorderHighlightColor.cgColor
-        } else if isSelected {
-            dashedBorderView.strokeColor = nil
-        } else {
-            dashedBorderView.strokeColor = UIColor.categoryBackgroundColor.cgColor
-        }
-
-        textLabel.textColor = isSelected ? .selectedTextColor : .defaultTextColor
-        dashedBorderView.fillColor = isSelected ? UIColor.cellSelectionColor.cgColor : nil
-    }
+    private let dashedBorderView = CAShapeLayer()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -61,11 +46,9 @@ class AddPhraseCollectionViewCell: VocableCollectionViewCell {
 
         // Needs a weak spot that can break while resizing to avoid
         // constraint errors
-        let rightConstraint = textLabel.rightAnchor.constraint(equalTo: contentView.layoutMarginsGuide.rightAnchor)
-        rightConstraint.priority = .init(999)
+        let rightConstraint = textLabel.rightAnchor.constraint(equalTo: contentView.layoutMarginsGuide.rightAnchor).withPriority(999)
+        let bottomConstraint = textLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor).withPriority(999)
 
-        let bottomConstraint = textLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
-        bottomConstraint.priority = .init(999)
         NSLayoutConstraint.activate([
             rightConstraint,
             textLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
@@ -76,27 +59,25 @@ class AddPhraseCollectionViewCell: VocableCollectionViewCell {
         updateContentViews()
     }
 
+    override func updateContentViews() {
+        super.updateContentViews()
+
+        if isHighlighted && !isSelected {
+            dashedBorderView.strokeColor = UIColor.cellBorderHighlightColor.cgColor
+        } else if isSelected {
+            dashedBorderView.strokeColor = nil
+        } else {
+            dashedBorderView.strokeColor = UIColor.categoryBackgroundColor.cgColor
+        }
+
+        textLabel.textColor = isSelected ? .selectedTextColor : .defaultTextColor
+        dashedBorderView.fillColor = isSelected ? UIColor.cellSelectionColor.cgColor : nil
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         dashedBorderView.frame = bounds
         dashedBorderView.path = UIBezierPath(roundedRect: bounds, cornerRadius: 8).cgPath
-    }
-
-    func setup(title: String) {
-        textLabel.text = title
-        updateContentViews()
-    }
-
-    func setup(with image: UIImage?) {
-        guard let image = image else {
-            return
-        }
-
-        let systemImageAttachment = NSTextAttachment(image: image)
-        let attributedString = NSAttributedString(attachment: systemImageAttachment)
-
-        textLabel.attributedText = attributedString
-        updateContentViews()
     }
 }
 

--- a/Vocable/Common/AddPhraseCollectionViewCell.swift
+++ b/Vocable/Common/AddPhraseCollectionViewCell.swift
@@ -8,10 +8,10 @@
 
 import UIKit
 
-class AddPhraseCollectionViewCell: VocableCollectionViewCell {
-    private let textLabel = UILabel(frame: .zero)
+class AddPhraseCollectionViewCell: PresetItemCollectionViewCell {
 
-    private let dashedBorderView = CAShapeLayer()
+    private let borderWidth = 6.0
+    private let cornerRadius = 8.0
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -24,34 +24,11 @@ class AddPhraseCollectionViewCell: VocableCollectionViewCell {
     }
 
     private func commonInit() {
-
         contentView.preservesSuperviewLayoutMargins = true
 
-        borderedView.isHidden = true
-
-        dashedBorderView.strokeColor = UIColor.categoryBackgroundColor.cgColor
-        dashedBorderView.lineDashPattern = [6, 6]
-        dashedBorderView.fillColor = nil
-        dashedBorderView.lineWidth = 6
-        contentView.layer.addSublayer(dashedBorderView)
-
-        textLabel.attributedText = .addPhraseTitle
-        textLabel.textAlignment = .center
-        textLabel.numberOfLines = 0
-        textLabel.adjustsFontSizeToFitWidth = true
-        textLabel.minimumScaleFactor = 0.5
-
-        textLabel.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(textLabel)
-
-        let layoutGuide = contentView.layoutMarginsGuide
-        NSLayoutConstraint.activate([
-            textLabel.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor).withPriority(999),
-            textLabel.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
-            textLabel.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor),
-            textLabel.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor).withPriority(999)
-        ])
-
+        textLabel.numberOfLines = 1
+        setup(title: NSLocalizedString("preset.category.add.phrase.title", comment: "Add phrase button title"),
+              with: UIImage(systemName: "plus"))
         updateContentViews()
     }
 
@@ -59,21 +36,21 @@ class AddPhraseCollectionViewCell: VocableCollectionViewCell {
         super.updateContentViews()
 
         if isHighlighted && !isSelected {
-            dashedBorderView.strokeColor = UIColor.cellBorderHighlightColor.cgColor
+            borderedView.borderColor = .cellBorderHighlightColor
         } else if isSelected {
-            dashedBorderView.strokeColor = nil
+            borderedView.borderColor = .collectionViewBackgroundColor
         } else {
-            dashedBorderView.strokeColor = UIColor.categoryBackgroundColor.cgColor
+            borderedView.borderColor = .categoryBackgroundColor
         }
 
-        textLabel.textColor = isSelected ? .selectedTextColor : .defaultTextColor
-        dashedBorderView.fillColor = isSelected ? UIColor.cellSelectionColor.cgColor : nil
-    }
+        borderedView.backgroundColor = .collectionViewBackgroundColor
+        borderedView.fillColor = .collectionViewBackgroundColor
+        borderedView.borderWidth = borderWidth
+        borderedView.isOpaque = true
+        borderedView.cornerRadius = cornerRadius
+        borderedView.borderDashPattern = [6, 6]
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        dashedBorderView.frame = bounds
-        dashedBorderView.path = UIBezierPath(roundedRect: bounds, cornerRadius: 8).cgPath
+        layoutMargins = .init(uniform: cornerRadius + borderWidth)
     }
 }
 

--- a/Vocable/Common/AddPhraseCollectionViewCell.swift
+++ b/Vocable/Common/AddPhraseCollectionViewCell.swift
@@ -44,16 +44,12 @@ class AddPhraseCollectionViewCell: VocableCollectionViewCell {
         textLabel.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(textLabel)
 
-        // Needs a weak spot that can break while resizing to avoid
-        // constraint errors
-        let rightConstraint = textLabel.rightAnchor.constraint(equalTo: contentView.layoutMarginsGuide.rightAnchor).withPriority(999)
-        let bottomConstraint = textLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor).withPriority(999)
-
+        let layoutGuide = contentView.layoutMarginsGuide
         NSLayoutConstraint.activate([
-            rightConstraint,
-            textLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
-            textLabel.leftAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leftAnchor),
-            bottomConstraint
+            textLabel.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor).withPriority(999),
+            textLabel.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
+            textLabel.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor),
+            textLabel.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor).withPriority(999)
         ])
 
         updateContentViews()
@@ -85,7 +81,11 @@ private extension NSAttributedString {
     static var addPhraseTitle: NSAttributedString {
         let text = NSLocalizedString("preset.category.add.phrase.title", comment: "Add phrase button title")
         let image = UIImage(systemName: "plus")!
-        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 22, weight: .bold)]
+        let font: UIFont = (UITraitCollection.current.horizontalSizeClass == .regular
+                            && UITraitCollection.current.verticalSizeClass == .regular)
+                            ? UIFont.systemFont(ofSize: 28, weight: .bold)
+                            : UIFont.systemFont(ofSize: 22, weight: .bold)
+        let attributes: [NSAttributedString.Key: Any] = [.font: font]
         return NSAttributedString.imageAttachedString(for: text, with: image, attributes: attributes)
     }
 }

--- a/Vocable/Common/AddPhraseCollectionViewCell.swift
+++ b/Vocable/Common/AddPhraseCollectionViewCell.swift
@@ -1,0 +1,96 @@
+//
+//  AddPhraseCollectionViewCell.swift
+//  Vocable
+//
+//  Created by Jesse Morgan on 4/8/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import UIKit
+
+class AddPhraseCollectionViewCell: VocableCollectionViewCell {
+    let textLabel = UILabel(frame: .zero)
+
+    let dashedBorderView = CAShapeLayer()
+
+    override func updateContentViews() {
+        super.updateContentViews()
+
+        dashedBorderView.strokeColor = isHighlighted ? nil : UIColor.categoryBackgroundColor.cgColor
+
+        textLabel.textColor = isSelected ? .selectedTextColor : .defaultTextColor
+        textLabel.backgroundColor = .clear
+        textLabel.isOpaque = true
+        textLabel.font = UIFont.systemFont(ofSize: 28, weight: .bold)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+
+        contentView.preservesSuperviewLayoutMargins = true
+
+        fillColor = .clear
+
+        dashedBorderView.strokeColor = UIColor.categoryBackgroundColor.cgColor
+        dashedBorderView.lineDashPattern = [8, 6]
+        dashedBorderView.frame = bounds
+        dashedBorderView.fillColor = nil
+        dashedBorderView.lineWidth = 6
+        dashedBorderView.path = UIBezierPath(roundedRect: bounds, cornerRadius: 8).cgPath
+        layer.addSublayer(dashedBorderView)
+
+        let text = NSLocalizedString("preset.category.add.phrase.title", comment: "Add phrase button title")
+        let image = UIImage(systemName: "plus")!
+        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 22, weight: .bold)]
+        textLabel.attributedText = NSAttributedString.imageAttachedString(for: text, with: image, attributes: attributes)
+        textLabel.textAlignment = .center
+        textLabel.numberOfLines = 0
+        textLabel.adjustsFontSizeToFitWidth = true
+        textLabel.minimumScaleFactor = 0.5
+
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(textLabel)
+
+        // Needs a weak spot that can break while resizing to avoid
+        // constraint errors
+        let rightConstraint = textLabel.rightAnchor.constraint(equalTo: contentView.layoutMarginsGuide.rightAnchor)
+        rightConstraint.priority = .init(999)
+
+        let bottomConstraint = textLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
+        bottomConstraint.priority = .init(999)
+        NSLayoutConstraint.activate([
+            rightConstraint,
+            textLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            textLabel.leftAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leftAnchor),
+            bottomConstraint
+        ])
+
+        updateContentViews()
+    }
+
+    func setup(title: String) {
+        textLabel.text = title
+        updateContentViews()
+    }
+
+    func setup(with image: UIImage?) {
+        guard let image = image else {
+            return
+        }
+
+        let systemImageAttachment = NSTextAttachment(image: image)
+        let attributedString = NSAttributedString(attachment: systemImageAttachment)
+
+        textLabel.attributedText = attributedString
+        updateContentViews()
+    }
+}

--- a/Vocable/Common/AttributedString+Helpers.swift
+++ b/Vocable/Common/AttributedString+Helpers.swift
@@ -1,0 +1,33 @@
+//
+//  AttributedString+Helpers.swift
+//  Vocable
+//
+//  Created by Jesse Morgan on 4/8/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import UIKit
+
+extension NSAttributedString {
+
+    static func imageAttachedString(for string: String, with image: UIImage, attributes: [Key: Any]? = nil) -> NSAttributedString {
+        let isRightToLeftLayout = UITraitCollection.current.layoutDirection == .rightToLeft
+
+        let formatString: String  = isRightToLeftLayout ?
+            .localizedStringWithFormat("%@ ", string) :
+            .localizedStringWithFormat(" %@", string)
+
+        let text = NSMutableAttributedString(string: formatString, attributes: attributes)
+        let attachment = NSMutableAttributedString(attachment: NSTextAttachment(image: image))
+        if let attributes = attributes {
+            attachment.addAttributes(attributes, range: .entireRange(of: attachment.string))
+        }
+
+        let textRange = NSRange(of: text.string)
+        let insertionIndex = isRightToLeftLayout ? textRange.upperBound : textRange.lowerBound
+
+        text.insert(attachment, at: insertionIndex)
+        return text
+    }
+
+}

--- a/Vocable/Common/NSAttributedString+Helpers.swift
+++ b/Vocable/Common/NSAttributedString+Helpers.swift
@@ -1,5 +1,5 @@
 //
-//  AttributedString+Helpers.swift
+//  NSAttributedString+Helpers.swift
 //  Vocable
 //
 //  Created by Jesse Morgan on 4/8/22.

--- a/Vocable/Common/PresetItemCollectionViewCell.swift
+++ b/Vocable/Common/PresetItemCollectionViewCell.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 class PresetItemCollectionViewCell: VocableCollectionViewCell {
+
     let textLabel = UILabel(frame: .zero)
     
     override func updateContentViews() {
@@ -41,7 +42,6 @@ class PresetItemCollectionViewCell: VocableCollectionViewCell {
     }
     
     private func commonInit() {
-
         contentView.preservesSuperviewLayoutMargins = true
 
         textLabel.textAlignment = .center
@@ -52,37 +52,24 @@ class PresetItemCollectionViewCell: VocableCollectionViewCell {
         textLabel.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(textLabel)
 
-        // Needs a weak spot that can break while resizing to avoid
-        // constraint errors
-        let rightConstraint = textLabel.rightAnchor.constraint(equalTo: contentView.layoutMarginsGuide.rightAnchor)
-        rightConstraint.priority = .init(999)
-
-        let bottomConstraint = textLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
-        bottomConstraint.priority = .init(999)
+        let layoutGuide = contentView.layoutMarginsGuide
         NSLayoutConstraint.activate([
-            rightConstraint,
-            textLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
-            textLabel.leftAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leftAnchor),
-            bottomConstraint
+            textLabel.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor).withPriority(999),
+            textLabel.topAnchor.constraint(equalTo: layoutGuide.topAnchor),
+            textLabel.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor),
+            textLabel.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor).withPriority(999)
         ])
 
         updateContentViews()
     }
 
-    func setup(title: String) {
-        textLabel.text = title
-        updateContentViews()
-    }
-    
-    func setup(with image: UIImage?) {
-        guard let image = image else {
-            return
+    func setup(title: String, with image: UIImage? = nil) {
+        if let image = image {
+            textLabel.attributedText = NSAttributedString.imageAttachedString(for: title, with: image)
+        } else {
+            textLabel.text = title
         }
-        
-        let systemImageAttachment = NSTextAttachment(image: image)
-        let attributedString = NSAttributedString(attachment: systemImageAttachment)
-        
-        textLabel.attributedText = attributedString
+
         updateContentViews()
     }
 }

--- a/Vocable/Common/PresetItemCollectionViewCell.swift
+++ b/Vocable/Common/PresetItemCollectionViewCell.swift
@@ -26,7 +26,7 @@ class PresetItemCollectionViewCell: VocableCollectionViewCell {
         }()
 
         textLabel.textColor = textColor
-        textLabel.backgroundColor = .clear
+        textLabel.backgroundColor = borderedView.fillColor
         textLabel.isOpaque = true
         textLabel.font = UIFont.systemFont(ofSize: 28, weight: .bold)
     }

--- a/Vocable/Common/Views/BorderedView.swift
+++ b/Vocable/Common/Views/BorderedView.swift
@@ -103,6 +103,12 @@ class BorderedView: UIView {
         }
     }
 
+    var borderDashPattern: [NSNumber]? {
+        didSet {
+            updateBorderProperties()
+        }
+    }
+
     override var frame: CGRect {
         didSet {
             updateShapeLayer()
@@ -138,6 +144,8 @@ class BorderedView: UIView {
     }
 
     private func updateBorderProperties() {
+        shapeLayer.lineDashPattern = borderDashPattern
+        shapeLayer.lineJoin = .round
         shapeLayer.lineWidth = borderWidth
         shapeLayer.strokeColor = borderColor.cgColor
         shapeLayer.masksToBounds = false

--- a/Vocable/Extensions/NSDiffableDataSourceSnapshot+Map.swift
+++ b/Vocable/Extensions/NSDiffableDataSourceSnapshot+Map.swift
@@ -1,0 +1,25 @@
+//
+//  NSDiffableDataSourceSnapshot+Map.swift
+//  Vocable
+//
+//  Created by Jesse Morgan on 4/12/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import UIKit
+
+extension NSDiffableDataSourceSnapshot {
+    func mapItemIdentifier<NewIdentifierType: Hashable>(_ transform: (ItemIdentifierType) -> NewIdentifierType) -> NSDiffableDataSourceSnapshot<SectionIdentifierType, NewIdentifierType> {
+        var updatedSnapshot = NSDiffableDataSourceSnapshot<SectionIdentifierType, NewIdentifierType>()
+
+        updatedSnapshot.appendSections(sectionIdentifiers)
+
+        for sectionId in sectionIdentifiers {
+            let categoryItems = itemIdentifiers(inSection: sectionId).map(transform)
+
+            updatedSnapshot.appendItems(categoryItems, toSection: sectionId)
+        }
+
+        return updatedSnapshot
+    }
+}

--- a/Vocable/Extensions/NSDiffableDataSourceSnapshot+Map.swift
+++ b/Vocable/Extensions/NSDiffableDataSourceSnapshot+Map.swift
@@ -15,9 +15,8 @@ extension NSDiffableDataSourceSnapshot {
         updatedSnapshot.appendSections(sectionIdentifiers)
 
         for sectionId in sectionIdentifiers {
-            let categoryItems = itemIdentifiers(inSection: sectionId).map(transform)
-
-            updatedSnapshot.appendItems(categoryItems, toSection: sectionId)
+            let items = itemIdentifiers(inSection: sectionId).map(transform)
+            updatedSnapshot.appendItems(items, toSection: sectionId)
         }
 
         return updatedSnapshot

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -119,17 +119,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
         let pageCountBefore = collectionView.layout.pagesPerSection
         let fetchedSnapshot = snapshot as NSDiffableDataSourceSnapshot<String, NSManagedObjectID>
 
-        var updatedSnapshot = Snapshot()
-
-        updatedSnapshot.appendSections(fetchedSnapshot.sectionIdentifiers)
-
-        for sectionId in fetchedSnapshot.sectionIdentifiers {
-            let categoryItems = fetchedSnapshot.itemIdentifiers(inSection: sectionId).map(CategoryItem.persistedPhrase)
-
-            updatedSnapshot.appendItems(categoryItems, toSection: sectionId)
-        }
-
-        updatedSnapshot.appendItems([.addNewPhrase])
+        let updatedSnapshot = transformFetchedSnapshot(fetchedSnapshot)
 
         dataSourceProxy.apply(updatedSnapshot, animatingDifferences: false)
 
@@ -179,6 +169,24 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
             addNewPhraseButtonSelected()
         }
 
+    }
+
+    private func transformFetchedSnapshot(_ fetchedSnapshot: NSDiffableDataSourceSnapshot<String, NSManagedObjectID>) -> Snapshot {
+        var updatedSnapshot = Snapshot()
+
+        updatedSnapshot.appendSections(fetchedSnapshot.sectionIdentifiers)
+
+        for sectionId in fetchedSnapshot.sectionIdentifiers {
+            let categoryItems = fetchedSnapshot.itemIdentifiers(inSection: sectionId).map(CategoryItem.persistedPhrase)
+
+            updatedSnapshot.appendItems(categoryItems, toSection: sectionId)
+        }
+
+        if updatedSnapshot.numberOfItems != 0 {
+            updatedSnapshot.appendItems([.addNewPhrase])
+        }
+
+        return updatedSnapshot
     }
 
     private func installEmptyStateIfNeeded() {

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -20,7 +20,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
 
     private var disposables = Set<AnyCancellable>()
 
-    enum CategoryItem: Hashable {
+    private enum CategoryItem: Hashable {
         case persistedPhrase(NSManagedObjectID)
         case addNewPhrase
     }

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -179,7 +179,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
     private func makeSnapshot(from fetchedSnapshot: NSDiffableDataSourceSnapshot<String, NSManagedObjectID>) -> Snapshot {
         var updatedSnapshot = fetchedSnapshot.mapItemIdentifier(CategoryItem.persistedPhrase)
 
-        if updatedSnapshot.numberOfItems != 0 {
+        if category.allowsCustomPhrases, updatedSnapshot.numberOfItems != 0 {
             updatedSnapshot.appendItems([.addNewPhrase])
         }
 

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -177,15 +177,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
     }
 
     private func makeSnapshot(from fetchedSnapshot: NSDiffableDataSourceSnapshot<String, NSManagedObjectID>) -> Snapshot {
-        var updatedSnapshot = Snapshot()
-
-        updatedSnapshot.appendSections(fetchedSnapshot.sectionIdentifiers)
-
-        for sectionId in fetchedSnapshot.sectionIdentifiers {
-            let categoryItems = fetchedSnapshot.itemIdentifiers(inSection: sectionId).map(CategoryItem.persistedPhrase)
-
-            updatedSnapshot.appendItems(categoryItems, toSection: sectionId)
-        }
+        var updatedSnapshot = fetchedSnapshot.mapItemIdentifier(CategoryItem.persistedPhrase)
 
         if updatedSnapshot.numberOfItems != 0 {
             updatedSnapshot.appendItems([.addNewPhrase])

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -151,7 +151,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
             context.perform { [weak self] in
                 guard
                     let self = self,
-                    let phrase = Phrase.fetchObject(in: self.frc.managedObjectContext, matching: objectId),
+                    let phrase = Phrase.fetchObject(in: context, matching: objectId),
                     let utterance = phrase.utterance
                 else {
                     self?.lastUtterance = nil
@@ -162,7 +162,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
 
                 if self.category.identifier != Category.Identifier.recents {
                     phrase.lastSpokenDate = Date()
-                    try? self.frc.managedObjectContext.save()
+                    try? context.save()
                 }
 
                 // Dispatch to get off the main queue for performance

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -28,17 +28,19 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
     private lazy var dataSourceProxy = DataSource(collectionView: collectionView) { [weak self] (collectionView, indexPath, item) -> UICollectionViewCell? in
         guard let self = self else { return nil }
 
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PresetItemCollectionViewCell.reuseIdentifier, for: indexPath) as? PresetItemCollectionViewCell
-
         switch item {
         case .persistedPhrase(let objectId):
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PresetItemCollectionViewCell.reuseIdentifier, for: indexPath) as? PresetItemCollectionViewCell
+
             guard let phrase = Phrase.fetchObject(in: self.frc.managedObjectContext, matching: objectId) else { return cell }
             cell?.textLabel.text = phrase.utterance
-        case .addNewPhrase:
-            cell?.textLabel.text = "Add New Phrase"
-        }
 
-        return cell
+            return cell
+        case .addNewPhrase:
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AddPhraseCollectionViewCell.reuseIdentifier, for: indexPath) as? AddPhraseCollectionViewCell
+
+            return cell
+        }
     }
 
     private lazy var fetchRequest: NSFetchRequest<Phrase> = {
@@ -76,6 +78,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
         assert(category != nil, "Category not assigned")
 
         collectionView.register(PresetItemCollectionViewCell.self, forCellWithReuseIdentifier: PresetItemCollectionViewCell.reuseIdentifier)
+        collectionView.register(AddPhraseCollectionViewCell.self, forCellWithReuseIdentifier: AddPhraseCollectionViewCell.reuseIdentifier)
         collectionView.delaysContentTouches = false
 
         updateLayoutForCurrentTraitCollection()

--- a/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
@@ -370,29 +370,11 @@ private extension GazeableAlertViewController {
 }
 
 private extension NSAttributedString {
-    // TODO: use imageAttachedString() instead
     static var removeCategoryTitle: NSAttributedString {
-        let isRightToLeftLayout = UITraitCollection.current.layoutDirection == .rightToLeft
-
-        let buttonText = NSLocalizedString("category_editor.detail.button.remove_category.title", comment: "Remove category button label within the category detail screen.")
-
-        let formatString: String  = isRightToLeftLayout ?
-            .localizedStringWithFormat("%@ ", buttonText) :
-            .localizedStringWithFormat(" %@", buttonText)
-
+        let text = NSLocalizedString("category_editor.detail.button.remove_category.title", comment: "Remove category button label within the category detail screen.")
         let attributes: [NSAttributedString.Key: Any] = [
             .font: UIFont.systemFont(ofSize: 22, weight: .bold)
         ]
-
-        let text = NSMutableAttributedString(string: formatString, attributes: attributes)
-        let attachment = NSMutableAttributedString(attachment: NSTextAttachment(image: UIImage(systemName: "trash")!))
-        attachment.addAttributes(attributes, range: .entireRange(of: attachment.string))
-
-        let textRange = NSRange(of: text.string)
-        let insertionIndex = isRightToLeftLayout ? textRange.upperBound : textRange.lowerBound
-
-        text.insert(attachment, at: insertionIndex)
-
-        return text
+       return NSAttributedString.imageAttachedString(for: text, with: UIImage(systemName: "trash")!, attributes: attributes)
     }
 }

--- a/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoryDetailViewController.swift
@@ -370,6 +370,7 @@ private extension GazeableAlertViewController {
 }
 
 private extension NSAttributedString {
+    // TODO: use imageAttachedString() instead
     static var removeCategoryTitle: NSAttributedString {
         let isRightToLeftLayout = UITraitCollection.current.layoutDirection == .rightToLeft
 

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -51,6 +51,9 @@
 /* 'Yes' num pad response */
 "preset.category.numberpad.phrase.yes.title" = "Yes";
 
+/* Add phrase to category button title */
+"preset.category.add.phrase.title" = "Add Phrase";
+
 /* No email account configured error alert dismiss button title */
 "settings.alert.no_email_configured.button.dismiss.title" = "OK";
 


### PR DESCRIPTION
closes #538, #539, & #540

# Description of Work
This PR implements the new `+ Add Phrase` cell that is appended to the end of any list of phrases in a category within the main screen (except for the `123` category). Since these cells have a unique dashed border line, when selecting the cell, the yellow border is also dashed to maintain consistent styling.

## iPhone
<img src=https://user-images.githubusercontent.com/37670742/162504124-d883e480-f455-433a-9e40-4e92d9e342ee.jpeg width=350>

## iPad
<img src=https://user-images.githubusercontent.com/37670742/162504447-1961cb4b-0fa6-4002-a051-179f03b1fcde.png>

## Highlighted State
<img src=https://user-images.githubusercontent.com/37670742/162504289-f33a6d23-57a0-4553-af91-ad5c1ca9cce5.png>


---
