### PR TITLE
#553 | Fixing Volume Issue During Listening Mode 🎛️ 

### DIFF
--- a/Vocable/Features/Voice/AudioEngineController.swift
+++ b/Vocable/Features/Voice/AudioEngineController.swift
@@ -181,7 +181,7 @@ class AudioEngineController: NSObject, AVAudioPlayerDelegate {
                 if self.registeredSpeechControllers.isEmpty {
                     if self.audioSession.category != .playback {
                         print("AUDIO SESSION CATEGORY: playback")
-                        try self.audioSession.setCategory(.playback, mode: .spokenAudio, options: .interruptSpokenAudioAndMixWithOthers)
+                        try self.audioSession.setCategory(.playback, mode: .spokenAudio, options: .duckOthers)
                         sessionNeedsActivation = true
                     }
                     self.audioEngineShouldRun = !self.registeredSpeechControllers.isEmpty
@@ -204,7 +204,7 @@ class AudioEngineController: NSObject, AVAudioPlayerDelegate {
                         // be prepared for speech synthesis
                         if self.audioSession.category != .playback {
                             print("AUDIO SESSION CATEGORY: playback")
-                            try self.audioSession.setCategory(.playback, mode: .spokenAudio, options: .interruptSpokenAudioAndMixWithOthers)
+                            try self.audioSession.setCategory(.playback, mode: .spokenAudio, options: .duckOthers)
                             sessionNeedsActivation = true
                         }
                         result = false

--- a/Vocable/Features/Voice/AudioEngineController.swift
+++ b/Vocable/Features/Voice/AudioEngineController.swift
@@ -181,7 +181,7 @@ class AudioEngineController: NSObject, AVAudioPlayerDelegate {
                 if self.registeredSpeechControllers.isEmpty {
                     if self.audioSession.category != .playback {
                         print("AUDIO SESSION CATEGORY: playback")
-                        try self.audioSession.setCategory(.playback, mode: .spokenAudio, options: .duckOthers)
+                        try self.audioSession.setCategory(.playback, mode: .spokenAudio, options: .interruptSpokenAudioAndMixWithOthers)
                         sessionNeedsActivation = true
                     }
                     self.audioEngineShouldRun = !self.registeredSpeechControllers.isEmpty
@@ -190,7 +190,7 @@ class AudioEngineController: NSObject, AVAudioPlayerDelegate {
 
                     if self.audioSession.category != .playAndRecord {
                         print("AUDIO SESSION CATEGORY: playAndRecord")
-                        try self.audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker])
+                        try self.audioSession.setCategory(.playAndRecord, mode: .spokenAudio, options: [.defaultToSpeaker])
                         sessionNeedsActivation = true
                     }
 
@@ -204,7 +204,7 @@ class AudioEngineController: NSObject, AVAudioPlayerDelegate {
                         // be prepared for speech synthesis
                         if self.audioSession.category != .playback {
                             print("AUDIO SESSION CATEGORY: playback")
-                            try self.audioSession.setCategory(.playback, mode: .spokenAudio, options: .duckOthers)
+                            try self.audioSession.setCategory(.playback, mode: .spokenAudio, options: .interruptSpokenAudioAndMixWithOthers)
                             sessionNeedsActivation = true
                         }
                         result = false


### PR DESCRIPTION
closes #553 

# Description of Work
This PR fixes a bug where the output volume was too low for listening mode which was fixed by setting the audio mode to `spokenAudio` instead of `voiceChat`. This mode seems to lower the output volume by default. Apple states that the `voiceChat` mode should only be used for "two-way voice communication, such as using Voice over Internet Protocol (VoIP)" which shouldn't be applicable in our case since it's used for text to speech.

---
