### PR TITLE
[629] Phrase + Category cell identifier updates

### DIFF
--- a/Vocable/Features/Root/CategoriesCarouselViewController.swift
+++ b/Vocable/Features/Root/CategoriesCarouselViewController.swift
@@ -173,7 +173,7 @@ import Combine
             return
         }
         cell.setup(title: category.name!)
-        cell.accessibilityIdentifier = ["category_title_cell", category.identifier].compacted().joined(separator: "_")
+        cell.accessibilityIdentifier = category.identifier
     }
 
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {

--- a/Vocable/Features/Root/CategoryDetailViewController.swift
+++ b/Vocable/Features/Root/CategoryDetailViewController.swift
@@ -122,7 +122,7 @@ class CategoryDetailViewController: PagingCarouselViewController, NSFetchedResul
 
             guard let phrase = Phrase.fetchObject(in: self.frc.managedObjectContext, matching: objectId) else { return }
             cell?.textLabel.text = phrase.utterance
-
+            cell?.accessibilityIdentifier = phrase.identifier
         case .addNewPhrase:
             let cell = cell as? AddPhraseCollectionViewCell
             cell?.accessibilityIdentifier = "add_new_phrase"

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -20,17 +20,15 @@ class MainScreen: BaseScreen {
     static let pageNumber = XCUIApplication().staticTexts["bottomPagination.pageNumber"]
     static let addPhraseLabel = XCUIApplication().cells["add_new_phrase"]
     
-    // Find the current selected category and return it as a CategoryTitleCellIdentifier
-    static var selectedCategoryCell: CategoryTitleCellIdentifier {
-        let identifierPrefix = CategoryTitleCellIdentifier.categoryTitleCellPrefix
-        let identifierPredicate = NSPredicate(format: "identifier CONTAINS %@", identifierPrefix)
+    // Find the current selected category and return it as a CategoryIdentifier
+    static var selectedCategoryCell: CategoryIdentifier {
         let isSelectedPredicate = NSPredicate(format: "isSelected == true")
         
         // Build our query that first finds all category title cells, then finds among those the one that is selected
-        let query = XCUIApplication().cells.containing(identifierPredicate).containing(isSelectedPredicate)
+        let query = XCUIApplication().cells.containing(isSelectedPredicate)
         
         // Return the selected category's full identifier
-        return CategoryTitleCellIdentifier(query.element.identifier)!
+        return CategoryIdentifier(query.element.identifier)
     }
     
     static func isTextDisplayed(_ text: String) -> Bool {
@@ -41,8 +39,7 @@ class MainScreen: BaseScreen {
     ///
     ///  Categories are interacted with via their identifier, which we represent with the CategoryIdentifier type struct.
     static func locateAndSelectDestinationCategory(_ destinationCategory: CategoryIdentifier) {
-        let titleCellIdentifier = CategoryTitleCellIdentifier(destinationCategory).identifier
-        let destinationCell = app.cells[titleCellIdentifier]
+        let destinationCell = app.cells[destinationCategory.identifier]
         let selectedCell = app.cells[selectedCategoryCell.identifier]
         
         repeat {

--- a/VocableUITests/Tests/CategoryIdentifier.swift
+++ b/VocableUITests/Tests/CategoryIdentifier.swift
@@ -30,7 +30,7 @@ struct CategoryIdentifier {
 struct CategoryTitleCellIdentifier {
 
     let categoryIdentifier: CategoryIdentifier
-    static let categoryTitleCellPrefix: String = "category_title_cell_"
+    static let categoryTitleCellPrefix: String = ""
     var identifier: String {
         CategoryTitleCellIdentifier.categoryTitleCellPrefix + categoryIdentifier.identifier
     }

--- a/VocableUITests/Tests/CategoryIdentifier.swift
+++ b/VocableUITests/Tests/CategoryIdentifier.swift
@@ -50,19 +50,19 @@ struct CategoryTitleCellIdentifier {
 
 struct PresetCategories {
     
-    var list: [CategoryTitleCellIdentifier]
+    var list: [CategoryIdentifier]
     
     init() {
         self.list = [
-            CategoryTitleCellIdentifier(CategoryIdentifier.general),
-            CategoryTitleCellIdentifier(CategoryIdentifier.basicNeeds),
-            CategoryTitleCellIdentifier(CategoryIdentifier.personalCare),
-            CategoryTitleCellIdentifier(CategoryIdentifier.conversation),
-            CategoryTitleCellIdentifier(CategoryIdentifier.environment),
-            CategoryTitleCellIdentifier(CategoryIdentifier.keyPad),
-            CategoryTitleCellIdentifier(CategoryIdentifier.mySayings),
-            CategoryTitleCellIdentifier(CategoryIdentifier.recents),
-            CategoryTitleCellIdentifier(CategoryIdentifier.listen)
+            CategoryIdentifier.general,
+            CategoryIdentifier.basicNeeds,
+            CategoryIdentifier.personalCare,
+            CategoryIdentifier.conversation,
+            CategoryIdentifier.environment,
+            CategoryIdentifier.keyPad,
+            CategoryIdentifier.mySayings,
+            CategoryIdentifier.recents,
+            CategoryIdentifier.listen
         ]
     }
     

--- a/VocableUITests/Tests/CategoryIdentifier.swift
+++ b/VocableUITests/Tests/CategoryIdentifier.swift
@@ -27,27 +27,6 @@ struct CategoryIdentifier {
     
 }
 
-struct CategoryTitleCellIdentifier {
-
-    let categoryIdentifier: CategoryIdentifier
-    static let categoryTitleCellPrefix: String = ""
-    var identifier: String {
-        CategoryTitleCellIdentifier.categoryTitleCellPrefix + categoryIdentifier.identifier
-    }
-    
-    init?(_ identifier: String){
-        if identifier.isEmpty{
-            return nil
-        }
-        self.categoryIdentifier = CategoryIdentifier(identifier.replacingOccurrences(of: CategoryTitleCellIdentifier.categoryTitleCellPrefix, with: ""))
-    }
-    
-    init(_ identifier: CategoryIdentifier) {
-        self.categoryIdentifier = identifier
-    }
-    
-}
-
 struct PresetCategories {
     
     var list: [CategoryIdentifier]

--- a/VocableUITests/Tests/MainScreenPaginationTests.swift
+++ b/VocableUITests/Tests/MainScreenPaginationTests.swift
@@ -97,8 +97,6 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
     }
     
     func testPaginationAdjustsToDeviceOrientation() {
-        let categoryTitleCell = CategoryTitleCellIdentifier(customCategoryIdentifier!)
-
         // Add enough phrases to ensure that rotating the device will add a page; 7 phrases
         for phrase in listOfPhrases.startIndex..<7 {
             CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
@@ -106,8 +104,8 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
         
         // Return to the Main Screen and navigate to the test category
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
-        MainScreen.locateAndSelectDestinationCategory(categoryTitleCell.categoryIdentifier)
-        XCTAssertEqual(MainScreen.selectedCategoryCell.identifier, categoryTitleCell.identifier)
+        MainScreen.locateAndSelectDestinationCategory(customCategoryIdentifier!)
+        XCTAssertEqual(MainScreen.selectedCategoryCell.identifier, customCategoryIdentifier?.identifier)
         
         // Verify we're on the first page
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)

--- a/VocableUITests/Tests/MainScreenTests.swift
+++ b/VocableUITests/Tests/MainScreenTests.swift
@@ -29,7 +29,7 @@ class MainScreenTests: BaseTest {
             if listOfCategoriesToSkip.contains(categoryName.identifier) {
                 continue;
             }
-            MainScreen.locateAndSelectDestinationCategory(categoryName.categoryIdentifier)
+            MainScreen.locateAndSelectDestinationCategory(categoryName)
             firstPhrase = XCUIApplication().collectionViews.staticTexts.element(boundBy: 0).label
             XCUIApplication().collectionViews.staticTexts[firstPhrase].tap()
             listOfSelectedPhrases.append(firstPhrase)
@@ -43,7 +43,7 @@ class MainScreenTests: BaseTest {
     
     func testDefaultCategoriesExist() {
         for categoryName in PresetCategories().list {
-            MainScreen.locateAndSelectDestinationCategory(categoryName.categoryIdentifier)
+            MainScreen.locateAndSelectDestinationCategory(categoryName)
             XCTAssertEqual(MainScreen.selectedCategoryCell.identifier, categoryName.identifier, "Preset category with ID '\(categoryName.identifier)' was not found")
         }
     }
@@ -64,7 +64,7 @@ class MainScreenTests: BaseTest {
             if listOfCategoriesToSkip.contains(category.identifier) {
                 continue;
             }
-            MainScreen.locateAndSelectDestinationCategory(category.categoryIdentifier)
+            MainScreen.locateAndSelectDestinationCategory(category)
             _ = XCUIApplication().collectionViews.staticTexts.element(boundBy: 0).waitForExistence(timeout: 0.5) // Wait for scrolling to stop
             let firstPhraseInCategory = XCUIApplication().collectionViews.staticTexts.element(boundBy: 0).label
             XCUIApplication().collectionViews.staticTexts[firstPhraseInCategory].tap()
@@ -98,7 +98,7 @@ class MainScreenTests: BaseTest {
         // Confirm that the category is no longer accessible.
         for category in PresetCategories().list {
             // If we come across the category we expect to be hidden, fail the test. Otherwise the test will pass.
-            MainScreen.locateAndSelectDestinationCategory(category.categoryIdentifier)
+            MainScreen.locateAndSelectDestinationCategory(category)
             if MainScreen.selectedCategoryCell.identifier == hiddenCategoryIdentifier {
                 XCTFail("The category with identifier, '\(hiddenCategoryIdentifier)', was not hidden as expected.")
             }

--- a/VocableUITests/Tests/MainScreenTests.swift
+++ b/VocableUITests/Tests/MainScreenTests.swift
@@ -11,10 +11,10 @@ import XCTest
 
 class MainScreenTests: BaseTest {
     
-    private let listOfCategoriesToSkip = [CategoryTitleCellIdentifier(CategoryIdentifier.keyPad).identifier,
-                                          CategoryTitleCellIdentifier(CategoryIdentifier.mySayings).identifier,
-                                          CategoryTitleCellIdentifier(CategoryIdentifier.listen).identifier,
-                                          CategoryTitleCellIdentifier(CategoryIdentifier.recents).identifier]
+    private let listOfCategoriesToSkip = [CategoryIdentifier.keyPad.identifier,
+                                          CategoryIdentifier.mySayings.identifier,
+                                          CategoryIdentifier.listen.identifier,
+                                          CategoryIdentifier.recents.identifier]
     
      // For each preset category (the first 5 categories), tap() the top left
      // phrase, then verify that all selected phrases appear in "Recents"
@@ -81,7 +81,7 @@ class MainScreenTests: BaseTest {
     
     func testDisablingCategory() {
         let hiddenCategoryName = "General"
-        let hiddenCategoryIdentifier = CategoryTitleCellIdentifier(CategoryIdentifier.general).identifier
+        let hiddenCategoryIdentifier = CategoryIdentifier.general.identifier
         
         SettingsScreen.navigateToSettingsCategoryScreen()
         XCTAssertTrue(SettingsScreen.locateCategoryCell(hiddenCategoryName).element.exists)


### PR DESCRIPTION
Closes #629 

* Adds preset cell identifiers to the main screen
* Removes the `category_title_cell_` prefix
* Tests will likely need to be adjusted after the latter change
