### PR TITLE
[616] Fix retain cycle crash in Category Details VC

### DIFF
--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -220,7 +220,9 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
         if category.identifier == Category.Identifier.recents {
             collectionView.backgroundView = EmptyStateView(type: EmptyStateType.recents)
         } else {
-            collectionView.backgroundView = EmptyStateView(type: EmptyStateType.phraseCollection, action: addNewPhraseButtonSelected)
+            collectionView.backgroundView = EmptyStateView(type: EmptyStateType.phraseCollection, action: { [weak self] in
+                self?.addNewPhraseButtonSelected()
+            })
         }
     }
 

--- a/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
+++ b/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
@@ -18,8 +18,8 @@ final class SelectionModeViewController: VocableCollectionViewController {
         case headTrackingUnsupportedFooter
     }
 
-    private lazy var dataSource: UICollectionViewDiffableDataSource<Int, SelectionModeItem> = .init(collectionView: collectionView) { (collectionView, indexPath, item) -> UICollectionViewCell in
-        return self.collectionView(collectionView, cellForItemAt: indexPath, item: item)
+    private lazy var dataSource: UICollectionViewDiffableDataSource<Int, SelectionModeItem> = .init(collectionView: collectionView) { [weak self] (collectionView, indexPath, item) -> UICollectionViewCell? in
+        return self?.collectionView(collectionView, cellForItemAt: indexPath, item: item)
     }
 
     override func viewDidLoad() {

--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -86,7 +86,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
             return cell
         case .versionNum:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SettingsFooterCollectionViewCell.reuseIdentifier, for: indexPath) as! SettingsFooterCollectionViewCell
-            cell.setup(versionLabel: self.versionAndBuildNumber)
+            cell.setup(versionLabel: SettingsViewController.versionAndBuildNumber)
             return cell
         case .pidTuner:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SettingsCollectionViewCell.reuseIdentifier, for: indexPath) as! SettingsCollectionViewCell
@@ -95,7 +95,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
         }
     }
 
-    private var versionAndBuildNumber: String {
+    static private var versionAndBuildNumber: String {
         let versionNumber = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
         return "Version \(versionNumber)-\(buildNumber)"
@@ -127,7 +127,10 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
         collectionView.register(UINib(nibName: "SettingsFooterCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: SettingsFooterCollectionViewCell.reuseIdentifier)
         collectionView.register(UINib(nibName: "SettingsCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: SettingsCollectionViewCell.reuseIdentifier)
 
-        collectionView.collectionViewLayout = UICollectionViewCompositionalLayout { (sectionIndex, environment) -> NSCollectionLayoutSection? in
+        collectionView.collectionViewLayout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex, environment) -> NSCollectionLayoutSection? in
+            guard let self = self else {
+                return nil
+            }
             let section = self.dataSource.snapshot().sectionIdentifiers[sectionIndex]
             switch section {
             case .internalSettings:
@@ -338,7 +341,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
         let composeVC = MFMailComposeViewController()
         composeVC.mailComposeDelegate = self
         composeVC.setToRecipients(["vocable@willowtreeapps.com"])
-        composeVC.setSubject("Feedback for iOS Vocable \(versionAndBuildNumber)")
+        composeVC.setSubject("Feedback for iOS Vocable \(SettingsViewController.versionAndBuildNumber)")
         self.composeVC = composeVC
 
         self.present(composeVC, animated: true)

--- a/Vocable/Features/Settings/TimingSensitivity/TimingSensitivityViewController.swift
+++ b/Vocable/Features/Settings/TimingSensitivity/TimingSensitivityViewController.swift
@@ -18,8 +18,8 @@ final class TimingSensitivityViewController: VocableCollectionViewController {
     private let maxDwellTimeDuration = 5.0
     private let minDwellTimeDuration = 0.5
 
-    private lazy var dataSource = UICollectionViewDiffableDataSource<Int, SelectionModeItem>(collectionView: collectionView) { (collectionView, indexPath, item) -> UICollectionViewCell in
-        return self.collectionView(collectionView, cellForItemAt: indexPath, item: item)
+    private lazy var dataSource = UICollectionViewDiffableDataSource<Int, SelectionModeItem>(collectionView: collectionView) { [weak self] (collectionView, indexPath, item) -> UICollectionViewCell? in
+        return self?.collectionView(collectionView, cellForItemAt: indexPath, item: item)
     }
 
     override func viewDidLoad() {
@@ -45,8 +45,8 @@ final class TimingSensitivityViewController: VocableCollectionViewController {
         collectionView.register(UINib(nibName: "DwellTimeCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: DwellTimeCollectionViewCell.reuseIdentifier)
         collectionView.register(UINib(nibName: "SensitivityCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: SensitivityCollectionViewCell.reuseIdentifier)
 
-        collectionView.collectionViewLayout = UICollectionViewCompositionalLayout { (_, environment) -> NSCollectionLayoutSection? in
-            self.section(environment: environment)
+        collectionView.collectionViewLayout = UICollectionViewCompositionalLayout { [weak self] (_, environment) -> NSCollectionLayoutSection? in
+            self?.section(environment: environment)
         }
 
         updateDataSource()


### PR DESCRIPTION
Closes #616 

A retain cycle was causing the datasource to outlive the view controller that owned it, which was causing problems in certain user flows. 