### PR TITLE
Adjusting Edit Phrase # of Rows & Columns 🎛️ 

### DIFF
--- a/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
+++ b/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
@@ -73,16 +73,16 @@ final class EditPhrasesViewController: PagingCarouselViewController, NSFetchedRe
     private func updateLayoutForCurrentTraitCollection() {
         collectionView.layout.interItemSpacing = .init(interRowSpacing: 8, interColumnSpacing: 30)
 
-        switch (traitCollection.horizontalSizeClass, traitCollection.verticalSizeClass) {
-        case (.regular, .regular):
+        switch sizeClass {
+        case .hRegular_vRegular:
             collectionView.layout.numberOfColumns = .fixedCount(2)
-            collectionView.layout.numberOfRows = .flexible(minHeight: .absolute(130))
-        case (.compact, .regular):
+            collectionView.layout.numberOfRows = .flexible(minHeight: .absolute(100))
+        case .hCompact_vRegular:
             collectionView.layout.numberOfColumns = .fixedCount(1)
-            collectionView.layout.numberOfRows = .flexible(minHeight: .absolute(130))
-        case (.compact, .compact), (.regular, .compact):
-            collectionView.layout.numberOfColumns = .fixedCount(1)
-            collectionView.layout.numberOfRows = .fixedCount(2)
+            collectionView.layout.numberOfRows = .flexible(minHeight: .absolute(64))
+        case .hCompact_vCompact, .hRegular_vCompact:
+            collectionView.layout.numberOfColumns = .fixedCount(2)
+            collectionView.layout.numberOfRows = .flexible(minHeight: .absolute(64))
         default:
             break
         }

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -12,8 +12,8 @@ class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
     
     func testCanNavigatePages() {
         // Add enough phrases to have 2 pages.
-        for phrase in listOfPhrases.startIndex..<5 {
-            CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
+        listOfPhrases.forEach { phrase in
+            CustomCategoriesScreen.addPhrase(phrase)
         }
         
         // Verify that the user is on the first page and the next page buttons are enabled.
@@ -36,7 +36,7 @@ class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
     
     func testPagesAdjustToNewPhrases() {
         // Add enough phrases (4) to fill one page.
-        for phrase in listOfPhrases.startIndex..<4 {
+        for phrase in listOfPhrases.startIndex..<8 {
             CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
         }
         

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -12,7 +12,7 @@ class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
     
     func testCanNavigatePages() {
         // Add enough phrases to have 2 pages.
-        for phrase in listOfPhrases.startIndex..<8 {
+        for phrase in listOfPhrases.startIndex..<9 {
             CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
         }
         

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -12,8 +12,8 @@ class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
     
     func testCanNavigatePages() {
         // Add enough phrases to have 2 pages.
-        listOfPhrases.forEach { phrase in
-            CustomCategoriesScreen.addPhrase(phrase)
+        for phrase in listOfPhrases.startIndex..<8 {
+            CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
         }
         
         // Verify that the user is on the first page and the next page buttons are enabled.

--- a/VocableUITests/Tests/CustomPhraseBaseTest.swift
+++ b/VocableUITests/Tests/CustomPhraseBaseTest.swift
@@ -14,7 +14,7 @@ class CustomPhraseBaseTest: BaseTest {
     private(set) var customCategoryIdentifier: CategoryIdentifier?
     
     // To avoid potential duplication from random strings, we'll have our own phrase bank to pull from.
-    private(set) var listOfPhrases: [String] = ["A", "B", "C", "D", "E", "F", "G", "H"]
+    private(set) var listOfPhrases: [String] = ["A", "B", "C", "D", "E", "F", "G", "H", "I"]
     
     override func setUp() {
         super.setUp()

--- a/VocableUITests/Tests/MainScreenPaginationTests.swift
+++ b/VocableUITests/Tests/MainScreenPaginationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 class MainScreenPaginationTests: CustomPhraseBaseTest {
     
     func testDeletingPhrasesAdjustsPagination() {
-        listOfPhrases.forEach { phrase in
-            CustomCategoriesScreen.addPhrase(phrase)
+        for phrase in listOfPhrases.startIndex..<8 {
+            CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
         }
         
         // Navigate to main screen to verify page numbers; expected to be "Page 1 of 2"


### PR DESCRIPTION
# Description of Work
The number of rows and columns were not matching designs, so there were much less phrases for each page when editing phrases on iPhone and iPad. The number of rows on iPhone were made a bit larger than the Figma designs in order to better fit wrapped text.

## Before
| Orientation | iPhone 13 | iPad Pro 11" |
| :--- | :---: | :---: |
| Portrait | <img src=https://user-images.githubusercontent.com/37670742/165340449-3feddc81-6279-48e1-a171-c51e0ae73884.png height=500> | <img src=https://user-images.githubusercontent.com/37670742/165340543-a1ff599b-acd7-426d-8a37-6893814f5d62.png> |
| Landscape | <img src=https://user-images.githubusercontent.com/37670742/165340534-1a3c45c6-6fa4-4907-a17f-47c8ebc1a4d6.png> | <img src=https://user-images.githubusercontent.com/37670742/165340562-ab118cac-91ca-4cdc-9329-fe009addcfb7.png> |

## After
| Orientation | iPhone 13 | iPad Pro 11" |
| :--- | :---: | :---: |
| Portrait | <img src=https://user-images.githubusercontent.com/37670742/165340757-c8102563-59e5-4d00-b326-e6d91a1b63f6.png height=500> | <img src=https://user-images.githubusercontent.com/37670742/165340941-2ffba009-2f2f-4ecb-bf92-a3a66a5f2eb2.png> |
| Landscape | <img src=https://user-images.githubusercontent.com/37670742/165340796-197ca16c-7e9b-4163-9093-290e1885b775.png> | <img src=https://user-images.githubusercontent.com/37670742/165341044-6245caea-022e-4c34-b464-eeb8801b99d2.png> |

---
