### PR TITLE
[637] Defaulting Listening Mode Feature Flag On

### DIFF
--- a/Vocable/AppConfig/AppConfig.swift
+++ b/Vocable/AppConfig/AppConfig.swift
@@ -17,7 +17,6 @@ extension UserDefaultsKey {
     static let sensitivitySetting: UserDefaultsKey = "sensitivitySetting"
     static let dwellDuration: UserDefaultsKey = "dwellDuration"
     static let isHeadTrackingEnabled: UserDefaultsKey = "isHeadTrackingEnabled"
-    static let listeningModeFeatureFlagEnabled: UserDefaultsKey = "listeningModeFeatureFlagEnabled"
 }
 
 struct AppConfig {

--- a/Vocable/AppConfig/ListeningModeConfig.swift
+++ b/Vocable/AppConfig/ListeningModeConfig.swift
@@ -10,15 +10,19 @@ import Foundation
 import Combine
 import CoreData
 
-final class ListenModeFeatureConfiguration {
+final class ListenModeFeatureConfiguration: ObservableObject {
     
     static let shared = ListenModeFeatureConfiguration()
 
     // Whether the feature is active or not
     // Not exposed to consumers, but used for dynamically
     // determining whether the feature is enabled
-    @PublishedDefault(.listeningModeFeatureFlagEnabled)
-    private(set) var isFeatureFlagEnabled: Bool = true
+    @PublishedValue
+    var isFeatureFlagEnabled: Bool = true {
+        willSet {
+            self.objectWillChange.send()
+        }
+    }
 
     // Whether listening mode is allowed to function
     // This can vary based on the feature flag AND the user preference

--- a/Vocable/AppConfig/ListeningModeConfig.swift
+++ b/Vocable/AppConfig/ListeningModeConfig.swift
@@ -18,7 +18,7 @@ final class ListenModeFeatureConfiguration {
     // Not exposed to consumers, but used for dynamically
     // determining whether the feature is enabled
     @PublishedDefault(.listeningModeFeatureFlagEnabled)
-    private(set) var isFeatureFlagEnabled: Bool = false
+    private(set) var isFeatureFlagEnabled: Bool = true
 
     // Whether listening mode is allowed to function
     // This can vary based on the feature flag AND the user preference

--- a/Vocable/Features/Voice/ListenModeDebugView.swift
+++ b/Vocable/Features/Voice/ListenModeDebugView.swift
@@ -83,7 +83,7 @@ struct ListenModeDebugView: View {
     @ObservedObject private var storage = ListenModeDebugStorage.shared
 
     @AppStorage(.listeningModeFeatureFlagEnabled)
-    var listeningModeFeatureFlagEnabled = false
+    var listeningModeFeatureFlagEnabled = true
 
     @ViewBuilder
     private var listView: some View {

--- a/Vocable/Features/Voice/ListenModeDebugView.swift
+++ b/Vocable/Features/Voice/ListenModeDebugView.swift
@@ -82,15 +82,14 @@ struct ListenModeDebugView: View {
 
     @ObservedObject private var storage = ListenModeDebugStorage.shared
 
-    @AppStorage(.listeningModeFeatureFlagEnabled)
-    var listeningModeFeatureFlagEnabled = true
+    @ObservedObject private var config = ListenModeFeatureConfiguration.shared
 
     @ViewBuilder
     private var listView: some View {
         VStack {
             if storage.contexts.isEmpty {
                 VStack(spacing: 24) {
-                    Toggle("Enable Listen Mode", isOn: $listeningModeFeatureFlagEnabled)
+                    Toggle("Enable Listen Mode", isOn: $config.isFeatureFlagEnabled)
                     Spacer()
                     Text("No Entries").font(.title).bold()
                     Text("The most recent listening sessions will be recorded here for easy debugging").font(.subheadline)
@@ -99,7 +98,7 @@ struct ListenModeDebugView: View {
             } else {
                 List {
                     Section {
-                        Toggle("Enable Listen Mode", isOn: $listeningModeFeatureFlagEnabled)
+                        Toggle("Enable Listen Mode", isOn: $config.isFeatureFlagEnabled)
                     }
                     Section {
                         ForEach(storage.contexts, id: \.self) {


### PR DESCRIPTION
closes #637

# Description of Work
The listening mode feature flag is now defaulted to true so that listening mode should show up on a fresh app install.

## Notes to Test
- Since the feature flag setting is saved on device, you'll want to remove the app and re-install to test that the feature flag is on by default.

---
