### PR TITLE
[488] Add head tracking support footer text to settings ui

### DIFF
--- a/Vocable/Common/Views/EmptyStateView.swift
+++ b/Vocable/Common/Views/EmptyStateView.swift
@@ -182,6 +182,7 @@ final class EmptyStateView: UIView {
             stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             stackView.widthAnchor.constraint(lessThanOrEqualTo: readableContentGuide.widthAnchor),
+            stackView.widthAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.widthAnchor),
             stackView.heightAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.heightAnchor)
         ])
 

--- a/Vocable/Features/Settings/ListeningMode/SettingsFooterTextSupplementaryView.xib
+++ b/Vocable/Features/Settings/ListeningMode/SettingsFooterTextSupplementaryView.xib
@@ -15,7 +15,7 @@
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jD7-H6-bi2">
-                    <rect key="frame" x="16" y="8" width="288" height="26.5"/>
+                    <rect key="frame" x="16" y="0.0" width="288" height="26.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
                     <color key="textColor" name="DefaultFontColor"/>
                     <nil key="highlightedColor"/>
@@ -28,7 +28,7 @@
                 <constraint firstItem="jD7-H6-bi2" firstAttribute="leading" secondItem="U6b-Vx-4bR" secondAttribute="leadingMargin" id="Wrv-RV-ygX"/>
                 <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="jD7-H6-bi2" secondAttribute="bottom" id="hCA-sj-fkt"/>
             </constraints>
-            <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
+            <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
             <connections>
                 <outlet property="textLabel" destination="jD7-H6-bi2" id="m0z-n3-btk"/>
             </connections>

--- a/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
+++ b/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
@@ -176,12 +176,11 @@ final class SelectionModeViewController: VocableCollectionViewController {
         let systemVersion = UIDevice.current.systemVersion
         let sensorName = "TrueDepth"
         let neuralEngineName = "Apple Neural Engine"
-        let supportedPlatformsiOS14 = "iOS 14 and iPadOS 14"
 
         let format = NSLocalizedString("settings.selection_mode.head_tracking_unsupported_footer",
-                                       comment: "Footer text explaining that the user's device and/or operating system version is incompatible with head tracking and which devices and operating system versions support head tracking")
+                                       comment: "Footer text explaining that the user's device and/or operating system version is incompatible with head tracking and which devices do support head tracking")
 
-        let text = String(format: format, model, systemName, systemVersion, sensorName, neuralEngineName, supportedPlatformsiOS14)
+        let text = String(format: format, model, systemName, systemVersion, sensorName, neuralEngineName)
         return text
     }
 

--- a/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
+++ b/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
@@ -14,6 +14,10 @@ final class SelectionModeViewController: VocableCollectionViewController {
         case headTrackingToggle
     }
 
+    private enum SupplementaryKind: String {
+        case headTrackingUnsupportedFooter
+    }
+
     private lazy var dataSource: UICollectionViewDiffableDataSource<Int, SelectionModeItem> = .init(collectionView: collectionView) { (collectionView, indexPath, item) -> UICollectionViewCell in
         return self.collectionView(collectionView, cellForItemAt: indexPath, item: item)
     }
@@ -30,6 +34,11 @@ final class SelectionModeViewController: VocableCollectionViewController {
         navigationBar.title = NSLocalizedString("selection_mode.header.title", comment: "Selection mode screen header title")
     }
 
+    override func viewLayoutMarginsDidChange() {
+        super.viewLayoutMarginsDidChange()
+        collectionView.collectionViewLayout.invalidateLayout()
+    }
+    
     // MARK: UICollectionViewDataSource
 
     private func updateDataSource() {
@@ -42,7 +51,21 @@ final class SelectionModeViewController: VocableCollectionViewController {
     private func setupCollectionView() {
         collectionView.backgroundColor = .collectionViewBackgroundColor
         collectionView.register(UINib(nibName: "SettingsToggleCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: SettingsToggleCollectionViewCell.reuseIdentifier)
+        collectionView.register(UINib(nibName: "SettingsFooterTextSupplementaryView", bundle: nil),
+                                forSupplementaryViewOfKind: SupplementaryKind.headTrackingUnsupportedFooter.rawValue,
+                                withReuseIdentifier: SupplementaryKind.headTrackingUnsupportedFooter.rawValue)
 
+        dataSource.supplementaryViewProvider = { (collectionView, elementKind, indexPath) in
+            switch SupplementaryKind(rawValue: elementKind) {
+            case .none:
+                return nil
+            case .headTrackingUnsupportedFooter:
+
+                let footer = collectionView.dequeueReusableSupplementaryView(ofKind: elementKind, withReuseIdentifier: elementKind, for: indexPath) as! SettingsFooterTextSupplementaryView
+                footer.textLabel.text = SelectionModeViewController.headTrackingUnsupportedLocalizedString
+                return footer
+            }
+        }
         collectionView.collectionViewLayout = UICollectionViewCompositionalLayout(sectionProvider: { [weak self] (_, environment) -> NSCollectionLayoutSection? in
             return self?.layoutSection(environment: environment)
         })
@@ -52,10 +75,10 @@ final class SelectionModeViewController: VocableCollectionViewController {
 
         let itemHeightDimension: NSCollectionLayoutDimension
         if sizeClass.contains(.vCompact) {
-                itemHeightDimension = NSCollectionLayoutDimension.absolute(50)
-            } else {
-                itemHeightDimension = NSCollectionLayoutDimension.absolute(100)
-            }
+            itemHeightDimension = NSCollectionLayoutDimension.absolute(50)
+        } else {
+            itemHeightDimension = NSCollectionLayoutDimension.absolute(100)
+        }
 
         let itemWidthDimension = NSCollectionLayoutDimension.fractionalWidth(1.0)
         let columnCount = 1
@@ -70,6 +93,15 @@ final class SelectionModeViewController: VocableCollectionViewController {
         section.interGroupSpacing = 8
         section.contentInsets = sectionInsets(for: environment)
         section.contentInsets.top = 16
+        section.contentInsets.bottom = 32
+        if !AppConfig.isHeadTrackingSupported {
+
+            let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(200))
+            let footer = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: footerSize,
+                                                                     elementKind: SupplementaryKind.headTrackingUnsupportedFooter.rawValue,
+                                                                     alignment: .bottom)
+            section.boundarySupplementaryItems = [footer]
+        }
         return section
     }
 
@@ -133,6 +165,24 @@ final class SelectionModeViewController: VocableCollectionViewController {
 
     private func toggleHeadTracking() {
         AppConfig.isHeadTrackingEnabled.toggle()
+    }
+
+    private static var headTrackingUnsupportedLocalizedString: String {
+
+        // Attempting to follow these guidelines: https://developer.apple.com/app-store/marketing/guidelines/
+        // These trademarks should not be localized unless the system provides the localized string
+        let model = UIDevice.current.localizedModel
+        let systemName = UIDevice.current.systemName
+        let systemVersion = UIDevice.current.systemVersion
+        let sensorName = "TrueDepth"
+        let neuralEngineName = "Apple Neural Engine"
+        let supportedPlatformsiOS14 = "iOS 14 and iPadOS 14"
+
+        let format = NSLocalizedString("settings.selection_mode.head_tracking_unsupported_footer",
+                                       comment: "Footer text explaining that the user's device and/or operating system version is incompatible with head tracking and which devices and operating system versions support head tracking")
+
+        let text = String(format: format, model, systemName, systemVersion, sensorName, neuralEngineName, supportedPlatformsiOS14)
+        return text
     }
 
 }

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -181,3 +181,5 @@
 "settings.alert.reset_app_settings_failure.body" = "Vocable failed to reset. Please try again or reinstall Vocable if the issue persists.";
 
 "settings.alert.reset_app_settings_failure.button.ok" = "OK";
+
+"settings.selection_mode.head_tracking_unsupported_footer" = "This %1$@ on %2$@ %3$@ does not support head tracking.\n\nHead tracking is supported on all devices with a %4$@ camera, and on most devices with %6$@.";


### PR DESCRIPTION
closes #488

# Description of Work
* Adds footer text to the head tracking settings screen if the device does not support head tracking:

![Simulator Screen Shot - iPhone 8 - 2022-04-18 at 14 59 55](https://user-images.githubusercontent.com/143916/163860796-7ea7fec0-772b-4947-9373-4ae2016e371a.png)


## Notes to Test (Optional)
* Devices that do support head tracking will not show this footer text
