### PR TITLE
[645] Listening Mode Unsupported Feature

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -141,7 +141,7 @@
 		6BFB18C224002C7B002C3515 /* Phrases.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 6BFB18C024002C7B002C3515 /* Phrases.xcdatamodeld */; };
 		6BFB18C424004406002C3515 /* NSManagedObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFB18C324004406002C3515 /* NSManagedObject+Helpers.swift */; };
 		6BFB18C624004711002C3515 /* ModelObjectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFB18C524004711002C3515 /* ModelObjectExtensions.swift */; };
-		6BFB67BA2819C80900DB58BE /* ListeningModeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFB67B92819C80900DB58BE /* ListeningModeConfig.swift */; };
+		6BFB67BA2819C80900DB58BE /* ListenModeFeatureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFB67B92819C80900DB58BE /* ListenModeFeatureConfiguration.swift */; };
 		714407ED243CEEA1009D077B /* Category+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714407EC243CEEA1009D077B /* Category+Helpers.swift */; };
 		718D7FAE2419546F00FDEF93 /* EditPhrasesCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718D7FAD2419546F00FDEF93 /* EditPhrasesCollectionViewCell.swift */; };
 		718D7FB0241954C400FDEF93 /* EditPhrasesCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 718D7FAF241954C400FDEF93 /* EditPhrasesCollectionViewCell.xib */; };
@@ -373,7 +373,7 @@
 		6BFB18C124002C7B002C3515 /* Phrases.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Phrases.xcdatamodel; sourceTree = "<group>"; };
 		6BFB18C324004406002C3515 /* NSManagedObject+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Helpers.swift"; sourceTree = "<group>"; };
 		6BFB18C524004711002C3515 /* ModelObjectExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelObjectExtensions.swift; sourceTree = "<group>"; };
-		6BFB67B92819C80900DB58BE /* ListeningModeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningModeConfig.swift; sourceTree = "<group>"; };
+		6BFB67B92819C80900DB58BE /* ListenModeFeatureConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListenModeFeatureConfiguration.swift; sourceTree = "<group>"; };
 		714407EC243CEEA1009D077B /* Category+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Category+Helpers.swift"; sourceTree = "<group>"; };
 		718D7FAD2419546F00FDEF93 /* EditPhrasesCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPhrasesCollectionViewCell.swift; sourceTree = "<group>"; };
 		718D7FAF241954C400FDEF93 /* EditPhrasesCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditPhrasesCollectionViewCell.xib; sourceTree = "<group>"; };
@@ -796,7 +796,7 @@
 			isa = PBXGroup;
 			children = (
 				B8DA9DEF23EDECEE00FEBE19 /* AppConfig.swift */,
-				6BFB67B92819C80900DB58BE /* ListeningModeConfig.swift */,
+				6BFB67B92819C80900DB58BE /* ListenModeFeatureConfiguration.swift */,
 			);
 			path = AppConfig;
 			sourceTree = "<group>";
@@ -1293,7 +1293,7 @@
 				64981D7C258A8014007EFA82 /* VocableChoicesModel.mlmodel in Sources */,
 				64F49906245B40BC00348592 /* SettingsViewController.swift in Sources */,
 				6B9DFA6E23E88A5F0037673E /* LowPassInterpolator.swift in Sources */,
-				6BFB67BA2819C80900DB58BE /* ListeningModeConfig.swift in Sources */,
+				6BFB67BA2819C80900DB58BE /* ListenModeFeatureConfiguration.swift in Sources */,
 				A96D61D524229F6400577144 /* SettingsCollectionViewCell.swift in Sources */,
 				A94C3FAE27F49CBC001D4F01 /* CategoryNameEditorConfigurationProvider.swift in Sources */,
 				A95D07BE24326475004ECE64 /* CursorSensitivity.swift in Sources */,

--- a/Vocable/AppConfig/ListenModeFeatureConfiguration.swift
+++ b/Vocable/AppConfig/ListenModeFeatureConfiguration.swift
@@ -1,5 +1,5 @@
 //
-//  ListeningModeConfig.swift
+//  ListenModeFeatureConfiguration.swift
 //  Vocable
 //
 //  Created by Chris Stroud on 4/27/22.
@@ -36,7 +36,7 @@ final class ListenModeFeatureConfiguration: ObservableObject {
 
     // The user's preference for whether the overall listening mode feature is enabled
     @PublishedDefault(.listeningModeEnabledPreference)
-    var listeningModeEnabledPreference: Bool = ListenModeFeatureConfiguration.deviceSupportsListeningMode()
+    var listeningModeEnabledPreference: Bool = ListenModeFeatureConfiguration.deviceSupportsListeningMode
 
     // The user's preference for whether the hotword feature is enabled
     @PublishedDefault(.listeningModeHotWordEnabledPreference)
@@ -57,7 +57,7 @@ final class ListenModeFeatureConfiguration: ObservableObject {
                 lhs.2 == rhs.2
             }
             .sink { [weak self] (isFlagEnabled, isListeningModeEnabled, isHotWordEnabled) in
-                let modeEnabled = isFlagEnabled && isListeningModeEnabled && ListenModeFeatureConfiguration.deviceSupportsListeningMode()
+                let modeEnabled = isFlagEnabled && isListeningModeEnabled && ListenModeFeatureConfiguration.deviceSupportsListeningMode
                 let hotwordEnabled = modeEnabled && isHotWordEnabled
                 self?.isEnabled = modeEnabled
                 self?.isHotWordEnabled = hotwordEnabled
@@ -83,7 +83,7 @@ final class ListenModeFeatureConfiguration: ObservableObject {
         }
     }
 
-    private static func deviceSupportsListeningMode() -> Bool {
+    static var deviceSupportsListeningMode: Bool {
 
         guard SpeechRecognitionController.deviceSupportsSpeech else {
             return false

--- a/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
+++ b/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
@@ -42,7 +42,8 @@ final class ListeningModeViewController: VocableCollectionViewController {
         var accessory: VocableListCellAccessory {
             switch self {
             case .listeningModeEnabled:
-                return .toggle(isOn: AppConfig.listeningMode.listeningModeEnabledPreference)
+                return .toggle(isOn: AppConfig.listeningMode.listeningModeEnabledPreference
+                              && ListenModeFeatureConfiguration.deviceSupportsListeningMode)
             case .hotWordEnabled:
                 return .toggle(isOn: AppConfig.listeningMode.hotwordEnabledPreference)
             }
@@ -102,7 +103,7 @@ final class ListeningModeViewController: VocableCollectionViewController {
         } else {
             snapshot.appendSections([.listeningMode])
             snapshot.appendItems([.listeningModeEnabled])
-            if AppConfig.listeningMode.listeningModeEnabledPreference {
+            if AppConfig.listeningMode.listeningModeEnabledPreference, ListenModeFeatureConfiguration.deviceSupportsListeningMode {
                 snapshot.appendSections([.hotword])
                 snapshot.appendItems([.hotWordEnabled])
             }
@@ -142,13 +143,18 @@ final class ListeningModeViewController: VocableCollectionViewController {
             guard let self = self else { return footerView }
 
             let text: String
-            let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
-            switch section {
-            case .listeningMode:
-                text = String(localized: "settings.listening_mode.listening_mode_explanation_footer")
-            case .hotword:
-                text = String(localized: "settings.listening_mode.hotword_explanation_footer")
+            if ListenModeFeatureConfiguration.deviceSupportsListeningMode {
+                let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
+                switch section {
+                case .listeningMode:
+                    text = String(localized: "settings.listening_mode.listening_mode_explanation_footer")
+                case .hotword:
+                    text = String(localized: "settings.listening_mode.hotword_explanation_footer")
+                }
+            } else {
+                text = String(localized: "settings.listening_mode.device_unsupported_explanation_footer")
             }
+            
             let fontSize: CGFloat = self.sizeClass.contains(any: .compact) ? 18 : 26
             footerView.textLabel.font = .systemFont(ofSize: fontSize)
             footerView.textLabel.text = text
@@ -170,6 +176,7 @@ final class ListeningModeViewController: VocableCollectionViewController {
     private func updateContentConfiguration(for cell: VocableListCell, at indexPath: IndexPath, item: ContentItem) {
         let config = VocableListContentConfiguration(title: item.title,
                                                      accessory: item.accessory,
+                                                     isPrimaryActionEnabled: ListenModeFeatureConfiguration.deviceSupportsListeningMode,
                                                      accessibilityIdentifier: item.accessibilityID) { [weak self] in
             guard let self = self, let indexPath = self.dataSource.indexPath(for: item) else { return }
             self.collectionView(self.collectionView, didSelectItemAt: indexPath)

--- a/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
+++ b/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
@@ -152,7 +152,14 @@ final class ListeningModeViewController: VocableCollectionViewController {
                     text = String(localized: "settings.listening_mode.hotword_explanation_footer")
                 }
             } else {
-                text = String(localized: "settings.listening_mode.device_unsupported_explanation_footer")
+                let model = UIDevice.current.localizedModel
+                let systemName = UIDevice.current.systemName
+                let systemVersion = UIDevice.current.systemVersion
+                let siriName = "Siri"
+
+                let format = String(localized: "settings.listening_mode.device_unsupported_explanation_footer")
+
+                text = String(format: format, model, systemName, systemVersion, siriName)
             }
             
             let fontSize: CGFloat = self.sizeClass.contains(any: .compact) ? 18 : 26

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -261,6 +261,9 @@
 /* Footer text displayed in the Listening Mode preferences screen. This text describes the \"Hey Vocable\" feature, how it is activated, and how it automatically navigates the user to the Listening Mode screen. */
 "settings.listening_mode.hotword_explanation_footer" = "When this shortcut is enabled, anyone can say \"Hey, Vocable\" to prompt the app to navigate to the listening mode screen.";
 
+/* Footer text displayed in the Listening Mode preferences screen. This is only displayed if the user's device does not support Listening Mode because of it's language or lack of neural engine. */
+"settings.listening_mode.device_unsupported_explanation_footer" = "Your device does not currently support Listening Mode. Either your language is not supported or your device lacks machine learning capabilities.";
+
 /* Title of Listening Mode preferences cell that toggles Listening Mode on or off when selected */
 "settings.listening_mode.listening_mode_toggle_cell.title" = "Listening Mode";
 

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -262,7 +262,7 @@
 "settings.listening_mode.hotword_explanation_footer" = "When this shortcut is enabled, anyone can say \"Hey, Vocable\" to prompt the app to navigate to the listening mode screen.";
 
 /* Footer text displayed in the Listening Mode preferences screen. This is only displayed if the user's device does not support Listening Mode because of it's language or lack of neural engine. */
-"settings.listening_mode.device_unsupported_explanation_footer" = "Your device does not currently support Listening Mode. Either your language is not supported or your device lacks machine learning capabilities.";
+"settings.listening_mode.device_unsupported_explanation_footer" = "This %1$@ on %2$@ %3$@ does not support Listening Mode.\n\nListening Mode is currently only available in English and requires %5$@ to be enabled.";
 
 /* Title of Listening Mode preferences cell that toggles Listening Mode on or off when selected */
 "settings.listening_mode.listening_mode_toggle_cell.title" = "Listening Mode";


### PR DESCRIPTION
closes #645

# Description of Work
When a device does not support listening mode (if the device's language is not set to English or if Siri is disabled), the listening mode toggle will now be disabled and have an explanation footer explaining the feature is not supported on the device.

---
