### PR TITLE
CircleCI release branch TestFlight update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,9 @@ workflows:
       - buildanddeploytotestflight:
           filters:
             branches:
-              only: develop
+              only: 
+                - develop
+                - release/*
           requires:
             - export-localizations-for-crowdin
             - build-and-test


### PR DESCRIPTION
Updates pipeline to produce TestFlight builds from both `develop` and `release/*` branches

Will cherry-pick into the release branch post-merge