### PR TITLE
#477 | Fixing category selection after deletion

### DIFF
--- a/Vocable/Extensions/UICollectionView+Helpers.swift
+++ b/Vocable/Extensions/UICollectionView+Helpers.swift
@@ -20,25 +20,39 @@ extension UICollectionView {
     }
 
     func indexPath(nearestTo indexPath: IndexPath) -> IndexPath? {
-        return self.indexPath(before: indexPath) ?? self.indexPath(after: indexPath)
+        let validSections = 0..<numberOfSections
+        guard validSections.contains(indexPath.section) else { return nil }
+
+        let validItems = 0..<numberOfItems(inSection: indexPath.section)
+        guard validItems.contains(indexPath.item) else {
+            return self.indexPath(before: indexPath) ?? self.indexPath(after: indexPath)
+        }
+
+        return indexPath
     }
 
     func indexPath(after indexPath: IndexPath) -> IndexPath? {
+        let validSections = 0..<numberOfSections
+        guard validSections.contains(indexPath.section) else { return nil }
+
         let itemsInSection = numberOfItems(inSection: indexPath.section)
         let candidateIndex = indexPath.item + 1
         if candidateIndex >= itemsInSection {
             return nil
         } else {
-            return IndexPath(row: candidateIndex, section: 0)
+            return IndexPath(row: candidateIndex, section: indexPath.section)
         }
     }
 
     func indexPath(before indexPath: IndexPath) -> IndexPath? {
+        let validSections = 0..<numberOfSections
+        guard validSections.contains(indexPath.section) else { return nil }
+
         let candidateIndex = indexPath.item - 1
         if candidateIndex < 0 {
             return nil
         } else {
-            return IndexPath(row: candidateIndex, section: 0)
+            return IndexPath(row: candidateIndex, section: indexPath.section)
         }
     }
 }

--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -194,6 +194,11 @@ import Combine
             }
 
             let newItemIndexPath: IndexPath? = {
+                if let category = Category.fetchObject(in: NSPersistentContainer.shared.viewContext, matching: previous.objectID),
+                   category.isUserRemoved {
+                    return previous.indexPath
+                }
+
                 if let indexPath = self.dataSourceProxy.indexPath(for: previous.objectID) {
                     return indexPath
                 }

--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -194,11 +194,6 @@ import Combine
             }
 
             let newItemIndexPath: IndexPath? = {
-                if let category = Category.fetchObject(in: NSPersistentContainer.shared.viewContext, matching: previous.objectID),
-                   category.isUserRemoved {
-                    return previous.indexPath
-                }
-
                 if let indexPath = self.dataSourceProxy.indexPath(for: previous.objectID) {
                     return indexPath
                 }


### PR DESCRIPTION
closes #477

# Description of Work
Fixing a bug where after deleting the first category and navigating back to the home screen, the second category was selected inside of the first.

---
