### PR TITLE
[607] Fix main screen phrases not updating when edited in settings

### DIFF
--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -131,16 +131,16 @@ import Combine
         }
 
         let selectedIndexPaths = Set(collectionView.indexPathsForSelectedItems?.map {
-            dataSourceProxy.indexPath(fromMappedIndexPath: $0)
+            dataSourceProxy.indexPath(fromVirtual: $0)
             } ?? [])
         for path in selectedIndexPaths where path != indexPath {
-            dataSourceProxy.performActions(on: path) { (aPath) in
-                collectionView.deselectItem(at: aPath, animated: true)
+            dataSourceProxy.performActions(on: path) { elements in
+                collectionView.deselectItem(at: elements.virtualIndexPath, animated: true)
             }
         }
 
-        dataSourceProxy.performActions(on: indexPath) { (aPath) in
-            collectionView.selectItem(at: aPath, animated: true, scrollPosition: [])
+        dataSourceProxy.performActions(on: indexPath) { elements in
+            collectionView.selectItem(at: elements.virtualIndexPath, animated: true, scrollPosition: [])
         }
     }
 
@@ -181,10 +181,10 @@ import Combine
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
 
         let previousItem: (objectID: NSManagedObjectID, indexPath: IndexPath)? = {
-            guard let mapped = collectionView.indexPathsForSelectedItems?.first else {
+            guard let virtualIndexPath = collectionView.indexPathsForSelectedItems?.first else {
                 return nil
             }
-            let indexPath = dataSourceProxy.indexPath(fromMappedIndexPath: mapped)
+            let indexPath = dataSourceProxy.indexPath(fromVirtual: virtualIndexPath)
             guard let objectID = dataSourceProxy.itemIdentifier(for: indexPath) else {
                 return nil
             }
@@ -307,8 +307,8 @@ import Combine
         for indexPath in collectionView.indexPathsForSelectedItems ?? [] {
             collectionView.deselectItem(at: indexPath, animated: false)
         }
-        dataSourceProxy.performActions(on: destinationIndexPath) { (aPath) in
-            collectionView.selectItem(at: aPath, animated: false, scrollPosition: [])
+        dataSourceProxy.performActions(on: destinationIndexPath) { elements in
+            collectionView.selectItem(at: elements.virtualIndexPath, animated: false, scrollPosition: [])
         }
 
         collectionView.scrollToNearestSelectedIndexPathOrCurrentPageBoundary()
@@ -321,13 +321,13 @@ import Combine
         updateSelectedItemForHorizontallyCompactLayout()
     }
 
-    func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
+    func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt virtualIndexPath: IndexPath) -> Bool {
         return false
     }
 
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let mappedIndexPath = dataSourceProxy.indexPath(fromMappedIndexPath: indexPath)
-        categoryObjectID = frc.object(at: mappedIndexPath).objectID
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt virtualIndexPath: IndexPath) {
+        let indexPath = dataSourceProxy.indexPath(fromVirtual: virtualIndexPath)
+        categoryObjectID = frc.object(at: indexPath).objectID
         updateSelectedIndexPathsInProxyDataSource()
     }
 
@@ -349,8 +349,8 @@ import Combine
         for indexPath in collectionView.indexPathsForSelectedItems ?? [] {
             collectionView.deselectItem(at: indexPath, animated: false)
         }
-        dataSourceProxy.performActions(on: desiredIndexPath) { (aPath) in
-            collectionView.selectItem(at: aPath, animated: false, scrollPosition: [])
+        dataSourceProxy.performActions(on: desiredIndexPath) { elements in
+            collectionView.selectItem(at: elements.virtualIndexPath, animated: false, scrollPosition: [])
         }
 
         collectionView.scrollToNearestSelectedIndexPathOrCurrentPageBoundary()

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -212,38 +212,6 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
         collectionView.backgroundView = nil
     }
 
-    @objc private func handleCellDeletionButton(_ sender: UIButton) {
-
-        func deleteAction() {
-            self.deletePhrase(sender)
-        }
-
-        let title = NSLocalizedString("category_editor.alert.delete_phrase_confirmation.title",
-                                      comment: "Delete phrase confirmation alert title")
-        let deleteButtonTitle = NSLocalizedString("category_editor.alert.delete_phrase_confirmation.button.delete.title",
-                                                  comment: "Delete phrase alert action button title")
-        let cancelButtonTitle = NSLocalizedString("category_editor.alert.delete_phrase_confirmation.button.cancel.title",
-                                                  comment: "Delete phrase alert cancel button title")
-
-        let alert = GazeableAlertViewController(alertTitle: title)
-        alert.addAction(.cancel(withTitle: cancelButtonTitle))
-        alert.addAction(.delete(withTitle: deleteButtonTitle, handler: deleteAction))
-        self.present(alert, animated: true)
-    }
-
-    private func deletePhrase(_ sender: UIButton) {
-        guard let indexPath = collectionView.indexPath(containing: sender) else {
-            assertionFailure("Failed to obtain index path")
-            return
-        }
-
-        let safeIndexPath = dataSourceProxy.indexPath(fromMappedIndexPath: indexPath)
-        let phrase = frc.object(at: safeIndexPath)
-        let context = NSPersistentContainer.shared.viewContext
-        context.delete(phrase)
-        try? context.save()
-    }
-
     @IBAction func addNewPhraseButtonSelected() {
         let vc = TextEditorViewController()
         let context = NSPersistentContainer.shared.newBackgroundContext()

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -103,23 +103,30 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
     private func makeDataSource() -> DataSource {
         DataSource(collectionView: collectionView) { [weak self] (collectionView, indexPath, item) -> UICollectionViewCell? in
             guard let self = self else { return nil }
-
+            let cell: UICollectionViewCell
             switch item {
-            case .persistedPhrase(let objectId):
-                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PresetItemCollectionViewCell.reuseIdentifier, for: indexPath) as? PresetItemCollectionViewCell
-
-                guard let phrase = Phrase.fetchObject(in: self.frc.managedObjectContext, matching: objectId) else { return cell }
-                cell?.textLabel.text = phrase.utterance
-
-                return cell
+            case .persistedPhrase:
+                cell = collectionView.dequeueReusableCell(withReuseIdentifier: PresetItemCollectionViewCell.reuseIdentifier, for: indexPath)
             case .addNewPhrase:
-                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AddPhraseCollectionViewCell.reuseIdentifier, for: indexPath) as? AddPhraseCollectionViewCell
-                cell?.accessibilityIdentifier = "add_new_phrase"
-                
-                return cell
+                cell = collectionView.dequeueReusableCell(withReuseIdentifier: AddPhraseCollectionViewCell.reuseIdentifier, for: indexPath)
             }
+            self.configureCell(cell, for: item, at: indexPath)
+            return cell
         }
+    }
 
+    private func configureCell(_ cell: UICollectionViewCell, for item: CategoryItem, at indexPath: IndexPath) {
+        switch item {
+        case .persistedPhrase(let objectId):
+            let cell = cell as? PresetItemCollectionViewCell
+
+            guard let phrase = Phrase.fetchObject(in: self.frc.managedObjectContext, matching: objectId) else { return }
+            cell?.textLabel.text = phrase.utterance
+
+        case .addNewPhrase:
+            let cell = cell as? AddPhraseCollectionViewCell
+            cell?.accessibilityIdentifier = "add_new_phrase"
+        }
     }
 
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
@@ -132,7 +139,17 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
         if #available(iOS 15, *) {
             dataSourceProxy.apply(updatedSnapshot, animatingDifferences: false)
         } else {
-            dataSourceProxy.apply(updatedSnapshot, animatingDifferences: true)
+            dataSourceProxy.apply(updatedSnapshot, animatingDifferences: true) { [weak self] in
+                guard let self = self, #unavailable(iOS 15) else { return }
+
+                // This is effectively the same iOS 14 fix we have for
+                // screens that have been updated for VocableListCell
+                let visibleIndexPaths = self.collectionView.indexPathsForVisibleItems
+                self.dataSourceProxy.performActions(on: visibleIndexPaths) { elements in
+                    guard let cell = self.collectionView.cellForItem(at: elements.virtualIndexPath) else { return }
+                    self.configureCell(cell, for: elements.itemIdentifier, at: elements.virtualIndexPath)
+                }
+            }
         }
         let pageCountAfter = collectionView.layout.pagesPerSection
 

--- a/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
+++ b/Vocable/Features/Settings/EditCategories/EditCategoriesViewController.swift
@@ -187,7 +187,7 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
         }
     }
 
-    private func mappedIndexPathForCategory(withObjectID objectID: NSManagedObjectID) -> IndexPath? {
+    private func indexPathForCategory(withObjectID objectID: NSManagedObjectID) -> IndexPath? {
         guard let category = fetchResultsController.managedObjectContext.object(with: objectID) as? Category else {
             return nil
         }
@@ -197,12 +197,12 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
             return nil
         }
 
-        return diffableDataSource.indexPath(fromMappedIndexPath: standardIndexPath)
+        return diffableDataSource.indexPath(fromVirtual: standardIndexPath)
     }
 
     private func handleMoveUpForCategory(withObjectID objectID: NSManagedObjectID) {
 
-        guard let fromIndexPath = mappedIndexPathForCategory(withObjectID: objectID) else {
+        guard let fromIndexPath = indexPathForCategory(withObjectID: objectID) else {
             return
         }
         guard let toIndexPath = collectionView.indexPath(before: fromIndexPath) else {
@@ -217,7 +217,7 @@ final class EditCategoriesViewController: PagingCarouselViewController, NSFetche
 
     private func handleMoveDownForCategory(withObjectID objectID: NSManagedObjectID) {
 
-        guard let fromIndexPath = mappedIndexPathForCategory(withObjectID: objectID) else {
+        guard let fromIndexPath = indexPathForCategory(withObjectID: objectID) else {
             return
         }
         guard let toIndexPath = collectionView.indexPath(after: fromIndexPath) else {


### PR DESCRIPTION
Fixes #607 

* Renamed some existing vocabulary to make the infinite scroll proxy datasource more approachable (I was having a hard time following it to implement this change)
* Deleted some unreferenced code that was in this same screen
* Added a means for iOS 14 to reconfigure visible cells on this screen. Converting this screen to VocableListCell felt excessive.