### PR TITLE
[623] Add support for disabling animations as launch argument

### DIFF
--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -105,6 +105,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "disableAnimations"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "enableListeningMode"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -70,6 +70,9 @@
                   Identifier = "CustomPhraseTests/testPagination()">
                </Test>
                <Test
+                  Identifier = "MainScreenPaginationTests/testCanScrollPagesWithPaginationArrows()">
+               </Test>
+               <Test
                   Identifier = "MainScreenTests/testCustonCategoryPagination()">
                </Test>
                <Test
@@ -102,10 +105,6 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "resetAppDataOnLaunch"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "disableAnimations"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Vocable/AppDelegate.swift
+++ b/Vocable/AppDelegate.swift
@@ -54,6 +54,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
+        if LaunchArguments.contains(.disableAnimations) {
+            print("-disableAnimations detected")
+            UIView.setAnimationsEnabled(false)
+        }
+
         // Ensure that the persistent store has the current
         // default presets before presenting UI
         performPersistenceMigrationForCurrentLanguage()

--- a/Vocable/Common/CarouselGridCollectionViewController.swift
+++ b/Vocable/Common/CarouselGridCollectionViewController.swift
@@ -107,7 +107,8 @@ class CarouselGridCollectionView: UICollectionView {
             needsInitialScrollToMiddle = false
         }
         if let offset = layout.scrollOffsetForPageWithOffsetFromCurrentPage(offset: 1) {
-            scrollRectToVisible(CGRect(origin: offset, size: bounds.size), animated: true)
+            let shouldAnimate = UIView.areAnimationsEnabled
+            scrollRectToVisible(CGRect(origin: offset, size: bounds.size), animated: shouldAnimate)
         }
     }
 
@@ -117,7 +118,8 @@ class CarouselGridCollectionView: UICollectionView {
             needsInitialScrollToMiddle = false
         }
         if let offset = layout.scrollOffsetForPageWithOffsetFromCurrentPage(offset: -1) {
-            scrollRectToVisible(CGRect(origin: offset, size: bounds.size), animated: true)
+            let shouldAnimate = UIView.areAnimationsEnabled
+            scrollRectToVisible(CGRect(origin: offset, size: bounds.size), animated: shouldAnimate)
         }
     }
 

--- a/Vocable/Common/LaunchArguments.swift
+++ b/Vocable/Common/LaunchArguments.swift
@@ -13,6 +13,7 @@ public struct LaunchArguments {
     public enum Key: String {
         case resetAppDataOnLaunch
         case enableListeningMode
+        case disableAnimations
     }
 
     static func contains(_ key: Key) -> Bool {

--- a/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
+++ b/Vocable/Features/Settings/EditPhrases/EditPhrasesViewController.swift
@@ -111,7 +111,7 @@ final class EditPhrasesViewController: PagingCarouselViewController, NSFetchedRe
         }
 
         if pageCountBefore < 2, pageCountAfter > 1 {
-            collectionView.scrollToMiddleSection(animated: true)
+            collectionView.scrollToMiddleSection(animated: UIView.areAnimationsEnabled)
         }
     }
 

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -75,7 +75,8 @@ class BaseScreen {
         
         // Loop through each custom category page to find our phrase
         for _ in 1...totalPageCount {
-            if XCUIApplication().cells.staticTexts.containing(predicate).element.exists {
+            // We make sure to wait, accounting for adding/deleting a phrase
+            if XCUIApplication().cells.staticTexts.containing(predicate).element.waitForExistence(timeout: 0.5) {
                 flag = true
                 break
             } else {

--- a/VocableUITests/Screens/CustomCategoriesScreen.swift
+++ b/VocableUITests/Screens/CustomCategoriesScreen.swift
@@ -35,7 +35,7 @@ class CustomCategoriesScreen: BaseScreen {
     
     static func addPhrase(_ phrase: String) {
         categoriesPageAddPhraseButton.tap()
-        _ = KeyboardScreen.checkmarkAddButton.waitForExistence(timeout: 0.5)
+        _ = KeyboardScreen.checkmarkAddButton.waitForExistence(timeout: 0.75)
         KeyboardScreen.typeText(phrase)
         KeyboardScreen.checkmarkAddButton.tap()
         _ = categoriesPageAddPhraseButton.waitForExistence(timeout: 0.5)

--- a/VocableUITests/Screens/CustomCategoriesScreen.swift
+++ b/VocableUITests/Screens/CustomCategoriesScreen.swift
@@ -38,6 +38,7 @@ class CustomCategoriesScreen: BaseScreen {
         _ = KeyboardScreen.checkmarkAddButton.waitForExistence(timeout: 0.5)
         KeyboardScreen.typeText(phrase)
         KeyboardScreen.checkmarkAddButton.tap()
+        _ = categoriesPageAddPhraseButton.waitForExistence(timeout: 0.5)
     }
     
     static func addRandomPhrases(numberOfPhrases: Int) {
@@ -47,6 +48,7 @@ class CustomCategoriesScreen: BaseScreen {
             KeyboardScreen.typeText(randomPhrase)
             KeyboardScreen.checkmarkAddButton.tap()
         }
+        _ = categoriesPageAddPhraseButton.waitForExistence(timeout: 0.5)
     }
     
     static func returnToMainScreenFromCategoriesList() {

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -111,6 +111,7 @@ class SettingsScreen: BaseScreen {
     static func navigateToSettingsCategoryScreen() {
         MainScreen.settingsButton.tap(afterWaitingForExistenceWithTimeout: 2)
         categoriesButton.tap(afterWaitingForExistenceWithTimeout: 2)
+        _ = settingsPageAddCategoryButton.waitForExistence(timeout: 0.5)
     }
     
     static func returnToMainScreen() {

--- a/VocableUITests/Tests/BaseTest.swift
+++ b/VocableUITests/Tests/BaseTest.swift
@@ -14,7 +14,7 @@ class BaseTest: XCTestCase {
     override func setUp() {
         let app = XCUIApplication()
         app.configure {
-            Arguments(.resetAppDataOnLaunch, .enableListeningMode)
+            Arguments(.resetAppDataOnLaunch, .enableListeningMode, .disableAnimations)
         }
         continueAfterFailure = false
         app.launch()

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -41,7 +41,7 @@ class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
     
     func testPagesAdjustToNewPhrases() {
         // Add enough phrases (7) to fill one page.
-        for phrase in listOfPhrases.startIndex..<7 {
+        for phrase in listOfPhrases.startIndex..<8 {
             CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
         }
         

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -35,8 +35,8 @@ class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
     }
     
     func testPagesAdjustToNewPhrases() {
-        // Add enough phrases (4) to fill one page.
-        for phrase in listOfPhrases.startIndex..<8 {
+        // Add enough phrases (7) to fill one page.
+        for phrase in listOfPhrases.startIndex..<7 {
             CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
         }
         

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -10,10 +10,15 @@ import XCTest
 
 class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
     
+    /* TODO: There is an existing bug(s) that causes this test to fail with
+     animations turned off. We will re-enable this test once they're fixed.
+     https://github.com/willowtreeapps/vocable-ios/issues/597
+     https://github.com/willowtreeapps/vocable-ios/issues/594
+     */
     func testCanNavigatePages() {
         // Add enough phrases to have 2 pages.
-        for phrase in listOfPhrases.startIndex..<9 {
-            CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
+        listOfPhrases.forEach { phrase in
+            CustomCategoriesScreen.addPhrase(phrase)
         }
         
         // Verify that the user is on the first page and the next page buttons are enabled.

--- a/VocableUITests/Tests/CustomCategoryTests.swift
+++ b/VocableUITests/Tests/CustomCategoryTests.swift
@@ -66,6 +66,7 @@ class CustomCategoryTests: CustomCategoryBaseTest {
         SettingsScreen.openCategorySettings(category: customCategoryName)
         SettingsScreen.removeCategoryButton.tap()
         SettingsScreen.alertRemoveButton.tap()
+        _ = SettingsScreen.settingsPageAddCategoryButton.waitForExistence(timeout: 0.5)
         XCTAssertFalse(SettingsScreen.doesCategoryExist(customCategoryName))
     }
   

--- a/VocableUITests/Tests/MainScreenPaginationTests.swift
+++ b/VocableUITests/Tests/MainScreenPaginationTests.swift
@@ -61,7 +61,7 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
         VTAssertPaginationEquals(1, of: 2)
     }
     
-    /* TODO: There is an existing bug(s) that cause this test to fail with
+    /* TODO: There is an existing bug(s) that causes this test to fail with
      animations turned off. We will re-enable this test once they're fixed.
      https://github.com/willowtreeapps/vocable-ios/issues/597
      https://github.com/willowtreeapps/vocable-ios/issues/594

--- a/VocableUITests/Tests/MainScreenPaginationTests.swift
+++ b/VocableUITests/Tests/MainScreenPaginationTests.swift
@@ -61,6 +61,11 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
         VTAssertPaginationEquals(1, of: 2)
     }
     
+    /* TODO: There is an existing bug(s) that cause this test to fail with
+     animations turned off. We will re-enable this test once they're fixed.
+     https://github.com/willowtreeapps/vocable-ios/issues/597
+     https://github.com/willowtreeapps/vocable-ios/issues/594
+     */
     func testCanScrollPagesWithPaginationArrows() {
         // Add enough phrases to push the total number of pages to 2
         listOfPhrases.forEach { phrase in


### PR DESCRIPTION
Closes #623

Allows UI tests to disable animations as a launch argument. They run quite fast on my machine now.