### PR TITLE
#646 | Treat Listening Mode like a hidden category when turned off

### DIFF
--- a/Vocable/Extensions/Category+Helpers.swift
+++ b/Vocable/Extensions/Category+Helpers.swift
@@ -86,12 +86,15 @@ extension Category {
 
     static func visibleCategoriesPredicate(includeUserHidden: Bool = true) -> NSPredicate {
         var predicate = !Predicate(\Category.isUserRemoved)
+
         if !includeUserHidden {
             predicate &= !Predicate(\Category.isHidden)
+
+            if !AppConfig.listeningMode.isEnabled {
+                predicate &= !Predicate(\Category.identifier, equalTo: Category.Identifier.listeningMode)
+            }
         }
-        if !AppConfig.listeningMode.isEnabled {
-            predicate &= !Predicate(\Category.identifier, equalTo: Category.Identifier.listeningMode)
-        }
+
         return predicate
     }
     


### PR DESCRIPTION
Closes #646

# Description of Work

This PR changes the way we treat the Listening Mode category when displaying all categories in the Edit Categories screen. Previously, Listening mode would be completely removed from the list when disabled, however, we are now treating it like a hidden category:

- It gets placed after the enabled categories
- Its reorder buttons become disabled
- It can still be tapped on by the user to re-enable Listening Mode
