### PR TITLE
[556] Update Listening Mode localized strings

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		6BD84F9D2604F8F600D4CD3E /* ListenModeDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD84F9C2604F8F600D4CD3E /* ListenModeDebugView.swift */; };
 		6BD84FA22604FB1A00D4CD3E /* ListenModeDebugStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD84FA12604FB1A00D4CD3E /* ListenModeDebugStorage.swift */; };
 		6BDE5D3D25C1DF1600F47066 /* TranscriptionOutputTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDE5D3C25C1DF1600F47066 /* TranscriptionOutputTextView.swift */; };
+		6BE02F7F28188CEB002CCCED /* String+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE02F7E28188CEB002CCCED /* String+Localization.swift */; };
 		6BE23D562444DCBE0032CAE4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6BE23D542444DCBE0032CAE4 /* Localizable.strings */; };
 		6BE2628B25BB376700281BB5 /* AudioPermissionPromptController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE2628A25BB376700281BB5 /* AudioPermissionPromptController.swift */; };
 		6BE7E9842459D328007B01F2 /* PagingCarouselViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE7E9832459D328007B01F2 /* PagingCarouselViewController.swift */; };
@@ -328,6 +329,7 @@
 		6BD84F9C2604F8F600D4CD3E /* ListenModeDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenModeDebugView.swift; sourceTree = "<group>"; };
 		6BD84FA12604FB1A00D4CD3E /* ListenModeDebugStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenModeDebugStorage.swift; sourceTree = "<group>"; };
 		6BDE5D3C25C1DF1600F47066 /* TranscriptionOutputTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranscriptionOutputTextView.swift; sourceTree = "<group>"; };
+		6BE02F7E28188CEB002CCCED /* String+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
 		6BE23D552444DCBE0032CAE4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6BE23D5724450FDA0032CAE4 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6BE2628A25BB376700281BB5 /* AudioPermissionPromptController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPermissionPromptController.swift; sourceTree = "<group>"; };
@@ -924,6 +926,7 @@
 				4E014DA927EA53BC00561FC8 /* NSRange+.swift */,
 				4E8A303B27EBB95C000177B1 /* BidirectionalCollection+.swift */,
 				A93E46F6280614670081D544 /* NSDiffableDataSourceSnapshot+Map.swift */,
+				6BE02F7E28188CEB002CCCED /* String+Localization.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1190,6 +1193,7 @@
 				6B823BD323F4AE250099F65E /* PIDInterpolator.swift in Sources */,
 				B8DA9DE823EB833200FEBE19 /* BorderedView.swift in Sources */,
 				6B3FBBE825FBC72600B7D2CD /* ListeningResponseContentViewController.swift in Sources */,
+				6BE02F7F28188CEB002CCCED /* String+Localization.swift in Sources */,
 				6B5C490F2460627B00A4433C /* NumericCategoryContentViewController.swift in Sources */,
 				6B9DFA6023E889DB0037673E /* Extensions.swift in Sources */,
 				6B17CD7C23E9DFD50050BCB8 /* AVSpeechSynthesizer+Shared.swift in Sources */,

--- a/Vocable/Extensions/Category+Helpers.swift
+++ b/Vocable/Extensions/Category+Helpers.swift
@@ -82,6 +82,9 @@ extension Category {
     
     static func updateAllOrdinalValues(in context: NSManagedObjectContext) throws {
 
+        let listeningModeCategory = Category.fetch(.listeningMode, in: context)
+        listeningModeCategory.isHidden = !AppConfig.isListeningModeEnabled
+
         let request: NSFetchRequest<Category> = Category.fetchRequest()
         request.predicate = !Predicate(\Category.isUserRemoved)
         request.sortDescriptors = [

--- a/Vocable/Extensions/String+Localization.swift
+++ b/Vocable/Extensions/String+Localization.swift
@@ -1,0 +1,19 @@
+//
+//  String+Localization.swift
+//  Vocable
+//
+//  Created by Chris Stroud on 4/26/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import Foundation
+
+// Allows the new iOS 15 syntax/API to work on earlier iOS versions.
+// Not guaranteed to have identical behavior, but has been tested enough
+// to give confidence that it should work well enough for our purposes.
+extension String {
+    @available(iOS, obsoleted: 15.0, message: "Use String(localized keyAndValue:, table:, bundle:, locale:, comment:) instead")
+    init(localized key: String, table: String? = nil, bundle: Bundle = .main, locale: Locale = .current, comment: StaticString? = nil) {
+        self = bundle.localizedString(forKey: key, value: nil, table: table)
+    }
+}

--- a/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
+++ b/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
@@ -12,18 +12,51 @@ import Combine
 
 final class ListeningModeViewController: VocableCollectionViewController {
 
+    private enum Section: Int {
+        case listeningMode
+        case hotword
+    }
+
     private enum ContentItem: Int {
         case listeningModeEnabled
         case hotWordEnabled
+
+        var title: String {
+            switch self {
+            case .listeningModeEnabled:
+                return String(localized: "settings.listening_mode.listening_mode_toggle_cell.title")
+            case .hotWordEnabled:
+                return String(localized: "settings.listening_mode.hot_word_toggle_cell.title")
+            }
+        }
+
+        var accessibilityID: String {
+            switch self {
+            case .listeningModeEnabled:
+                return "listening_mode_toggle"
+            case .hotWordEnabled:
+                return "hot_word_toggle"
+            }
+        }
+
+        var accessory: VocableListCellAccessory {
+            switch self {
+            case .listeningModeEnabled:
+                return .toggle(isOn: AppConfig.isListeningModeEnabled)
+            case .hotWordEnabled:
+                return .toggle(isOn: AppConfig.isHotWordPermitted)
+            }
+        }
     }
 
-    private lazy var dataSource: UICollectionViewDiffableDataSource<Int, ContentItem> = .init(collectionView: collectionView) { [weak self] (collectionView, indexPath, item) -> UICollectionViewCell in
-        guard let self = self else { return UICollectionViewCell() }
-        return self.collectionView(collectionView, cellForItemAt: indexPath, item: item)
-    }
+    private typealias Snapshot = NSDiffableDataSourceSnapshot<Section, ContentItem>
+    private typealias Datasource = UICollectionViewDiffableDataSource<Section, ContentItem>
+
+    private var dataSource: Datasource!
 
     private var authorizationController = AudioPermissionPromptController()
     private var authorizationCancellable: AnyCancellable?
+    private var cellRegistration: UICollectionView.CellRegistration<VocableListCell, ContentItem>!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,8 +77,7 @@ final class ListeningModeViewController: VocableCollectionViewController {
     }
 
     private func setupNavigationBar() {
-        #warning("Needs localization")
-        navigationBar.title = "Listening Mode"
+        navigationBar.title = String(localized: "settings.listening_mode.title")
     }
 
     override func viewLayoutMarginsDidChange() {
@@ -63,41 +95,84 @@ final class ListeningModeViewController: VocableCollectionViewController {
     // MARK: UICollectionViewDataSource
 
     private func updateDataSource(animated: Bool = false) {
-        var snapshot = NSDiffableDataSourceSnapshot<Int, ContentItem>()
+        var snapshot = Snapshot()
         if let state = authorizationController.state {
             collectionView.backgroundView = EmptyStateView.listening(state.state, action: state.action)
             updateBackgroundViewLayoutMargins()
         } else {
-            snapshot.appendSections([0])
+            snapshot.appendSections([.listeningMode])
             snapshot.appendItems([.listeningModeEnabled])
             if AppConfig.isListeningModeEnabled {
+                snapshot.appendSections([.hotword])
                 snapshot.appendItems([.hotWordEnabled])
             }
             collectionView.backgroundView = nil
         }
-        dataSource.apply(snapshot, animatingDifferences: animated)
+
+        if #available(iOS 15.0, *) {
+            let reconfigurableItems = [.hotWordEnabled, .listeningModeEnabled].filter(snapshot.itemIdentifiers.contains)
+            snapshot.reconfigureItems(reconfigurableItems)
+        }
+
+        dataSource.apply(snapshot, animatingDifferences: animated) { [weak self] in
+            // Workaround for diffable datasource not auto-reconfiguring on iOS 14
+            if #unavailable(iOS 15) {
+                self?.updateVisibleCellConfigurations()
+            }
+        }
     }
 
     private func setupCollectionView() {
+
+        collectionView.isScrollEnabled = false
         collectionView.backgroundColor = .collectionViewBackgroundColor
-        collectionView.register(UINib(nibName: "SettingsToggleCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: SettingsToggleCollectionViewCell.reuseIdentifier)
         collectionView.register(UINib(nibName: "SettingsFooterTextSupplementaryView", bundle: nil),
                                 forSupplementaryViewOfKind: "footerText",
                                 withReuseIdentifier: "footerText")
 
-        dataSource.supplementaryViewProvider = { (collectionView, elementKind, indexPath) in
-            let footerView = collectionView.dequeueReusableSupplementaryView(ofKind: elementKind, withReuseIdentifier: elementKind, for: indexPath) as! SettingsFooterTextSupplementaryView
-            footerView.textLabel.text = """
-When this shortcut is enabled, someone saying \"Hey Vocable\" aloud will automatically navigate to the listening mode screen.
+        let cellRegistration = UICollectionView.CellRegistration<VocableListCell, ContentItem>(handler: { [weak self] cell, indexPath, item in
+            self?.updateContentConfiguration(for: cell, at: indexPath, item: item)
+        })
 
-This shortcut makes it fast to kick off a conversation by saying something like \"Hey Vocable, are you feeling okay?\" and jumping straight to the suggested responses.
-"""
+        let dataSource = Datasource(collectionView: collectionView) { (collectionView, indexPath, item) in
+            collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item)
+        }
+
+        dataSource.supplementaryViewProvider = { [weak self] (collectionView, elementKind, indexPath) in
+            let footerView = collectionView.dequeueReusableSupplementaryView(ofKind: elementKind, withReuseIdentifier: elementKind, for: indexPath) as! SettingsFooterTextSupplementaryView
+            guard let self = self else { return footerView }
+
+            let text: String
+            let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
+            switch section {
+            case .listeningMode:
+                text = String(localized: "settings.listening_mode.listening_mode_explanation_footer")
+            case .hotword:
+                text = String(localized: "settings.listening_mode.hotword_explanation_footer")
+            }
+            footerView.textLabel.text = text
             return footerView
         }
 
-        collectionView.collectionViewLayout = UICollectionViewCompositionalLayout(sectionProvider: { [weak self] (_, environment) -> NSCollectionLayoutSection? in
+        let configuration = UICollectionViewCompositionalLayoutConfiguration()
+        configuration.interSectionSpacing = 44
+        let layout = UICollectionViewCompositionalLayout(sectionProvider: { [weak self] (_, environment) -> NSCollectionLayoutSection? in
             return self?.layoutSection(environment: environment)
-        })
+        }, configuration: configuration)
+        collectionView.collectionViewLayout = layout
+
+        self.cellRegistration = cellRegistration
+        self.dataSource = dataSource
+    }
+
+    private func updateContentConfiguration(for cell: VocableListCell, at indexPath: IndexPath, item: ContentItem) {
+        let config = VocableListContentConfiguration(title: item.title,
+                                                     accessory: item.accessory,
+                                                     accessibilityIdentifier: item.accessibilityID) { [weak self] in
+            guard let self = self, let indexPath = self.dataSource.indexPath(for: item) else { return }
+            self.collectionView(self.collectionView, didSelectItemAt: indexPath)
+        }
+        cell.contentConfiguration = config
     }
 
     private func layoutSection(environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
@@ -118,7 +193,7 @@ This shortcut makes it fast to kick off a conversation by saying something like 
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: columnCount)
         group.interItemSpacing = .fixed(8)
 
-        let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(500))
+        let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(1))
         let footerItem = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: footerSize, elementKind: "footerText", alignment: .bottom)
 
         let section = NSCollectionLayoutSection(group: group)
@@ -146,11 +221,9 @@ This shortcut makes it fast to kick off a conversation by saying something like 
         switch item {
         case .listeningModeEnabled:
             AppConfig.isListeningModeEnabled.toggle()
-            updateDataSource(animated: true)
-            let context = NSPersistentContainer.shared.viewContext
+
+            let context = NSPersistentContainer.shared.newBackgroundContext()
             context.perform {
-                let listeningModeCategory = Category.fetch(.listeningMode, in: context)
-                listeningModeCategory.isHidden = !AppConfig.isListeningModeEnabled
                 try? Category.updateAllOrdinalValues(in: context)
                 try? context.save()
             }
@@ -158,42 +231,27 @@ This shortcut makes it fast to kick off a conversation by saying something like 
         case .hotWordEnabled:
             AppConfig.isHotWordPermitted.toggle()
         }
-    }
 
-    func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
-        guard let item = dataSource.itemIdentifier(for: indexPath) else { return false }
-        switch item {
-        case .listeningModeEnabled:
-            return true
-        case .hotWordEnabled:
-            return AppConfig.isListeningModeEnabled && AppConfig.listeningModeFeatureFlagEnabled
-        }
+        updateDataSource(animated: true)
     }
 
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        guard let item = dataSource.itemIdentifier(for: indexPath) else { return false }
-        switch item {
-        case .listeningModeEnabled:
-            return true
-        case .hotWordEnabled:
-            return AppConfig.isListeningModeEnabled && AppConfig.listeningModeFeatureFlagEnabled
-        }
+        return false
     }
 
-    private func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath, item: ContentItem) -> UICollectionViewCell {
-        switch item {
-        case .listeningModeEnabled:
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SettingsToggleCollectionViewCell.reuseIdentifier, for: indexPath) as! SettingsToggleCollectionViewCell
-            #warning("Needs localization")
-            let title = "Listening mode"
-            cell.setup(title: title, value: AppConfig.$isListeningModeEnabled)
-            return cell
-        case .hotWordEnabled:
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SettingsToggleCollectionViewCell.reuseIdentifier, for: indexPath) as! SettingsToggleCollectionViewCell
-            #warning("Needs localization")
-            let title = "\"Hey Vocable\" shortcut"
-            cell.setup(title: title, value: AppConfig.$isHotWordPermitted)
-            return cell
+    func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
+    @available(iOS, obsoleted: 15, message: "Use snapshot-based reconfiguring instead")
+    private func updateVisibleCellConfigurations() {
+        for indexPath in self.collectionView.indexPathsForVisibleItems {
+            if let cell = self.collectionView.cellForItem(at: indexPath) as? VocableListCell {
+                guard let item = self.dataSource.itemIdentifier(for: indexPath) else {
+                    continue
+                }
+                self.updateContentConfiguration(for: cell, at: indexPath, item: item)
+            }
         }
     }
 }

--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -54,8 +54,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
                 return NSLocalizedString("settings.cell.tune_cursor.title",
                                          comment: "tune cursor debug settings menu item")
             case .listeningMode:
-                #warning("Needs localization")
-                return "Listening Mode"
+                return String(localized: "settings.cell.listening_mode.title")
             case .versionNum:
                 return ""
             }

--- a/Vocable/Features/Voice/ListeningResponseEmptyStateViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseEmptyStateViewController.swift
@@ -25,50 +25,55 @@ enum ListeningEmptyState: EmptyStateRepresentable, Equatable {
     case listenModeFreeResponse
 
     var title: String {
-        #warning("Needs localization & Final copy")
         switch self {
-        case .microphonePermissionUndetermined, .microphonePermissionDenied:
-            return "Microphone Access"
-        case .speechPermissionDenied, .speechPermissionUndetermined:
-            return "Speech Recognition"
+        case .microphonePermissionDenied:
+            return String(localized: "listening_mode.empty_state.microphone_permission_denied.title")
+        case .microphonePermissionUndetermined:
+            return String(localized: "listening_mode.empty_state.microphone_permission_undetermined.title")
+        case .speechPermissionDenied:
+            return String(localized: "listening_mode.empty_state.speech_permission_denied.title")
+        case .speechPermissionUndetermined:
+            return String(localized: "listening_mode.empty_state.speech_permission_undetermined.title")
         case .listeningResponse:
-            return "Listening..."
+            return String(localized: "listening_mode.empty_state.actively_listening.title")
         case .listenModeFreeResponse:
-            return "Sounds complicated"
+            return String(localized: "listening_mode.empty_state.free_response.title")
         case .speechServiceUnavailable:
-            return "Speech services unavailable"
+            return String(localized: "listening_mode.empty_state.speech_unavailable.title")
         }
     }
 
     var description: String? {
-        #warning("Needs localization & Final copy")
         switch self {
         case .microphonePermissionUndetermined:
-            return "Vocable needs microphone access to enable Listening Mode. The button below presents an iOS permission dialog that Vocable's head tracking cannot interract with."
+            return String(localized: "listening_mode.empty_state.microphone_permission_undetermined.message")
         case .microphonePermissionDenied:
-            return "Vocable needs to use the microphone to enable Listening Mode. Please enable microphone access in the system Settings app.\n\nYou can also disable Listening Mode to hide this category in Vocable's settings."
+            return String(localized: "listening_mode.empty_state.microphone_permission_denied.message")
         case .speechPermissionUndetermined:
-            return "Vocable needs to request speech permissions to enable Listening Mode. This will present an iOS permission dialog that Vocable's head tracking cannot interract with."
+            return String(localized: "listening_mode.empty_state.speech_permission_undetermined.message")
         case .speechPermissionDenied:
-            return "Vocable needs speech recognition to enable Listening Mode. Please enable speech recognition in the system Settings app.\n\nYou can also disable Listening Mode to hide this category in Vocable's settings."
+            return String(localized: "listening_mode.empty_state.speech_permission_denied.message")
         case .listeningResponse:
-            return "When in listening mode, if someone starts speaking, Vocable will try to show quick responses."
+            return String(localized: "listening_mode.empty_state.actively_listening.message")
         case .listenModeFreeResponse:
-            return "Not sure what to suggest. Please repeat or use the rest of Vocable to respond."
+            return String(localized: "listening_mode.empty_state.free_response.message")
         case .speechServiceUnavailable:
-            return "Please try again later"
+            return String(localized: "listening_mode.empty_state.speech_unavailable.message")
         }
     }
 
     var buttonTitle: String? {
-        #warning("Needs localization & Final copy")
         switch self {
         case .listenModeFreeResponse, .listeningResponse, .speechServiceUnavailable:
             return nil
-        case .microphonePermissionUndetermined, .speechPermissionUndetermined:
-            return "Grant Access"
-        case .microphonePermissionDenied, .speechPermissionDenied:
-            return "Open Settings"
+        case .microphonePermissionUndetermined:
+            return String(localized: "listening_mode.empty_state.microphone_permission_undetermined.action")
+        case .speechPermissionUndetermined:
+            return String(localized: "listening_mode.empty_state.speech_permission_undetermined.action")
+        case .microphonePermissionDenied:
+            return String(localized: "listening_mode.empty_state.microphone_permission_denied.action")
+        case .speechPermissionDenied:
+            return String(localized: "listening_mode.empty_state.speech_permission_denied.action")
         }
     }
 

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -96,6 +96,9 @@
 /* tune cursor debug settings menu item */
 "settings.cell.tune_cursor.title" = "Tune Cursor";
 
+/* Listening Mode root settings menu item. Navigates the user to the Listening Mode settings screen where they can configure their preferences for listening mode. */
+"settings.cell.listening_mode.title" = "Listening Mode";
+
 /* Settings screen header title */
 "settings.header.title" = "Settings";
 
@@ -183,3 +186,85 @@
 "settings.alert.reset_app_settings_failure.button.ok" = "OK";
 
 "settings.selection_mode.head_tracking_unsupported_footer" = "This %1$@ on %2$@ %3$@ does not support head tracking.\n\nHead tracking is supported on all devices with a %4$@ camera, and on most devices with %6$@.";
+
+/* Listening Mode preferences screen title */
+"settings.listening_mode.title" = "Listening Mode";
+
+/* Footer text displayed in the Listening Mode preferences screen. This text describes the overall Listening Mode feature as well as the kinds of responses it can generate for the user. */
+"settings.listening_mode.listening_mode_explanation_footer" = "When listening mode is enabled, anyone can ask a question out loud and Vocable will offer a selection of responses. Vocable supports either/or questions and questions that can be answered with yes, no, or a number.";
+
+/* Footer text displayed in the Listening Mode preferences screen. This text describes the \"Hey Vocable\" feature, how it is activated, and how it automatically navigates the user to the Listening Mode screen. */
+"settings.listening_mode.hotword_explanation_footer" = "When this shortcut is enabled, anyone can say \"Hey, Vocable\" to prompt the app to navigate to the listening mode screen.";
+
+/* Title of Listening Mode preferences cell that toggles Listening Mode on or off when selected */
+"settings.listening_mode.listening_mode_toggle_cell.title" = "Listening Mode";
+
+/* Title of Listening Mode preferences cell that toggles \"Hey Vocable\" shortcut feature on or off when selected */
+"settings.listening_mode.hot_word_toggle_cell.title" = "\"Hey Vocable\" shortcut";
+
+
+
+// MARK: Listening Mode Empty State Titles
+
+/* Listening mode empty state title for when microphone permissions are required, but the user has denied them */
+"listening_mode.empty_state.microphone_permission_denied.title" = "Microphone Access";
+
+/* Listening mode empty state title for when microphone permissions are required and the user has not been shown the system permissions prompt yet */
+"listening_mode.empty_state.microphone_permission_undetermined.title" = "Microphone Access";
+
+/* Listening mode empty state title for when speech recognition permissions are required, but the user has denied them */
+"listening_mode.empty_state.speech_permission_denied.title" = "Speech Recognition";
+
+/* Listening mode empty state title for when speech recognition permissions are required and the user has not been shown the system permissions prompt yet */
+"listening_mode.empty_state.speech_permission_undetermined.title" = "Speech Recognition";
+
+/* Listening mode empty state title for when listening has began but no responses have been displayed yet */
+"listening_mode.empty_state.actively_listening.title" = "Listening...";
+
+/* Listen mode empty state title for when no responses could be generated */
+"listening_mode.empty_state.free_response.title" = "Sounds complicated";
+
+/* Listen mode error state title for when Apple's speech to text service is unavailable */
+"listening_mode.empty_state.speech_unavailable.title" = "Speech services unavailable";
+
+
+
+// MARK: Listening Mode Empty State Messages
+
+/* Listening mode empty state message for when microphone permissions are required, but the user has denied them */
+"listening_mode.empty_state.microphone_permission_denied.message" = "Vocable needs to use the microphone to enable Listening Mode. Please enable microphone access in the system Settings app.\n\nYou can also disable Listening Mode to hide this category in Vocable's settings.";
+
+/* Listening mode empty state message for when microphone permissions are required and the user has not been shown the system permissions prompt yet */
+"listening_mode.empty_state.microphone_permission_undetermined.message" = "Vocable needs microphone access to enable Listening Mode. The button below presents an iOS permission dialog that Vocable's head tracking cannot interract with.";
+
+/* Listening mode empty state message for when speech recognition permissions are required, but the user has denied them */
+"listening_mode.empty_state.speech_permission_denied.message" = "Vocable needs speech recognition to enable Listening Mode. Please enable speech recognition in the system Settings app.\n\nYou can also disable Listening Mode to hide this category in Vocable's settings.";
+
+/* Listening mode empty state message for when speech recognition permissions are required and the user has not been shown the system permissions prompt yet */
+"listening_mode.empty_state.speech_permission_undetermined.message" = "Vocable needs to request speech permissions to enable Listening Mode. This will present an iOS permission dialog that Vocable's head tracking cannot interract with.";
+
+/* Listening mode empty state message for when listening has began but no responses have been displayed yet */
+"listening_mode.empty_state.actively_listening.message" = "When in listening mode, if someone starts speaking, Vocable will try to show quick responses.";
+
+/* Listen mode empty state message for when no responses could be generated */
+"listening_mode.empty_state.free_response.message" = "Not sure what to suggest. Please repeat or use the rest of Vocable to respond.";
+
+/* Listen mode error state message for when Apple's speech to text service is unavailable */
+"listening_mode.empty_state.speech_unavailable.message" = "Please try again later";
+
+
+
+// MARK: Listening Mode Empty State Button Titles
+
+/* Listen mode empty state action that will allow the user to open the Settings app in order to grant microphone permissions. */
+"listening_mode.empty_state.microphone_permission_denied.action" = "Open Settings";
+
+/* Listen mode empty state action that will allow the user to grant access to microphone permissions via the system permissions alert. */
+"listening_mode.empty_state.microphone_permission_undetermined.action" = "Grant Access";
+
+/* Listen mode empty state action that will allow the user to open the Settings app in order to grant speech recognition permissions. */
+"listening_mode.empty_state.speech_permission_denied.action" = "Open Settings";
+
+/* Listen mode empty state action that will allow the user to grant access to speech recognition permissions via the system permissions alert. */
+"listening_mode.empty_state.speech_permission_undetermined.action" = "Grant Access";
+


### PR DESCRIPTION
Closes #556 

* [Gently] overhauls the localization mechanism to appease the xliff export process and remove some code noise
    - `String(localized: )` should be preferred over `NSLocalizedString`
    - ^ that is iOS 15 API but it fits nicely with our objectives for iOS 14 so I'm stealing it and making a backward-compatible extension
* New strings should have their comments entered in Localizable.strings rather than in code
* Made the Listening Mode preferences screen use the `VocableListCell` API 
