### PR TITLE
Fixed Pagination Tests

### DIFF
--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -11,15 +11,13 @@ import XCTest
 class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
     
     func testCanNavigatePages() {
-        // Add 11 phrases; this results in 3 total pages for an iPhone and 2 total pages for an iPad
-        for phrase in listOfPhrases.startIndex..<11 {
+        // Add enough phrases to have 2 pages.
+        for phrase in listOfPhrases.startIndex..<5 {
             CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
         }
         
         // Verify that the user is on the first page and the next page buttons are enabled.
-        XCTAssertEqual(CustomCategoriesScreen.currentPageNumber, 1)
-        XCTAssertTrue(CustomCategoriesScreen.paginationLeftButton.isEnabled)
-        XCTAssertTrue(CustomCategoriesScreen.paginationRightButton.isEnabled)
+        VTAssertPaginationEquals(1, of: 2, enabledArrows: .both)
         
         // Use the RIGHT pagination button to traverse the pages, ending back on "Page 1 of X"
         for pageNumber in 1...CustomCategoriesScreen.totalPageCount {
@@ -37,25 +35,23 @@ class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
     }
     
     func testPagesAdjustToNewPhrases() {
-        // Add 10 phrases; this results in 3 starting pages for an iPhone and 1 full page for an iPad
-        for phrase in listOfPhrases.startIndex..<10 {
+        // Add enough phrases (4) to fill one page.
+        for phrase in listOfPhrases.startIndex..<4 {
             CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
         }
         
         // Verify that the user is on the first page.
         XCTAssertEqual(CustomCategoriesScreen.currentPageNumber, 1)
         
-        // Add 3 more phrases to push the total number of pages from N to N+1.
+        // Add 1 more phrase to push the total number of pages to 2.
         let originalPageCount = CustomCategoriesScreen.totalPageCount
         let expectedPageCountAfterAddingPhrase = originalPageCount + 1
-        CustomCategoriesScreen.addRandomPhrases(numberOfPhrases: 3)
+        CustomCategoriesScreen.addRandomPhrases(numberOfPhrases: 1)
         XCTAssertEqual(CustomCategoriesScreen.totalPageCount, expectedPageCountAfterAddingPhrase)
         
-        // Remove 3 phrases and verify that the page count reduces, back to the original count
-        for _ in 1...3 {
-            CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
-            SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
-        }
+        // Remove the additional phrase to verify that the page count reduces, back to the original count
+        CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
+        SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
         XCTAssertEqual(CustomCategoriesScreen.totalPageCount, originalPageCount)
     }
     

--- a/VocableUITests/Tests/CustomPhraseBaseTest.swift
+++ b/VocableUITests/Tests/CustomPhraseBaseTest.swift
@@ -14,7 +14,7 @@ class CustomPhraseBaseTest: BaseTest {
     private(set) var customCategoryIdentifier: CategoryIdentifier?
     
     // To avoid potential duplication from random strings, we'll have our own phrase bank to pull from.
-    private(set) var listOfPhrases: [String] = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P"]
+    private(set) var listOfPhrases: [String] = ["A", "B", "C", "D", "E", "F", "G", "H"]
     
     override func setUp() {
         super.setUp()

--- a/VocableUITests/Tests/MainScreenPaginationTests.swift
+++ b/VocableUITests/Tests/MainScreenPaginationTests.swift
@@ -10,8 +10,6 @@ import XCTest
 
 class MainScreenPaginationTests: CustomPhraseBaseTest {
     
-    // In order to ensure this test passes on both an iPhone and iPad device, we will add 16 phrase (2 pages on an iPad)
-    // then remove 8 of them so that the pages reduce from 2 to 1 page.
     func testDeletingPhrasesAdjustsPagination() {
         listOfPhrases.forEach { phrase in
             CustomCategoriesScreen.addPhrase(phrase)
@@ -22,14 +20,12 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
         MainScreen.locateAndSelectDestinationCategory(customCategoryIdentifier!)
         VTAssertPaginationEquals(1, of: 2)
         
-        // Delete 8 of the phrases to reduce the total number of pages to 1.
+        // Delete one of the phrases to reduce the total number of pages to 1.
         SettingsScreen.navigateToSettingsCategoryScreen()
         SettingsScreen.openCategorySettings(category: customCategoryName)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
-        for _ in 1...8 {
-            CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
-            SettingsScreen.alertDeleteButton.tap()
-        }
+        CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
+        SettingsScreen.alertDeleteButton.tap()
         
         // Navigate back to the home screen to verify that the total pages reduced from 2 to 1.
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
@@ -37,7 +33,6 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
     }
     
-    // In order to ensure there are 2 pages on iPad devices, we'll need 16 total phrases.
     func testAddingPhrasesAdjustsPagination() {
         // Use array slices to split the phrase bank into two sets of 8 phrases
         let listMidpoint = listOfPhrases.count / 2
@@ -67,7 +62,7 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
     }
     
     func testCanScrollPagesWithPaginationArrows() {
-        // Add enough phrases to push the total number of pages to at leaset 2 for iPad and iPhone (16).
+        // Add enough phrases to push the total number of pages to 2
         listOfPhrases.forEach { phrase in
             CustomCategoriesScreen.addPhrase(phrase)
         }
@@ -99,8 +94,8 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
     func testPaginationAdjustsToDeviceOrientation() {
         let categoryTitleCell = CategoryTitleCellIdentifier(customCategoryIdentifier!)
 
-        // Add 13 phrases. This is the min num of phrases to ensure an additional page is needed after device rotation on an iPad.
-        for phrase in listOfPhrases.startIndex..<13 {
+        // Add enough phrases to ensure that rotating the device will add a page; 7 phrases
+        for phrase in listOfPhrases.startIndex..<7 {
             CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
         }
         
@@ -109,28 +104,22 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
         MainScreen.locateAndSelectDestinationCategory(categoryTitleCell.categoryIdentifier)
         XCTAssertEqual(MainScreen.selectedCategoryCell.identifier, categoryTitleCell.identifier)
         
-        // Capture current total number of pages
-        let totalPagesInPortrait = MainScreen.totalPageCount
-        let expectedTotalPagesInLandscape = totalPagesInPortrait + 1
-        
         // Verify we're on the first page
-        XCTAssertEqual(MainScreen.currentPageNumber, 1)
+        VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
         
         // Rotate the device
         XCUIDevice.shared.orientation = .landscapeLeft
         _ = MainScreen.settingsButton.waitForExistence(timeout: 1) // Wait for rotation to complete
         
         // Ensure that the total number of pages increases and the current page stays the same
-        XCTAssertEqual(MainScreen.currentPageNumber, 1)
-        XCTAssertEqual(MainScreen.totalPageCount, expectedTotalPagesInLandscape)
+        VTAssertPaginationEquals(1, of: 2, enabledArrows: .both)
         
         // Rotate back to Portrait
         XCUIDevice.shared.orientation = .portrait
         _ = MainScreen.settingsButton.waitForExistence(timeout: 1) // Wait for rotation to complete
         
         // Verify that the pagination returns to initial state
-        XCTAssertEqual(MainScreen.currentPageNumber, 1)
-        XCTAssertEqual(MainScreen.totalPageCount, totalPagesInPortrait)
+        VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
     }
     
 }


### PR DESCRIPTION
I forgot to ensure the pagination tests would run on the latest changes in develop, with the new "+ Add Phrase" cell for categories on the Main Screen. 

To fix the pagination tests, I adjusted the number of phrases we add for our tests to account for the new cell. Also, having chatted with the team, refactored to only consider the iPhone device instead of both the iPhone and iPad. This shortens our test execution time significantly and simplifies the tests overall.

closes #592 

-----

## Notes to Test:
All tests in the MainScreenPaginationTests and CategoryPhrasesPaginationTests suites should pass locally, as well as on Circle CI. 


