### PR TITLE
[647] Bug Fix for Listening Mode Settings Screen

### DIFF
--- a/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
+++ b/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
@@ -124,7 +124,6 @@ final class ListeningModeViewController: VocableCollectionViewController {
 
     private func setupCollectionView() {
 
-        collectionView.isScrollEnabled = false
         collectionView.backgroundColor = .collectionViewBackgroundColor
         collectionView.register(UINib(nibName: "SettingsFooterTextSupplementaryView", bundle: nil),
                                 forSupplementaryViewOfKind: "footerText",

--- a/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
+++ b/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
@@ -149,7 +149,8 @@ final class ListeningModeViewController: VocableCollectionViewController {
             case .hotword:
                 text = String(localized: "settings.listening_mode.hotword_explanation_footer")
             }
-            footerView.textLabel.font = self.sizeClass.contains(any: .compact) ? .systemFont(ofSize: 18) : .systemFont(ofSize: 26)
+            let fontSize = sizeClass.contains(any: .compact) ? 18 : 26
+            footerView.textLabel.font = .systemFont(ofSize: fontSize)
             footerView.textLabel.text = text
             return footerView
         }

--- a/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
+++ b/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
@@ -149,14 +149,15 @@ final class ListeningModeViewController: VocableCollectionViewController {
             case .hotword:
                 text = String(localized: "settings.listening_mode.hotword_explanation_footer")
             }
-            let fontSize = sizeClass.contains(any: .compact) ? 18 : 26
+            let fontSize: CGFloat = self.sizeClass.contains(any: .compact) ? 18 : 26
             footerView.textLabel.font = .systemFont(ofSize: fontSize)
             footerView.textLabel.text = text
             return footerView
         }
 
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
-        configuration.interSectionSpacing = 16
+        let interSectionSpacing: CGFloat = self.sizeClass.contains(any: .compact) ? 16 : 44
+        configuration.interSectionSpacing = interSectionSpacing
         let layout = UICollectionViewCompositionalLayout(sectionProvider: { [weak self] (_, environment) -> NSCollectionLayoutSection? in
             return self?.layoutSection(environment: environment)
         }, configuration: configuration)

--- a/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
+++ b/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
@@ -149,12 +149,13 @@ final class ListeningModeViewController: VocableCollectionViewController {
             case .hotword:
                 text = String(localized: "settings.listening_mode.hotword_explanation_footer")
             }
+            footerView.textLabel.font = self.sizeClass.contains(any: .compact) ? .systemFont(ofSize: 18) : .systemFont(ofSize: 26)
             footerView.textLabel.text = text
             return footerView
         }
 
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
-        configuration.interSectionSpacing = 44
+        configuration.interSectionSpacing = 16
         let layout = UICollectionViewCompositionalLayout(sectionProvider: { [weak self] (_, environment) -> NSCollectionLayoutSection? in
             return self?.layoutSection(environment: environment)
         }, configuration: configuration)
@@ -177,7 +178,7 @@ final class ListeningModeViewController: VocableCollectionViewController {
     private func layoutSection(environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
 
         let itemHeightDimension: NSCollectionLayoutDimension
-        if sizeClass.contains(.vCompact) {
+        if sizeClass.contains(any: .compact) {
             itemHeightDimension = NSCollectionLayoutDimension.absolute(50)
         } else {
             itemHeightDimension = NSCollectionLayoutDimension.absolute(100)
@@ -199,7 +200,7 @@ final class ListeningModeViewController: VocableCollectionViewController {
         section.interGroupSpacing = 8
         section.contentInsets = sectionInsets(for: environment)
         section.contentInsets.top = 16
-        section.contentInsets.bottom = 32
+        section.contentInsets.bottom = sizeClass.contains(any: .compact) ? 16 : 32
         section.boundarySupplementaryItems = [footerItem]
         return section
     }


### PR DESCRIPTION
closes #647

# Description of Work
Adjusted font & spacing on iPhone so that the footer is no longer cut off. Also enables scrolling in the listen mode settings screen so that the user can scroll down to the footer in landscape on iPhone if it still gets cut off in the future.

| Orientation | iPhone Mini | iPad Mini |
| :--- | :---: | :---: |
| Portrait | <img src=https://user-images.githubusercontent.com/37670742/168294771-45a0e665-1bd5-40dc-8b15-483c8707148b.png height=500> | <img src=https://user-images.githubusercontent.com/37670742/168294848-5c17e95d-4eee-48bb-b53f-2eefc9a2b025.png> |
| Landscape | <img src=https://user-images.githubusercontent.com/37670742/168294919-c452a0bc-4faf-4ac5-b3e4-b701b04e5cb4.png> | <img src=https://user-images.githubusercontent.com/37670742/168294987-2cd12138-aaa6-43fd-9dac-dd50709f1275.png> |

---
