### PR TITLE
Removing Reset App Settings As Debug Feature

### DIFF
--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -62,7 +62,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
         }
 
         var isFeatureEnabled: Bool {
-            let debugFeatures: [SettingsItem] = [.resetAppSettings, .pidTuner]
+            let debugFeatures: [SettingsItem] = [.pidTuner]
             if debugFeatures.contains(self) {
                 return AppConfig.showDebugOptions
             }
@@ -160,7 +160,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
                               .pidTuner].filter(\.isFeatureEnabled))
         snapshot.appendSections([.externalURL])
         snapshot.appendItems([.privacyPolicy,
-                              .contactDevs].filter(\.isFeatureEnabled))
+                              .contactDevs])
         snapshot.appendSections([.version])
         snapshot.appendItems([.versionNum])
         dataSource.apply(snapshot, animatingDifferences: false)

--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -160,7 +160,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
                               .pidTuner].filter(\.isFeatureEnabled))
         snapshot.appendSections([.externalURL])
         snapshot.appendItems([.privacyPolicy,
-                              .contactDevs])
+                              .contactDevs].filter(\.isFeatureEnabled))
         snapshot.appendSections([.version])
         snapshot.appendItems([.versionNum])
         dataSource.apply(snapshot, animatingDifferences: false)


### PR DESCRIPTION
# Description of Work
The `Reset App Settings` option in the main setting screen was set as a debug feature, making it not visible on a production build. This PR removes it as a debug feature.

## Notes to Test (Optional)
This change should be noticeable by running on the app using `AppStore` scheme (where debug features are disabled/hidden).

---
