### PR TITLE
[Automation] #570 | Add Preset Phrase Tests

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		CE1406A224F3E8AD00C26225 /* SettingsScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1406A124F3E8AD00C26225 /* SettingsScreenTests.swift */; };
 		DC41F55427E4F5130099B7D5 /* CategoryIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC41F55227E4F35C0099B7D5 /* CategoryIdentifier.swift */; };
 		DC533C0127FCDF39005FEBBD /* CustomCategoryBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC533C0027FCDF39005FEBBD /* CustomCategoryBaseTest.swift */; };
+		DCF25CD52811AD2000DF766F /* PresetPhraseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF25CD42811AD2000DF766F /* PresetPhraseTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -430,6 +431,7 @@
 		CE1406A124F3E8AD00C26225 /* SettingsScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreenTests.swift; sourceTree = "<group>"; };
 		DC41F55227E4F35C0099B7D5 /* CategoryIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryIdentifier.swift; sourceTree = "<group>"; };
 		DC533C0027FCDF39005FEBBD /* CustomCategoryBaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCategoryBaseTest.swift; sourceTree = "<group>"; };
+		DCF25CD42811AD2000DF766F /* PresetPhraseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetPhraseTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -550,6 +552,7 @@
 				DC533C0027FCDF39005FEBBD /* CustomCategoryBaseTest.swift */,
 				627B53632800D0DE00FEBF25 /* CategoryPhrasesPaginationTests.swift */,
 				627B53652800D11100FEBF25 /* MainScreenPaginationTests.swift */,
+				DCF25CD42811AD2000DF766F /* PresetPhraseTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1298,6 +1301,7 @@
 				629B9B1F2809C99000EE6C19 /* XCUIElement.swift in Sources */,
 				628B35C227DF9C6B00299312 /* BaseScreen.swift in Sources */,
 				17D4162C245C6FE800FD81CD /* KeyboardScreenTests.swift in Sources */,
+				DCF25CD52811AD2000DF766F /* PresetPhraseTests.swift in Sources */,
 				17D4162E245C6FF600FD81CD /* KeyboardScreen.swift in Sources */,
 				DC41F55427E4F5130099B7D5 /* CategoryIdentifier.swift in Sources */,
 				CE1406A224F3E8AD00C26225 /* SettingsScreenTests.swift in Sources */,

--- a/Vocable/Common/AddPhraseCollectionViewCell.swift
+++ b/Vocable/Common/AddPhraseCollectionViewCell.swift
@@ -29,6 +29,7 @@ class AddPhraseCollectionViewCell: PresetItemCollectionViewCell {
         fillColor = .collectionViewBackgroundColor
 
         textLabel.numberOfLines = 1
+        textLabel.accessibilityIdentifier = "mainScreen.addPhrase"
         setup(title: NSLocalizedString("preset.category.add.phrase.title", comment: "Add phrase button title"),
               with: UIImage(systemName: "plus"))
     }

--- a/Vocable/Common/AddPhraseCollectionViewCell.swift
+++ b/Vocable/Common/AddPhraseCollectionViewCell.swift
@@ -29,7 +29,6 @@ class AddPhraseCollectionViewCell: PresetItemCollectionViewCell {
         fillColor = .collectionViewBackgroundColor
 
         textLabel.numberOfLines = 1
-        textLabel.accessibilityIdentifier = "mainScreen.addPhrase"
         setup(title: NSLocalizedString("preset.category.add.phrase.title", comment: "Add phrase button title"),
               with: UIImage(systemName: "plus"))
     }

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -114,7 +114,8 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
                 return cell
             case .addNewPhrase:
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AddPhraseCollectionViewCell.reuseIdentifier, for: indexPath) as? AddPhraseCollectionViewCell
-
+                cell?.accessibilityIdentifier = "add_new_phrase"
+                
                 return cell
             }
         }

--- a/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
+++ b/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
@@ -227,6 +227,7 @@ private extension EditPhrasesViewController {
                                                                         accessory: .disclosureIndicator()) { [weak self] in
                 self?.presentEditorForPhrase(with: phraseIdentifier)
             }
+            cell.accessibilityIdentifier = phrase.identifier
         }
     }
 }

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -69,7 +69,7 @@ class BaseScreen {
         return matchingText
     }
     
-    static func doesPhraseExist(_ phrase: String) -> Bool {
+    static func phraseDoesExist(_ phrase: String) -> Bool {
         var flag = false
         let predicate = NSPredicate(format: "label MATCHES %@", phrase)
         

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -69,4 +69,19 @@ class BaseScreen {
         return matchingText
     }
     
+    static func doesPhraseExist(_ phrase: String) -> Bool {
+        var flag = false
+        let predicate = NSPredicate(format: "label MATCHES %@", phrase)
+        
+        // Loop through each custom category page to find our phrase
+        for _ in 1...totalPageCount {
+            if XCUIApplication().cells.staticTexts.containing(predicate).element.exists {
+                flag = true
+                break
+            } else {
+                paginationRightButton.tap()
+            }
+        }
+        return flag
+    }
 }

--- a/VocableUITests/Screens/CustomCategoriesScreen.swift
+++ b/VocableUITests/Screens/CustomCategoriesScreen.swift
@@ -16,6 +16,11 @@ class CustomCategoriesScreen: BaseScreen {
     static let categoriesPageEditPhraseButton = XCUIApplication().buttons["categoryPhrase.editButton"]
     static let categoriesPageDeletePhraseButton = XCUIApplication().buttons["deleteButton"]
 
+    static var firstPhraseCell: XCUIElement {
+        let firstPhraseId = XCUIApplication().cells.firstMatch.identifier
+        return XCUIApplication().cells[firstPhraseId]
+    }
+    
     static func createCustomCategory(categoryName: String) {
         SettingsScreen.settingsPageAddCategoryButton.tap()
         KeyboardScreen.typeText(categoryName)

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -18,6 +18,7 @@ class MainScreen: BaseScreen {
     static let categoryLeftButton = XCUIApplication().buttons["root.categories_carousel.left_chevron"]
     static let categoryRightButton = XCUIApplication().buttons["root.categories_carousel.right_chevron"]
     static let pageNumber = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
+    static let addPhraseLabel = XCUIApplication().staticTexts["mainScreen.addPhrase"]
     
     // Find the current selected category and return it as a CategoryTitleCellIdentifier
     static var selectedCategoryCell: CategoryTitleCellIdentifier {

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -18,7 +18,7 @@ class MainScreen: BaseScreen {
     static let categoryLeftButton = XCUIApplication().buttons["root.categories_carousel.left_chevron"]
     static let categoryRightButton = XCUIApplication().buttons["root.categories_carousel.right_chevron"]
     static let pageNumber = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
-    static let addPhraseLabel = XCUIApplication().staticTexts["mainScreen.addPhrase"]
+    static let addPhraseLabel = XCUIApplication().cells["add_new_phrase"]
     
     // Find the current selected category and return it as a CategoryTitleCellIdentifier
     static var selectedCategoryCell: CategoryTitleCellIdentifier {

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -1,0 +1,93 @@
+//
+//  CustomCategoriesTests.swift
+//  VocableUITests
+//
+//  Created by Canan Arikan and Rudy Salas on 04/19/20.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+import XCTest
+
+class PresetPhraseTests: BaseTest {
+    
+    func testAddNewPhrase() {
+        let customPhrase = "Add"
+        let category = "Environment"
+                
+        // Navigate to our test category
+        SettingsScreen.navigateToSettingsCategoryScreen()
+        SettingsScreen.openCategorySettings(category: category)
+        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        CustomCategoriesScreen.categoriesPageAddPhraseButton.tap()
+        
+        // Add a phrase
+        KeyboardScreen.typeText(customPhrase)
+        KeyboardScreen.checkmarkAddButton.tap()
+        
+        // Verify that phrase doesn't exist in Category Details Screen
+        XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(customPhrase))
+        
+        // Verify that phrase doesn't exist in Main Screen
+        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
+        MainScreen.locateAndSelectDestinationCategory(.environment)
+        XCTAssertTrue(MainScreen.doesPhraseExist(customPhrase))
+    }
+    
+    func testEditPresetPhrase() {
+        let customPhrase = "ab"
+        let category = "Personal Care"
+                
+        // Navigate to our test category
+        SettingsScreen.navigateToSettingsCategoryScreen()
+        SettingsScreen.openCategorySettings(category: category)
+        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        
+        // Define the query that gives us the first phrase listed
+        let firstPhraseId = XCUIApplication().cells.firstMatch.identifier
+        let firstPhraseCell = XCUIApplication().cells[firstPhraseId]
+        let firstPhrase = firstPhraseCell.staticTexts.firstMatch.label
+        
+        firstPhraseCell.tap()
+        KeyboardScreen.typeText(customPhrase)
+        KeyboardScreen.checkmarkAddButton.tap()
+   
+        // Verify that preset phrase doesn't exist in Category Details Screen
+        XCTAssertFalse(CustomCategoriesScreen.doesPhraseExist(firstPhrase))
+        
+        // Verify that edited phrase exists in Category Details Screen
+        XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(firstPhrase+customPhrase))
+        
+        // Verify that preset phrase doesn't exist in Main Screen
+        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
+        MainScreen.locateAndSelectDestinationCategory(.personalCare)
+        XCTAssertFalse(MainScreen.doesPhraseExist(firstPhrase))
+        
+        // Verify that edited phrase exists in Main Screen
+        XCTAssertTrue(MainScreen.doesPhraseExist(firstPhrase+customPhrase))
+    }
+    
+    func testDeletePresetPhrase() {
+        let category = "Basic Needs"
+                
+        // Navigate to our test category
+        SettingsScreen.navigateToSettingsCategoryScreen()
+        SettingsScreen.openCategorySettings(category: category)
+        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        
+        // Define the query that gives us the first phrase listed
+        let firstPhraseId = XCUIApplication().cells.firstMatch.identifier
+        let firstPhraseCell = XCUIApplication().cells[firstPhraseId]
+        let firstPhrase = firstPhraseCell.staticTexts.firstMatch.label
+        
+        firstPhraseCell.buttons["deleteButton"].tap()
+        SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
+        
+        // Verify that phrase doesn't exist in Category Details Screen
+        XCTAssertFalse(CustomCategoriesScreen.doesPhraseExist(firstPhrase))
+        
+        // Verify that phrase doesn't exist in Main Screen
+        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
+        MainScreen.locateAndSelectDestinationCategory(.basicNeeds)
+        XCTAssertFalse(MainScreen.doesPhraseExist(firstPhrase))
+    }
+    
+    func testEditPhrasesButtonIsDisabledForNumberPadCategory() {

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -47,11 +47,11 @@ class PresetPhraseTests: BaseTest {
         KeyboardScreen.typeText(customPhrase)
         KeyboardScreen.checkmarkAddButton.tap()
    
-        let updatedPhrase = originalPhrase + customPhrase
-        // Verify that preset phrase doesn't exist in Category Details Screen
+        // Verify that the original phrase doesn't exist in Category Details Screen
         XCTAssertFalse(CustomCategoriesScreen.doesPhraseExist(originalPhrase))
         
-        // Verify that edited phrase exists in Category Details Screen
+        // Verify that updated phrase exists in Category Details Screen
+        let updatedPhrase = originalPhrase + customPhrase
         XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(updatedPhrase))
         
         // Verify that updated phrase exists in Main Screen

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -13,20 +13,16 @@ class PresetPhraseTests: BaseTest {
         let customPhrase = "Add"
         let category = "Environment"
                 
-        // Navigate to our test category
+        // Navigate to our test category and Add a phrase
         SettingsScreen.navigateToSettingsCategoryScreen()
         SettingsScreen.openCategorySettings(category: category)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
-        CustomCategoriesScreen.categoriesPageAddPhraseButton.tap()
+        CustomCategoriesScreen.addPhrase(customPhrase)
         
-        // Add a phrase
-        KeyboardScreen.typeText(customPhrase)
-        KeyboardScreen.checkmarkAddButton.tap()
-        
-        // Verify that phrase doesn't exist in Category Details Screen
+        // Verify that phrase does exist in Category Details Screen
         XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(customPhrase))
         
-        // Verify that phrase doesn't exist in Main Screen
+        // Verify that phrase doesn exist in Main Screen
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.environment)
         XCTAssertTrue(MainScreen.doesPhraseExist(customPhrase))
@@ -42,27 +38,28 @@ class PresetPhraseTests: BaseTest {
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Define the query that gives us the first phrase listed
-        let firstPhraseId = XCUIApplication().cells.firstMatch.identifier
-        let firstPhraseCell = XCUIApplication().cells[firstPhraseId]
-        let firstPhrase = firstPhraseCell.staticTexts.firstMatch.label
+        let originalPhraseId = XCUIApplication().cells.firstMatch.identifier
+        let originalPhraseCell = XCUIApplication().cells[originalPhraseId]
+        let originalPhrase = originalPhraseCell.staticTexts.firstMatch.label
         
-        firstPhraseCell.tap()
+        //firstPhraseCell.tap()
+        originalPhraseCell.staticTexts[originalPhrase].tap()
         KeyboardScreen.typeText(customPhrase)
         KeyboardScreen.checkmarkAddButton.tap()
    
+        let updatedPhrase = originalPhrase + customPhrase
         // Verify that preset phrase doesn't exist in Category Details Screen
-        XCTAssertFalse(CustomCategoriesScreen.doesPhraseExist(firstPhrase))
+        XCTAssertFalse(CustomCategoriesScreen.doesPhraseExist(originalPhrase))
         
         // Verify that edited phrase exists in Category Details Screen
-        XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(firstPhrase+customPhrase))
+        XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(updatedPhrase))
         
         // Verify that preset phrase doesn't exist in Main Screen
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.personalCare)
-        XCTAssertFalse(MainScreen.doesPhraseExist(firstPhrase))
         
         // Verify that edited phrase exists in Main Screen
-        XCTAssertTrue(MainScreen.doesPhraseExist(firstPhrase+customPhrase))
+        XCTAssertTrue(MainScreen.doesPhraseExist(updatedPhrase))
     }
     
     func testDeletePresetPhrase() {
@@ -121,12 +118,12 @@ class PresetPhraseTests: BaseTest {
         MainScreen.addPhraseLabel.tap()
         KeyboardScreen.typeText(testPhrase)
         KeyboardScreen.checkmarkAddButton.tap()
-        KeyboardScreen.createDuplicateButton.tap()
+        KeyboardScreen.createDuplicateButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
         
         // Assert that now we have two cells containing the same phrase
         let phrasePredicate = NSPredicate(format: "label MATCHES %@", testPhrase)
         let phraseQuery = XCUIApplication().staticTexts.containing(phrasePredicate)
         _ = phraseQuery.element.waitForExistence(timeout: 1)
-        XCTAssertEqual(phraseQuery.count, 2, "Expected both phrases to be presentin 'My Sayings'")
+        XCTAssertEqual(phraseQuery.count, 2, "Expected both phrases to be present in 'My Sayings'")
     }
 }

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -54,11 +54,9 @@ class PresetPhraseTests: BaseTest {
         // Verify that edited phrase exists in Category Details Screen
         XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(updatedPhrase))
         
-        // Verify that preset phrase doesn't exist in Main Screen
+        // Verify that updated phrase exists in Main Screen
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.personalCare)
-        
-        // Verify that edited phrase exists in Main Screen
         XCTAssertTrue(MainScreen.doesPhraseExist(updatedPhrase))
     }
     

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -91,3 +91,42 @@ class PresetPhraseTests: BaseTest {
     }
     
     func testEditPhrasesButtonIsDisabledForNumberPadCategory() {
+            let categoryName = "123"
+           
+            SettingsScreen.navigateToSettingsCategoryScreen()
+            SettingsScreen.openCategorySettings(category: categoryName)
+            XCTAssertFalse(CustomCategoriesScreen.editCategoryPhrasesButton.isEnabled)
+    }
+        
+    func testEditPhrasesButtonIsDisabledForRecentsCategory() {
+        let categoryName = "Recents"
+       
+        SettingsScreen.navigateToSettingsCategoryScreen()
+        SettingsScreen.openCategorySettings(category: categoryName)
+        XCTAssertFalse(CustomCategoriesScreen.editCategoryPhrasesButton.isEnabled)
+    }
+        
+    func testAddDuplicatePhrasesToMySayings() {
+        let testPhrase = "Test"
+        
+        MainScreen.keyboardNavButton.tap()
+        KeyboardScreen.typeText(testPhrase)
+        KeyboardScreen.favoriteButton.tap()
+        KeyboardScreen.navBarDismissButton.tap()
+       
+        MainScreen.locateAndSelectDestinationCategory(.mySayings)
+        XCTAssertTrue(MainScreen.doesPhraseExist(testPhrase), "Expected the first phrase \(testPhrase) to be added to and displayed in 'My Sayings'")
+        
+        // Add the same phrase again to the My Sayings
+        MainScreen.addPhraseLabel.tap()
+        KeyboardScreen.typeText(testPhrase)
+        KeyboardScreen.checkmarkAddButton.tap()
+        KeyboardScreen.createDuplicateButton.tap()
+        
+        // Assert that now we have two cells containing the same phrase
+        let phrasePredicate = NSPredicate(format: "label MATCHES %@", testPhrase)
+        let phraseQuery = XCUIApplication().staticTexts.containing(phrasePredicate)
+        _ = phraseQuery.element.waitForExistence(timeout: 1)
+        XCTAssertEqual(phraseQuery.count, 2, "Expected both phrases to be presentin 'My Sayings'")
+    }
+}

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -20,12 +20,12 @@ class PresetPhraseTests: BaseTest {
         CustomCategoriesScreen.addPhrase(customPhrase)
         
         // Verify that phrase does exist in Category Details Screen
-        XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(customPhrase))
+        XCTAssertTrue(CustomCategoriesScreen.phraseDoesExist(customPhrase))
         
         // Verify that phrase does exist in Main Screen
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.environment)
-        XCTAssertTrue(MainScreen.doesPhraseExist(customPhrase))
+        XCTAssertTrue(MainScreen.phraseDoesExist(customPhrase))
     }
     
     func testEditPresetPhrase() {
@@ -38,25 +38,23 @@ class PresetPhraseTests: BaseTest {
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Define the query that gives us the first phrase listed
-        let originalPhraseId = XCUIApplication().cells.firstMatch.identifier
-        let originalPhraseCell = XCUIApplication().cells[originalPhraseId]
-        let originalPhrase = originalPhraseCell.staticTexts.firstMatch.label
+        let originalPhrase = CustomCategoriesScreen.firstPhraseCell.staticTexts.firstMatch.label
         
-        originalPhraseCell.staticTexts[originalPhrase].tap()
+        CustomCategoriesScreen.firstPhraseCell.staticTexts[originalPhrase].tap()
         KeyboardScreen.typeText(customPhrase)
         KeyboardScreen.checkmarkAddButton.tap()
    
         // Verify that the original phrase doesn't exist in Category Details Screen
-        XCTAssertFalse(CustomCategoriesScreen.doesPhraseExist(originalPhrase))
+        XCTAssertFalse(CustomCategoriesScreen.phraseDoesExist(originalPhrase))
         
         // Verify that updated phrase exists in Category Details Screen
         let updatedPhrase = originalPhrase + customPhrase
-        XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(updatedPhrase))
+        XCTAssertTrue(CustomCategoriesScreen.phraseDoesExist(updatedPhrase))
         
         // Verify that updated phrase exists in Main Screen
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.personalCare)
-        XCTAssertTrue(MainScreen.doesPhraseExist(updatedPhrase))
+        XCTAssertTrue(MainScreen.phraseDoesExist(updatedPhrase))
     }
     
     func testDeletePresetPhrase() {
@@ -68,20 +66,18 @@ class PresetPhraseTests: BaseTest {
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Define the query that gives us the first phrase listed
-        let firstPhraseId = XCUIApplication().cells.firstMatch.identifier
-        let firstPhraseCell = XCUIApplication().cells[firstPhraseId]
-        let firstPhrase = firstPhraseCell.staticTexts.firstMatch.label
+        let firstPhrase = CustomCategoriesScreen.firstPhraseCell.staticTexts.firstMatch.label
         
-        firstPhraseCell.buttons["deleteButton"].tap()
+        CustomCategoriesScreen.firstPhraseCell.buttons["deleteButton"].tap()
         SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
         
         // Verify that phrase doesn't exist in Category Details Screen
-        XCTAssertFalse(CustomCategoriesScreen.doesPhraseExist(firstPhrase))
+        XCTAssertFalse(CustomCategoriesScreen.phraseDoesExist(firstPhrase))
         
         // Verify that phrase doesn't exist in Main Screen
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.basicNeeds)
-        XCTAssertFalse(MainScreen.doesPhraseExist(firstPhrase))
+        XCTAssertFalse(MainScreen.phraseDoesExist(firstPhrase))
     }
     
     func testEditPhrasesButtonIsDisabledForNumberPadCategory() {
@@ -109,7 +105,7 @@ class PresetPhraseTests: BaseTest {
         KeyboardScreen.navBarDismissButton.tap()
        
         MainScreen.locateAndSelectDestinationCategory(.mySayings)
-        XCTAssertTrue(MainScreen.doesPhraseExist(testPhrase), "Expected the first phrase \(testPhrase) to be added to and displayed in 'My Sayings'")
+        XCTAssertTrue(MainScreen.phraseDoesExist(testPhrase), "Expected the first phrase \(testPhrase) to be added to and displayed in 'My Sayings'")
         
         // Add the same phrase again to the My Sayings
         MainScreen.addPhraseLabel.tap()

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -22,7 +22,7 @@ class PresetPhraseTests: BaseTest {
         // Verify that phrase does exist in Category Details Screen
         XCTAssertTrue(CustomCategoriesScreen.doesPhraseExist(customPhrase))
         
-        // Verify that phrase doesn exist in Main Screen
+        // Verify that phrase does exist in Main Screen
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.environment)
         XCTAssertTrue(MainScreen.doesPhraseExist(customPhrase))

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -85,11 +85,11 @@ class PresetPhraseTests: BaseTest {
     }
     
     func testEditPhrasesButtonIsDisabledForNumberPadCategory() {
-            let categoryName = "123"
+        let categoryName = "123"
            
-            SettingsScreen.navigateToSettingsCategoryScreen()
-            SettingsScreen.openCategorySettings(category: categoryName)
-            XCTAssertFalse(CustomCategoriesScreen.editCategoryPhrasesButton.isEnabled)
+        SettingsScreen.navigateToSettingsCategoryScreen()
+        SettingsScreen.openCategorySettings(category: categoryName)
+        XCTAssertFalse(CustomCategoriesScreen.editCategoryPhrasesButton.isEnabled)
     }
         
     func testEditPhrasesButtonIsDisabledForRecentsCategory() {

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -42,7 +42,6 @@ class PresetPhraseTests: BaseTest {
         let originalPhraseCell = XCUIApplication().cells[originalPhraseId]
         let originalPhrase = originalPhraseCell.staticTexts.firstMatch.label
         
-        //firstPhraseCell.tap()
         originalPhraseCell.staticTexts[originalPhrase].tap()
         KeyboardScreen.typeText(customPhrase)
         KeyboardScreen.checkmarkAddButton.tap()


### PR DESCRIPTION
closes #570 

# Description of Work
`PresetPhraseTests` class created and new tests are added to test these scenarios:

- `testAddNewPhrase()`
- `testEditPresetPhrase()`
- `testDeletePresetPhrase()`
- `testEditPhrasesButtonIsDisabledForNumberPadCategory()`
- `testEditPhrasesButtonIsDisabledForRecentsCategory()`
- `testAddDuplicatePhrasesToMySayings()`

## Notes to Test (Optional)
`PresetPhraseTests` test suite should pass on an iPhone and iPad