### PR TITLE
Preset Data Injection Refactor: Pagination Tests

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		627B53662800D11200FEBF25 /* MainScreenPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627B53652800D11100FEBF25 /* MainScreenPaginationTests.swift */; };
 		628B35C227DF9C6B00299312 /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628B35C127DF9C6B00299312 /* BaseScreen.swift */; };
 		629B9B1F2809C99000EE6C19 /* XCUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629B9B1E2809C99000EE6C19 /* XCUIElement.swift */; };
+		62AE92572825C6CB004247EC /* PaginationBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AE92562825C6CB004247EC /* PaginationBaseTest.swift */; };
 		62E84887280DEF8600D42499 /* VocableTestAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E84886280DEF8600D42499 /* VocableTestAsserts.swift */; };
 		64599429258933370010EEFF /* VocableCore in Frameworks */ = {isa = PBXBuildFile; productRef = 64599428258933370010EEFF /* VocableCore */; settings = {ATTRIBUTES = (Required, ); }; };
 		64599431258938F50010EEFF /* ListeningResponseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64599430258938F50010EEFF /* ListeningResponseViewController.swift */; };
@@ -270,6 +271,7 @@
 		627B53652800D11100FEBF25 /* MainScreenPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScreenPaginationTests.swift; sourceTree = "<group>"; };
 		628B35C127DF9C6B00299312 /* BaseScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseScreen.swift; sourceTree = "<group>"; };
 		629B9B1E2809C99000EE6C19 /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
+		62AE92562825C6CB004247EC /* PaginationBaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationBaseTest.swift; sourceTree = "<group>"; };
 		62E84886280DEF8600D42499 /* VocableTestAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableTestAsserts.swift; sourceTree = "<group>"; };
 		64599430258938F50010EEFF /* ListeningResponseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningResponseViewController.swift; sourceTree = "<group>"; };
 		6459943D25895D9C0010EEFF /* SpeechRecognitionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionController.swift; sourceTree = "<group>"; };
@@ -599,6 +601,7 @@
 				627B53652800D11100FEBF25 /* MainScreenPaginationTests.swift */,
 				DCF25CD42811AD2000DF766F /* PresetPhraseTests.swift */,
 				6B2551822813288E0046C2EC /* PresetsOverrideTestCase.swift */,
+				62AE92562825C6CB004247EC /* PaginationBaseTest.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1413,6 +1416,7 @@
 				627B53662800D11200FEBF25 /* MainScreenPaginationTests.swift in Sources */,
 				6BE02F6E2816EF88002CCCED /* Environment.swift in Sources */,
 				DC533C0127FCDF39005FEBBD /* CustomCategoryBaseTest.swift in Sources */,
+				62AE92572825C6CB004247EC /* PaginationBaseTest.swift in Sources */,
 				6BE02F742816F504002CCCED /* XCUIApplication+LaunchConfiguration.swift in Sources */,
 				17F29479247419DD00A05434 /* SettingsScreen.swift in Sources */,
 				A9E49E6128130CAF0088A344 /* LaunchArguments.swift in Sources */,

--- a/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/Vocable.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -58,12 +58,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "CategoryPhrasesPaginationTests">
-               </Test>
-               <Test
-                  Identifier = "CategoryPhrasesPaginationTests/testCanNavigatePages()">
-               </Test>
-               <Test
                   Identifier = "CustomCategoriesTest">
                </Test>
                <Test
@@ -82,12 +76,6 @@
                   Identifier = "KeyboardScreenTests">
                </Test>
                <Test
-                  Identifier = "MainScreenPaginationTests">
-               </Test>
-               <Test
-                  Identifier = "MainScreenPaginationTests/testCanScrollPagesWithPaginationArrows()">
-               </Test>
-               <Test
                   Identifier = "MainScreenTests/testCustonCategoryPagination()">
                </Test>
                <Test
@@ -95,9 +83,6 @@
                </Test>
                <Test
                   Identifier = "PresetsOverrideTestCase">
-               </Test>
-               <Test
-                  Identifier = "SettingsScreenTests">
                </Test>
                <Test
                   Identifier = "SettingsScreenTests/testAddCustomCategory()">

--- a/VocableUITests/PresetsBuilders.swift
+++ b/VocableUITests/PresetsBuilders.swift
@@ -47,6 +47,23 @@ struct Category {
         self.presetCategory = category
         self.presetPhrases = phrases
     }
+    
+    init(
+        id: String = UUID().uuidString,
+        _ name: String,
+        hidden: Bool = false,
+        languageCode: String = "en",
+        phrases: [Phrase]
+    ) {
+
+        let category = PresetCategory(id: id, hidden: hidden, languageCode: languageCode, utterance: name)
+        let phrases = phrases.map { phrase in
+            PresetPhrase(id: phrase.id, categoryIds: [category.id], languageCode: phrase.languageCode, utterance: phrase.utterance)
+        }
+
+        self.presetCategory = category
+        self.presetPhrases = phrases
+    }
 }
 
 

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -73,4 +73,10 @@ class MainScreen: BaseScreen {
         return app.cells.staticTexts.containing(predicate).element
     }
     
+    static func navigateToSettingsAndOpenCategory(name: String) {
+        MainScreen.settingsButton.tap()
+        SettingsScreen.categoriesButton.tap()
+        SettingsScreen.openCategorySettings(category: name)
+    }
+    
 }

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -8,18 +8,12 @@
 
 import XCTest
 
-class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
+class CategoryPhrasesPaginationTests: PaginationBaseTest {
     
-    /* TODO: There is an existing bug(s) that causes this test to fail with
-     animations turned off. We will re-enable this test once they're fixed.
-     https://github.com/willowtreeapps/vocable-ios/issues/597
-     https://github.com/willowtreeapps/vocable-ios/issues/594
-     */
     func testCanNavigatePages() {
-        // Add enough phrases to have 2 pages.
-        listOfPhrases.forEach { phrase in
-            CustomCategoriesScreen.addPhrase(phrase)
-        }
+        // Navigate to our test category
+        MainScreen.navigateToSettingsAndOpenCategory(name: categoryTwo.presetCategory.utterance)
+        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Verify that the user is on the first page and the next page buttons are enabled.
         VTAssertPaginationEquals(1, of: 2, enabledArrows: .both)
@@ -36,36 +30,29 @@ class CategoryPhrasesPaginationTests: CustomPhraseBaseTest {
             CustomCategoriesScreen.paginationLeftButton.tap()
             XCTAssertEqual(CustomCategoriesScreen.currentPageNumber, pageNumber)
         }
-        
     }
     
     func testPagesAdjustToNewPhrases() {
-        // Add enough phrases (7) to fill one page.
-        for phrase in listOfPhrases.startIndex..<8 {
-            CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
-        }
-        
         // Verify that the user is on the first page.
-        XCTAssertEqual(CustomCategoriesScreen.currentPageNumber, 1)
+        MainScreen.navigateToSettingsAndOpenCategory(name: categoryOne.presetCategory.utterance)
+        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Add 1 more phrase to push the total number of pages to 2.
-        let originalPageCount = CustomCategoriesScreen.totalPageCount
-        let expectedPageCountAfterAddingPhrase = originalPageCount + 1
         CustomCategoriesScreen.addRandomPhrases(numberOfPhrases: 1)
-        XCTAssertEqual(CustomCategoriesScreen.totalPageCount, expectedPageCountAfterAddingPhrase)
+        VTAssertPaginationEquals(1, of: 2, enabledArrows: .both)
         
         // Remove the additional phrase to verify that the page count reduces, back to the original count
         CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
         SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
-        XCTAssertEqual(CustomCategoriesScreen.totalPageCount, originalPageCount)
+        VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
     }
     
     // It is expected that the pagination left and right arrows are disabled when there is only 1 total page
     func testNextPageButtonsDisabled() {
-        // Add 1 phrase so that the pagination buttons appear
-        XCTAssertTrue(CustomCategoriesScreen.emptyStateAddPhraseButton.exists, "Expected a new category to be in empty state.")
-        CustomCategoriesScreen.addRandomPhrases(numberOfPhrases: 1)
-    
+        // Navigate to our test category and open the 'Edit Phrases' screen
+        MainScreen.navigateToSettingsAndOpenCategory(name: categoryOne.presetCategory.utterance)
+        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        
         // Verify the page counts and that buttons appear; both buttons are disabled.
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
     }

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -12,7 +12,7 @@ class CategoryPhrasesPaginationTests: PaginationBaseTest {
     
     func testCanNavigatePages() {
         // Navigate to our test category
-        MainScreen.navigateToSettingsAndOpenCategory(name: categoryTwo.presetCategory.utterance)
+        MainScreen.navigateToSettingsAndOpenCategory(name: ninePhrasesCategory.presetCategory.utterance)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Verify that the user is on the first page and the next page buttons are enabled.
@@ -34,7 +34,7 @@ class CategoryPhrasesPaginationTests: PaginationBaseTest {
     
     func testPagesAdjustToNewPhrases() {
         // Verify that the user is on the first page.
-        MainScreen.navigateToSettingsAndOpenCategory(name: categoryOne.presetCategory.utterance)
+        MainScreen.navigateToSettingsAndOpenCategory(name: eightPhrasesCategory.presetCategory.utterance)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Add 1 more phrase to push the total number of pages to 2.
@@ -50,7 +50,7 @@ class CategoryPhrasesPaginationTests: PaginationBaseTest {
     // It is expected that the pagination left and right arrows are disabled when there is only 1 total page
     func testNextPageButtonsDisabled() {
         // Navigate to our test category and open the 'Edit Phrases' screen
-        MainScreen.navigateToSettingsAndOpenCategory(name: categoryOne.presetCategory.utterance)
+        MainScreen.navigateToSettingsAndOpenCategory(name: eightPhrasesCategory.presetCategory.utterance)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Verify the page counts and that buttons appear; both buttons are disabled.

--- a/VocableUITests/Tests/CustomPhraseTests.swift
+++ b/VocableUITests/Tests/CustomPhraseTests.swift
@@ -62,7 +62,7 @@ class CustomPhraseTests: CustomPhraseBaseTest {
         XCTAssert(MainScreen.isTextDisplayed(customPhrase), "Expected the phrase \(customPhrase) to be displayed")
         
         CustomCategoriesScreen.categoriesPageDeletePhraseButton.tap()
-        SettingsScreen.alertDeleteButton.tap()
+        SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
         XCTAssertTrue(CustomCategoriesScreen.emptyStateAddPhraseButton.exists, "Expected the phrase \(customPhrase) to not be displayed")
     }
     

--- a/VocableUITests/Tests/MainScreenPaginationTests.swift
+++ b/VocableUITests/Tests/MainScreenPaginationTests.swift
@@ -8,73 +8,40 @@
 
 import XCTest
 
-class MainScreenPaginationTests: CustomPhraseBaseTest {
+class MainScreenPaginationTests: PaginationBaseTest {
     
     func testDeletingPhrasesAdjustsPagination() {
-        for phrase in listOfPhrases.startIndex..<8 {
-            CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
-        }
-        
         // Navigate to main screen to verify page numbers; expected to be "Page 1 of 2"
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
-        MainScreen.locateAndSelectDestinationCategory(customCategoryIdentifier!)
         VTAssertPaginationEquals(1, of: 2)
         
         // Delete one of the phrases to reduce the total number of pages to 1.
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: customCategoryName)
+        MainScreen.navigateToSettingsAndOpenCategory(name: categoryOne.presetCategory.utterance)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
-        SettingsScreen.alertDeleteButton.tap()
+        SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
         
         // Navigate back to the home screen to verify that the total pages reduced from 2 to 1.
         CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
-        MainScreen.locateAndSelectDestinationCategory(customCategoryIdentifier!)
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
     }
     
     func testAddingPhrasesAdjustsPagination() {
-        // Use array slices to split the phrase bank into two sets of 8 phrases
-        let listMidpoint = listOfPhrases.count / 2
-        let firstSetOfPhrases = listOfPhrases[..<listMidpoint]
-        let secondSetOfPhrases = listOfPhrases[listMidpoint...]
-        
-        firstSetOfPhrases.forEach { phrase in
-            CustomCategoriesScreen.addPhrase(phrase)
-        }
-        
-        // Navigate to main screen to verify page numbers; expected to be "Page 1 of 1"
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
-        MainScreen.locateAndSelectDestinationCategory(customCategoryIdentifier!)
+        // Navigate to our test category to verify initial page numbers; expected to be "Page 1 of 1"
+        MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(categoryThree.presetCategory.id))
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
         
-        // Add 8 more phrases to verify that the pagination adjusts as expected; "Page 1 of 2"
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: customCategoryName)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
-        secondSetOfPhrases.forEach { phrase in
-            CustomCategoriesScreen.addPhrase(phrase)
-        }
+        // Use the '+ Add Phrase' button to add a new phrase
+        MainScreen.addPhraseLabel.tap()
+        KeyboardScreen.typeText("A")
+        KeyboardScreen.checkmarkAddButton.tap()
         
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
-        MainScreen.locateAndSelectDestinationCategory(customCategoryIdentifier!)
-        VTAssertPaginationEquals(1, of: 2)
+        // Verify that the pagination adjusts as expected
+        VTAssertPaginationEquals(1, of: 2, enabledArrows: .both)
     }
     
-    /* TODO: There is an existing bug(s) that causes this test to fail with
-     animations turned off. We will re-enable this test once they're fixed.
-     https://github.com/willowtreeapps/vocable-ios/issues/597
-     https://github.com/willowtreeapps/vocable-ios/issues/594
-     */
     func testCanScrollPagesWithPaginationArrows() {
-        // Add enough phrases to push the total number of pages to 2
-        listOfPhrases.forEach { phrase in
-            CustomCategoriesScreen.addPhrase(phrase)
-        }
-        
-        // Return to the Main Screen and navigate to the test category
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
-        MainScreen.locateAndSelectDestinationCategory(customCategoryIdentifier!)
+        // Navigate to the test category
+        MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(categoryTwo.presetCategory.id))
         
         // Verify that the category's pagination is "Page 1 of 2"; page next buttons are enabled
         VTAssertPaginationEquals(1, of: 2)
@@ -96,18 +63,9 @@ class MainScreenPaginationTests: CustomPhraseBaseTest {
         VTAssertPaginationEquals(1, of: 2)
     }
     
-    func testPaginationAdjustsToDeviceOrientation() {
-        // Add enough phrases to ensure that rotating the device will add a page; 7 phrases
-        for phrase in listOfPhrases.startIndex..<7 {
-            CustomCategoriesScreen.addPhrase(listOfPhrases[phrase])
-        }
-        
-        // Return to the Main Screen and navigate to the test category
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
-        MainScreen.locateAndSelectDestinationCategory(customCategoryIdentifier!)
-        XCTAssertEqual(MainScreen.selectedCategoryCell.identifier, customCategoryIdentifier?.identifier)
-        
+    func testPaginationAdjustsToDeviceOrientation() {        
         // Verify we're on the first page
+        MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(categoryThree.presetCategory.id))
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
         
         // Rotate the device

--- a/VocableUITests/Tests/MainScreenPaginationTests.swift
+++ b/VocableUITests/Tests/MainScreenPaginationTests.swift
@@ -15,7 +15,7 @@ class MainScreenPaginationTests: PaginationBaseTest {
         VTAssertPaginationEquals(1, of: 2)
         
         // Delete one of the phrases to reduce the total number of pages to 1.
-        MainScreen.navigateToSettingsAndOpenCategory(name: categoryOne.presetCategory.utterance)
+        MainScreen.navigateToSettingsAndOpenCategory(name: eightPhrasesCategory.presetCategory.utterance)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
         SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
@@ -27,7 +27,7 @@ class MainScreenPaginationTests: PaginationBaseTest {
     
     func testAddingPhrasesAdjustsPagination() {
         // Navigate to our test category to verify initial page numbers; expected to be "Page 1 of 1"
-        MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(categoryThree.presetCategory.id))
+        MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(sevenPhrasesCategory.presetCategory.id))
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
         
         // Use the '+ Add Phrase' button to add a new phrase
@@ -41,7 +41,7 @@ class MainScreenPaginationTests: PaginationBaseTest {
     
     func testCanScrollPagesWithPaginationArrows() {
         // Navigate to the test category
-        MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(categoryTwo.presetCategory.id))
+        MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(ninePhrasesCategory.presetCategory.id))
         
         // Verify that the category's pagination is "Page 1 of 2"; page next buttons are enabled
         VTAssertPaginationEquals(1, of: 2)
@@ -65,7 +65,7 @@ class MainScreenPaginationTests: PaginationBaseTest {
     
     func testPaginationAdjustsToDeviceOrientation() {        
         // Verify we're on the first page
-        MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(categoryThree.presetCategory.id))
+        MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(sevenPhrasesCategory.presetCategory.id))
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
         
         // Rotate the device

--- a/VocableUITests/Tests/PaginationBaseTest.swift
+++ b/VocableUITests/Tests/PaginationBaseTest.swift
@@ -1,42 +1,67 @@
 //
-//  PaginationBaseTest.swift
+//  CustomCategoriesBaseTest.swift
 //  VocableUITests
 //
-//  Created by Rudy Salas on 5/6/22.
+//  Created by Rudy Salas and Canan Arikan on 5/06/22.
 //  Copyright © 2022 WillowTree. All rights reserved.
 //
 
 import XCTest
 
 class PaginationBaseTest: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
+    
+    var categoryOne: Category {
+        Category(id: "first_category", "Category 1") {
+            Phrase("Please help")
+            Phrase("Hello")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
         }
     }
+    
+    var categoryTwo: Category {
+        Category(id: "second_category", "Category 2") {
+            Phrase("Please help")
+            Phrase("Hello")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+        }
+    }
+    
+    var categoryThree: Category {
+        Category(id: "third_category", "Category 3") {
+            Phrase("Please help")
+            Phrase("Hello")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+            Phrase("I need a blanket")
+        }
+    }
+    
+    override func setUp() {
+        let app = XCUIApplication()
+        app.configure {
+            Arguments(.resetAppDataOnLaunch, .enableListeningMode)
+            Environment(.overridePresets) {
+                Presets {
+                    categoryOne
+                    categoryTwo
+                    categoryThree
+                }
+            }
+        }
+        app.launch()
+    }
+    
 }

--- a/VocableUITests/Tests/PaginationBaseTest.swift
+++ b/VocableUITests/Tests/PaginationBaseTest.swift
@@ -9,39 +9,16 @@
 import XCTest
 
 class PaginationBaseTest: XCTestCase {
-    
-    let categoryOne = Category(id: "first_category", "Category 1") {
-        Phrase("Please help")
-        Phrase("Hello")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
+
+    static private func phrases(count: Int) -> [Phrase] {
+        (1...count).map { _ in
+            Phrase("Hello")
+        }
     }
     
-    let categoryTwo = Category(id: "second_category", "Category 2") {
-        Phrase("Please help")
-        Phrase("Hello")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-    }
-    
-    let categoryThree = Category(id: "third_category", "Category 3") {
-        Phrase("Please help")
-        Phrase("Hello")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-        Phrase("I need a blanket")
-    }
+    let categoryOne = Category(id: "first_category", "Category 1", phrases: PaginationBaseTest.phrases(count: 8))
+    let categoryTwo = Category(id: "second_category", "Category 2", phrases: PaginationBaseTest.phrases(count: 9))
+    let categoryThree = Category(id: "third_category", "Category 3", phrases: PaginationBaseTest.phrases(count: 7))
     
     override func setUp() {
         let app = XCUIApplication()

--- a/VocableUITests/Tests/PaginationBaseTest.swift
+++ b/VocableUITests/Tests/PaginationBaseTest.swift
@@ -16,9 +16,9 @@ class PaginationBaseTest: XCTestCase {
         }
     }
     
-    let categoryOne = Category(id: "first_category", "Category 1", phrases: PaginationBaseTest.phrases(count: 8))
-    let categoryTwo = Category(id: "second_category", "Category 2", phrases: PaginationBaseTest.phrases(count: 9))
-    let categoryThree = Category(id: "third_category", "Category 3", phrases: PaginationBaseTest.phrases(count: 7))
+    let eightPhrasesCategory = Category(id: "first_category", "Category 1", phrases: PaginationBaseTest.phrases(count: 8))
+    let ninePhrasesCategory = Category(id: "second_category", "Category 2", phrases: PaginationBaseTest.phrases(count: 9))
+    let sevenPhrasesCategory = Category(id: "third_category", "Category 3", phrases: PaginationBaseTest.phrases(count: 7))
     
     override func setUp() {
         let app = XCUIApplication()
@@ -26,9 +26,9 @@ class PaginationBaseTest: XCTestCase {
             Arguments(.resetAppDataOnLaunch, .enableListeningMode)
             Environment(.overridePresets) {
                 Presets {
-                    categoryOne
-                    categoryTwo
-                    categoryThree
+                    eightPhrasesCategory
+                    ninePhrasesCategory
+                    sevenPhrasesCategory
                 }
             }
         }

--- a/VocableUITests/Tests/PaginationBaseTest.swift
+++ b/VocableUITests/Tests/PaginationBaseTest.swift
@@ -1,0 +1,42 @@
+//
+//  PaginationBaseTest.swift
+//  VocableUITests
+//
+//  Created by Rudy Salas on 5/6/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import XCTest
+
+class PaginationBaseTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/VocableUITests/Tests/PaginationBaseTest.swift
+++ b/VocableUITests/Tests/PaginationBaseTest.swift
@@ -10,43 +10,37 @@ import XCTest
 
 class PaginationBaseTest: XCTestCase {
     
-    var categoryOne: Category {
-        Category(id: "first_category", "Category 1") {
-            Phrase("Please help")
-            Phrase("Hello")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-        }
+    let categoryOne = Category(id: "first_category", "Category 1") {
+        Phrase("Please help")
+        Phrase("Hello")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
     }
     
-    var categoryTwo: Category {
-        Category(id: "second_category", "Category 2") {
-            Phrase("Please help")
-            Phrase("Hello")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-        }
+    let categoryTwo = Category(id: "second_category", "Category 2") {
+        Phrase("Please help")
+        Phrase("Hello")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
     }
     
-    var categoryThree: Category {
-        Category(id: "third_category", "Category 3") {
-            Phrase("Please help")
-            Phrase("Hello")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-            Phrase("I need a blanket")
-        }
+    let categoryThree = Category(id: "third_category", "Category 3") {
+        Phrase("Please help")
+        Phrase("Hello")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
+        Phrase("I need a blanket")
     }
     
     override func setUp() {


### PR DESCRIPTION
closes #589 

### Description of Work
Refactored all of the pagination tests to leverage the preset data injection during app startup. We were able to create 3 categories that worked for all tests between the CategoryPhrasesPaginationTests and MainScreenPaginationTests classes. So we created a new base test class, PaginationBaseTest, which then sets up the app with the injected presets.

---

### Notes to Test:
On this branch only the MainScreenPaginationTests, CategoryPhrasesPaginationTests, SettingsScreenTests, and MainScreenTests should run. During this effort we re-enabled SettingsScreenTests, which did not need to be refactored, but they should run and pass along with the pagination tests.
