### PR TITLE
#644 | Start speech recognition in "Hot Word" mode when enabled from Settings

### DIFF
--- a/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
+++ b/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
@@ -54,7 +54,7 @@ final class ListeningModeViewController: VocableCollectionViewController {
 
     private var dataSource: Datasource!
 
-    private var authorizationController = AudioPermissionPromptController()
+    private var authorizationController = AudioPermissionPromptController(mode: .hotWord)
     private var authorizationCancellable: AnyCancellable?
     private var cellRegistration: UICollectionView.CellRegistration<VocableListCell, ContentItem>!
 

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -64,7 +64,7 @@ final class ListeningResponseViewController: VocableViewController {
 
     weak var delegate: ListeningResponseViewControllerDelegate?
 
-    private let permissionsController = AudioPermissionPromptController()
+    private let permissionsController = AudioPermissionPromptController(mode: .transcribing)
     private let speechRecognizerController = SpeechRecognitionController.shared
     private var transcriptionCancellable: AnyCancellable?
     private var permissionsCancellable: AnyCancellable?

--- a/Vocable/Features/Voice/SpeechRecognitionController.swift
+++ b/Vocable/Features/Voice/SpeechRecognitionController.swift
@@ -175,7 +175,7 @@ class SpeechRecognitionController: NSObject, SFSpeechRecognitionTaskDelegate, SF
         self.microphonePermissionStatus = AVAudioSession.sharedInstance().recordPermission
     }
 
-    private func startListening(mode: ListeningMode, resumingFromPause: Bool = false, requestablePermission: AudioPermission? = nil) {
+    func startListening(mode: ListeningMode, resumingFromPause: Bool = false, requestablePermission: AudioPermission? = nil) {
         guard AppConfig.listeningMode.isEnabled else { return }
 
         guard !isPaused && ((mode != self.mode) || (resumingFromPause && isListening)) else {


### PR DESCRIPTION
Closes #644

# Description of Work

This PR fixes an issue where the `SpeechRecognitionController` would always fire up in "transcription" mode when the user first granted permissions. This is the desired mode when we grant permissions from the Listen category on the Home screen, however this is not what we want when permissions are granted from the Settings screen. Instead, the "hot word" mode should be activated, so the app can properly handle actions after it recognizes the Hot Word.