### PR TITLE
#598 - Fix Listening Mode bug 🗣️ 🐞 

### DIFF
--- a/Vocable/Features/Root/RootViewController.swift
+++ b/Vocable/Features/Root/RootViewController.swift
@@ -96,7 +96,6 @@ import SwiftUI
         } else if #available(iOS 14.0, *), destinationIsListeningMode {
             let vc = ListeningResponseViewController()
             vc.delegate = self
-            vc.activate(withSpeechRecognizer: .shared)
             utterancePublisher = vc.$lastUtterance
             viewController = vc
         } else {
@@ -114,6 +113,10 @@ import SwiftUI
                     updateOutputLabelText(nil, isDictated: false)
                 }
             }
+
+            SpeechRecognitionController.shared.stopTranscribing()
+        } else {
+            SpeechRecognitionController.shared.startTranscribing()
         }
 
         utteranceCancellable = utterancePublisher.receive(on: DispatchQueue.main)
@@ -129,13 +132,6 @@ import SwiftUI
         let childrenToDisposeOf = children.filter {
             ![categoryCarousel, viewController].contains($0)
         }
-
-        // https://github.com/willowtreeapps/vocable-ios/issues/598
-        // Deactivate any living instances of ListeningResponseViewController
-        // so they will immediately stop attempting to interact with the SpeechRecognitionController
-        childrenToDisposeOf
-            .compactMap { $0 as? ListeningResponseViewController }
-            .forEach { $0.deactivate() }
 
         let contentTransform = CGAffineTransform.identity
         let transitionTransform = CGAffineTransform(translationX: 0,

--- a/Vocable/Features/Root/RootViewController.swift
+++ b/Vocable/Features/Root/RootViewController.swift
@@ -132,7 +132,7 @@ import SwiftUI
 
         // https://github.com/willowtreeapps/vocable-ios/issues/598
         // Deactivate any living instances of ListeningResponseViewController
-        // so the will immediately stop attempting to interact with the SpeechRecognitionController
+        // so they will immediately stop attempting to interact with the SpeechRecognitionController
         childrenToDisposeOf
             .compactMap { $0 as? ListeningResponseViewController }
             .forEach { $0.deactivate() }

--- a/Vocable/Features/Voice/SpeechRecognitionController.swift
+++ b/Vocable/Features/Voice/SpeechRecognitionController.swift
@@ -264,6 +264,7 @@ class SpeechRecognitionController: NSObject, SFSpeechRecognitionTaskDelegate, SF
         guard isPaused else {
             return
         }
+        print("RESUME LISTENING...")
         isPaused = false
         startListening(mode: mode, resumingFromPause: true)
     }


### PR DESCRIPTION
Closes #598

Listening mode would sometimes stop working if the user quickly switched between the Listening category and another category. This was caused by the fact that, when switching back, a new `ListeningResponseViewController` was initialized before the old one was deinitialized. So the `SpeechRecognitionController` was still receiving signals from the "old" insance, which were interfering with the signals from the "new" one.

This was resolved by adding an activate/deactivate mechanism to the `ListeningResponseViewController`, in which it can setup and tear down its relationship with the `SpeechRecognitionController`.