### PR TITLE
[563] Remove debug localizations

### DIFF
--- a/Vocable/Supporting Files/ar.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/ar.lproj/Localizable.strings
@@ -28,9 +28,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "تم حفظ التغييرات";
 
-/* This seems to not be used currently */
-"debug.assertion.presets_file_not_found" = "لم يتم العثور على إعدادات مسبقة";
-
 /* Cancel alert action title */
 "gaze_settings.alert.disable_head_tracking_confirmation.button.cancel.title" = "إلغاء";
 

--- a/Vocable/Supporting Files/da.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/da.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "Dine ændringer er gemt";
 
-/* This seems to not be used currently */
-"debug.assertion.presets_file_not_found" = "Ingen forudstillinger fundet";
-
 /* No comment provided by engineer. */
 "Delete All" = "Slet Alle";
 

--- a/Vocable/Supporting Files/da.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/da.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "Dine ændringer er gemt";
 
-/* No comment provided by engineer. */
-"Delete All" = "Slet Alle";
-
 /* Category empty state button.  This button appears with the empty state to allow the user to add a phrase */
 "empty_state.button.title" = "Tilføj sætning";
 
@@ -132,9 +129,6 @@
 
 /* Select something below to speak Hint Text */
 "main_screen.textfield_placeholder.default" = "Vælg noget nedenunder for at snakke";
-
-/* No comment provided by engineer. */
-"No Entries" = "Ingen poster";
 
 /* Page indicator progress format. \"Page x of n\" */
 "paging_progress_indicator_format" = "Side %1$d af %2$d";

--- a/Vocable/Supporting Files/de.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/de.lproj/Localizable.strings
@@ -49,9 +49,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "Änderungen gespeichert";
 
-/* This seems to not be used currently */
-"debug.assertion.presets_file_not_found" = "No presets found";
-
 /* No comment provided by engineer. */
 "Delete All" = "Alle löschen";
 

--- a/Vocable/Supporting Files/de.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/de.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "Änderungen gespeichert";
 
-/* No comment provided by engineer. */
-"Delete All" = "Alle löschen";
-
 /* Category empty state button.  This button appears with the empty state to allow the user to add a phrase */
 "empty_state.button.title" = "Satz hinzufügen";
 
@@ -132,9 +129,6 @@
 
 /* Select something below to speak Hint Text */
 "main_screen.textfield_placeholder.default" = "Wähle unten etwas aus, um zu sprechen";
-
-/* No comment provided by engineer. */
-"No Entries" = "Keine Einträge";
 
 /* Page indicator progress format. \"Page x of n\" */
 "paging_progress_indicator_format" = "Seite %1$d von %2$d";

--- a/Vocable/Supporting Files/de.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/de.lproj/Localizable.strings
@@ -1,6 +1,3 @@
-/* No comment provided by engineer. */
-"%@. %@" = "%1$@. %2$@";
-
 /* Categories Header title.  This text appears in the Settings flow when navigating to the list of Categories */
 "categories_list_editor.header.title" = "Kategorien";
 

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 /* changes to an existing phrase were saved successfully */
 "category_editor.toast.changes_saved.title" = "Changes saved";
 
-/* Debugging error message for when preloaded content is not found */
-/* This seems to not be used currently */
-"debug.assertion.presets_file_not_found" = "No presets found";
-
 /* Cancel alert action title */
 "gaze_settings.alert.disable_head_tracking_confirmation.button.cancel.title" = "Cancel";
 

--- a/Vocable/Supporting Files/es.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/es.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "Cambios guardados";
 
-/* This seems to not be used currently */
-"debug.assertion.presets_file_not_found" = "No hay presets disponibles";
-
 /* No comment provided by engineer. */
 "Delete All" = "Eliminar todo";
 

--- a/Vocable/Supporting Files/es.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/es.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "Cambios guardados";
 
-/* No comment provided by engineer. */
-"Delete All" = "Eliminar todo";
-
 /* Category empty state button.  This button appears with the empty state to allow the user to add a phrase */
 "empty_state.button.title" = "Agregar Phrase";
 
@@ -132,9 +129,6 @@
 
 /* Select something below to speak Hint Text */
 "main_screen.textfield_placeholder.default" = "Selecciona algo a continuación para hablar";
-
-/* No comment provided by engineer. */
-"No Entries" = "Sin elementos";
 
 /* Page indicator progress format. \"Page x of n\" */
 "paging_progress_indicator_format" = "Página %1$d de %2$d";

--- a/Vocable/Supporting Files/it.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/it.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "Modifiche salvate";
 
-/* This seems to not be used currently */
-"debug.assertion.presets_file_not_found" = "Nessun preset trovato";
-
 /* No comment provided by engineer. */
 "Delete All" = "Elimina tutto";
 

--- a/Vocable/Supporting Files/it.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/it.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "Modifiche salvate";
 
-/* No comment provided by engineer. */
-"Delete All" = "Elimina tutto";
-
 /* Category empty state button.  This button appears with the empty state to allow the user to add a phrase */
 "empty_state.button.title" = "Aggiungi frase";
 
@@ -132,9 +129,6 @@
 
 /* Select something below to speak Hint Text */
 "main_screen.textfield_placeholder.default" = "Seleziona qualcosa qui sotto per parlare";
-
-/* No comment provided by engineer. */
-"No Entries" = "Nessun Elemento";
 
 /* Page indicator progress format. \"Page x of n\" */
 "paging_progress_indicator_format" = "Pagina %1$d di %2$d";

--- a/Vocable/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "已保存更改";
 
-/* No comment provided by engineer. */
-"Delete All" = "全部刪除";
-
 /* Category empty state button.  This button appears with the empty state to allow the user to add a phrase */
 "empty_state.button.title" = "添加短语";
 
@@ -132,9 +129,6 @@
 
 /* Select something below to speak Hint Text */
 "main_screen.textfield_placeholder.default" = "请选择下面要说的对话";
-
-/* No comment provided by engineer. */
-"No Entries" = "没有条目";
 
 /* Page indicator progress format. \"Page x of n\" */
 "paging_progress_indicator_format" = "第 %1$d/%2$d 頁";

--- a/Vocable/Supporting Files/zh-Hans.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/zh-Hans.lproj/Localizable.strings
@@ -46,9 +46,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "已保存更改";
 
-/* This seems to not be used currently */
-"debug.assertion.presets_file_not_found" = "找不到预设";
-
 /* No comment provided by engineer. */
 "Delete All" = "全部刪除";
 

--- a/Vocable/Supporting Files/zh-Hant.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/zh-Hant.lproj/Localizable.strings
@@ -28,9 +28,6 @@
 /* Toast message that appears after saving edits made to the Category title */
 "category_editor.toast.successfully_saved.title" = "更改已儲存";
 
-/* This seems to not be used currently */
-"debug.assertion.presets_file_not_found" = "找不到預設";
-
 /* Cancel alert action title */
 "gaze_settings.alert.disable_head_tracking_confirmation.button.cancel.title" = "取消";
 


### PR DESCRIPTION
Closes #563 

# Description of Work
Removes debug-related localizations from the project

## Notes to Test
* I'm curious how the xliff export process will react to this after we merge into develop. I am not certain how these strings got here in the first place, so I'm crossing my fingers that there isn't something funky going on with the xliff exporter and SwiftUI that might cause them to pop back up. I don't think that's likely, since there are other Text() instances with string literals that were not localized in kind residing in the same file. Odds are it was briefly manually translated and then removed from the development localization but not the others.
