### PR TITLE
Test/636 data injection main screen tests

### DIFF
--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -58,6 +58,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "CategoryPhrasesPaginationTests">
+               </Test>
+               <Test
                   Identifier = "CategoryPhrasesPaginationTests/testCanNavigatePages()">
                </Test>
                <Test
@@ -67,13 +70,34 @@
                   Identifier = "CustomCategoriesTests/testPagination()">
                </Test>
                <Test
+                  Identifier = "CustomCategoryTests">
+               </Test>
+               <Test
+                  Identifier = "CustomPhraseTests">
+               </Test>
+               <Test
                   Identifier = "CustomPhraseTests/testPagination()">
+               </Test>
+               <Test
+                  Identifier = "KeyboardScreenTests">
+               </Test>
+               <Test
+                  Identifier = "MainScreenPaginationTests">
                </Test>
                <Test
                   Identifier = "MainScreenPaginationTests/testCanScrollPagesWithPaginationArrows()">
                </Test>
                <Test
                   Identifier = "MainScreenTests/testCustonCategoryPagination()">
+               </Test>
+               <Test
+                  Identifier = "PresetPhraseTests">
+               </Test>
+               <Test
+                  Identifier = "PresetsOverrideTestCase">
+               </Test>
+               <Test
+                  Identifier = "SettingsScreenTests">
                </Test>
                <Test
                   Identifier = "SettingsScreenTests/testAddCustomCategory()">

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -36,9 +36,11 @@ class MainScreen: BaseScreen {
     }
     
     /// Traverse the categories until the destination category is found, then tap on the category to ensure its phrases appear.
+    /// The function returns true if the category is found, false if it is not.
     ///
     ///  Categories are interacted with via their identifier, which we represent with the CategoryIdentifier type struct.
-    static func locateAndSelectDestinationCategory(_ destinationCategory: CategoryIdentifier) {
+    @discardableResult
+    static func locateAndSelectDestinationCategory(_ destinationCategory: CategoryIdentifier) -> Bool {
         let destinationCell = app.cells[destinationCategory.identifier]
         let selectedCell = app.cells[selectedCategoryCell.identifier]
         
@@ -46,12 +48,14 @@ class MainScreen: BaseScreen {
             
             if (destinationCell.exists) {
                 destinationCell.tap()
-                break
+                return true
             }
             categoryRightButton.tap()
            
             // We break the loop when we return to our original starting point
         } while (!selectedCell.waitForExistence(timeout: 0.5))
+        
+        return false
     }
     
     /// Assuming there is at least one page of phrases within a category, locate the cell containing the given phrase.

--- a/VocableUITests/Tests/MainScreenTests.swift
+++ b/VocableUITests/Tests/MainScreenTests.swift
@@ -11,26 +11,16 @@ import XCTest
 
 class MainScreenTests: XCTestCase {
     
-    let firstPhrase = Phrase(id: "phrase_one", "Please help")
-    let secondPhrase = Phrase(id: "phrase_two", "Hello")
-    let thirdPhrase = Phrase(id: "phrase_three", "I need a blanket")
-    
-    var firstTestCategory: Category {
-        Category(id: "first_category", "First") {
-            firstPhrase
-        }
+    let firstTestCategory = Category(id: "first_category", "First") {
+        Phrase(id: "phrase_one", "Please help")
     }
     
-    var secondTestCategory: Category {
-        Category(id: "second_category", "To Be Hidden") {
-            secondPhrase
-        }
+    let secondTestCategory = Category(id: "second_category", "To Be Hidden") {
+        Phrase(id: "phrase_two", "Hello")
     }
     
-    var thirdTestCategory: Category {
-        Category(id: "thrid_category", "Third") {
-            thirdPhrase
-        }
+    let thirdTestCategory = Category(id: "third_category", "Third") {
+        Phrase(id: "phrase_three", "I need a blanket")
     }
     
     override func setUp() {
@@ -55,12 +45,12 @@ class MainScreenTests: XCTestCase {
         // Navigate to a category and grab it's first, top most, phrase.
         MainScreen.locateAndSelectDestinationCategory(firstCategory)
         let phraseOne = XCUIApplication().collectionViews.staticTexts.element(boundBy: 0).label
-        XCTAssertEqual(phraseOne, firstPhrase.utterance)
+        XCTAssertEqual(phraseOne, firstTestCategory.presetPhrases[0].utterance)
         
         // Navigate to a different category and verify the top most phrase listed has changed.
         MainScreen.locateAndSelectDestinationCategory(secondCategory)
         let phraseTwo = XCUIApplication().collectionViews.staticTexts.element(boundBy: 0).label
-        XCTAssertEqual(phraseTwo, secondPhrase.utterance)
+        XCTAssertEqual(phraseTwo, secondTestCategory.presetPhrases[0].utterance)
     }
     
     func testWhenTappingPhrase_ThenThatPhraseDisplaysOnOutputLabel() {

--- a/VocableUITests/Tests/MainScreenTests.swift
+++ b/VocableUITests/Tests/MainScreenTests.swift
@@ -80,10 +80,10 @@ class MainScreenTests: XCTestCase {
     func testDisablingCategory() {
         let hiddenCategory = secondTestCategory
         SettingsScreen.navigateToSettingsCategoryScreen()
-        XCTAssertTrue(SettingsScreen.locateCategoryCell(hiddenCategory.presetCategory.id).element.exists)
+        XCTAssertTrue(SettingsScreen.locateCategoryCell(hiddenCategory.presetCategory.utterance).element.exists)
 
         // Navigate to the category and hide it.
-        SettingsScreen.openCategorySettings(category: hiddenCategory)
+        SettingsScreen.openCategorySettings(category: hiddenCategory.presetCategory.utterance)
         SettingsScreen.showCategoryButton.tap()
         
         // Return to the main screen

--- a/VocableUITests/Tests/MainScreenTests.swift
+++ b/VocableUITests/Tests/MainScreenTests.swift
@@ -34,7 +34,6 @@ class MainScreenTests: XCTestCase {
     }
     
     override func setUp() {
-        
         let app = XCUIApplication()
         app.configure {
             Arguments(.resetAppDataOnLaunch, .enableListeningMode, .disableAnimations)


### PR DESCRIPTION
Closes #636 
Part of the effort defined in #590 

### Description:
Refactored MainScreenTests to override presets, providing a more streamlined set of categories to aid in testing than having to work through the original nine. 

Some of the tests that exist in this class are better suited for a new test suite. This new test suite was originally begun in #569. So we will move them out and into the new class when we tackle that work. For now they're commented out.

Also, to make sure we have smaller PRs as we work through this refactor we disabled all other tests. We will re-enable them as we get to them during the refactor. Ergo the only tests that should run now are MainScreenTests.

---

### Notes to Test
All other tests have been disabled. The only tests that should run are:
- testSelectingCategoryChangesPhrases
- testWhenTappingPhrase_ThenThatPhraseDisplaysOnOutputLabel
- testDisablingCategory
