### PR TITLE
Refactor KeyboardScreen elements to use AccessibilityIDs

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -28,10 +28,13 @@
 		4E8A303C27EBB95C000177B1 /* BidirectionalCollection+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8A303B27EBB95C000177B1 /* BidirectionalCollection+.swift */; };
 		54D3C41723E37CD40061EF47 /* VocableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D3C41623E37CD40061EF47 /* VocableTests.swift */; };
 		62300C7E27F360930005CEF5 /* CustomCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62300C7D27F360930005CEF5 /* CustomCategoryTests.swift */; };
+		6244DFA328356E8A00B2C519 /* AccessibilityID+Shared+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A16C0F28354BE10015A755 /* AccessibilityID+Shared+Keyboard.swift */; };
+		6244DFA428356E8B00B2C519 /* AccessibilityID+Shared+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A16C0F28354BE10015A755 /* AccessibilityID+Shared+Keyboard.swift */; };
 		627B53642800D0DE00FEBF25 /* CategoryPhrasesPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627B53632800D0DE00FEBF25 /* CategoryPhrasesPaginationTests.swift */; };
 		627B53662800D11200FEBF25 /* MainScreenPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627B53652800D11100FEBF25 /* MainScreenPaginationTests.swift */; };
 		628B35C227DF9C6B00299312 /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628B35C127DF9C6B00299312 /* BaseScreen.swift */; };
 		629B9B1F2809C99000EE6C19 /* XCUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629B9B1E2809C99000EE6C19 /* XCUIElement.swift */; };
+		62A16C1028354BE10015A755 /* AccessibilityID+Shared+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A16C0F28354BE10015A755 /* AccessibilityID+Shared+Keyboard.swift */; };
 		62AE92572825C6CB004247EC /* PaginationBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AE92562825C6CB004247EC /* PaginationBaseTest.swift */; };
 		62E84887280DEF8600D42499 /* VocableTestAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E84886280DEF8600D42499 /* VocableTestAsserts.swift */; };
 		64599429258933370010EEFF /* VocableCore in Frameworks */ = {isa = PBXBuildFile; productRef = 64599428258933370010EEFF /* VocableCore */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -308,6 +311,7 @@
 		627B53652800D11100FEBF25 /* MainScreenPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScreenPaginationTests.swift; sourceTree = "<group>"; };
 		628B35C127DF9C6B00299312 /* BaseScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseScreen.swift; sourceTree = "<group>"; };
 		629B9B1E2809C99000EE6C19 /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
+		62A16C0F28354BE10015A755 /* AccessibilityID+Shared+Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccessibilityID+Shared+Keyboard.swift"; sourceTree = "<group>"; };
 		62AE92562825C6CB004247EC /* PaginationBaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationBaseTest.swift; sourceTree = "<group>"; };
 		62E84886280DEF8600D42499 /* VocableTestAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableTestAsserts.swift; sourceTree = "<group>"; };
 		64599430258938F50010EEFF /* ListeningResponseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningResponseViewController.swift; sourceTree = "<group>"; };
@@ -790,6 +794,7 @@
 			children = (
 				0E969127281C5F520097A3CC /* AccessibilityID.swift */,
 				6B8D3C03282C229300DDB9B7 /* AccessibilityID+Shared.swift */,
+				62A16C0F28354BE10015A755 /* AccessibilityID+Shared+Keyboard.swift */,
 				6B8D3C05282C22B800DDB9B7 /* AccessibilityID+Shared+Pagination.swift */,
 				6B8D3C07282C230B00DDB9B7 /* AccessibilityID+Root.swift */,
 				6B8D3C09282C233300DDB9B7 /* AccessibilityID+Root+Categories.swift */,
@@ -1467,6 +1472,7 @@
 				6B8D3C0E282C236200DDB9B7 /* AccessibilityID+Settings+EditCategories.swift in Sources */,
 				A90D790527F205E90032254E /* VocableListCellPrimaryButton.swift in Sources */,
 				A98E8A2323F1DBDF00BF1F22 /* SettingsFooterCollectionViewCell.swift in Sources */,
+				62A16C1028354BE10015A755 /* AccessibilityID+Shared+Keyboard.swift in Sources */,
 				A9FD68A528008AD3006ABA3F /* AddPhraseCollectionViewCell.swift in Sources */,
 				A9CF2AF9242D4F0A005633A7 /* SensitivityCollectionViewCell.swift in Sources */,
 				0E969128281C5F520097A3CC /* AccessibilityID.swift in Sources */,
@@ -1521,6 +1527,7 @@
 				627B53662800D11200FEBF25 /* MainScreenPaginationTests.swift in Sources */,
 				6BE02F6E2816EF88002CCCED /* Environment.swift in Sources */,
 				6B8D3C26282C288D00DDB9B7 /* AccessibilityID+Shared.swift in Sources */,
+				6244DFA428356E8B00B2C519 /* AccessibilityID+Shared+Keyboard.swift in Sources */,
 				DC533C0127FCDF39005FEBBD /* CustomCategoryBaseTest.swift in Sources */,
 				62AE92572825C6CB004247EC /* PaginationBaseTest.swift in Sources */,
 				6BE02F742816F504002CCCED /* XCUIApplication+LaunchConfiguration.swift in Sources */,
@@ -1551,6 +1558,7 @@
 				6BE02F6D2816EF88002CCCED /* Environment.swift in Sources */,
 				6B8D3C2C282C2B5E00DDB9B7 /* XCUIElementQuery+AccessibilityID.swift in Sources */,
 				6B8D3C16282C288C00DDB9B7 /* AccessibilityID.swift in Sources */,
+				6244DFA328356E8A00B2C519 /* AccessibilityID+Shared+Keyboard.swift in Sources */,
 				6B8D3C19282C288C00DDB9B7 /* AccessibilityID+Root+Categories.swift in Sources */,
 				6B8D3C15282C288C00DDB9B7 /* AccessibilityID+Settings+TimingSensitivity.swift in Sources */,
 				6B8D3C1B282C288C00DDB9B7 /* AccessibilityID+Settings+SelectionMode.swift in Sources */,

--- a/Vocable/Common/TextEditorViewController.swift
+++ b/Vocable/Common/TextEditorViewController.swift
@@ -72,7 +72,7 @@ class TextEditorViewController: VocableViewController, UICollectionViewDelegate 
         keyboardViewController.attributedText = initialAttributedText
 
         textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.accessibilityIdentifier = "keyboard.textView"
+        textView.accessibilityID = .shared.keyboard.outputTextView
         textView.textAlignment = .natural
 
         navigationBar.leftButton = leftButton

--- a/Vocable/Common/Views/TextEditorNavigationButton.swift
+++ b/Vocable/Common/Views/TextEditorNavigationButton.swift
@@ -27,10 +27,10 @@ final class TextEditorNavigationButton: GazeableButton {
     struct Configuration {
         let image: UIImage
         var isEnabled: Bool
-        let accessibilityIdentifier: String?
+        let accessibilityIdentifier: AccessibilityID?
         var action: Action?
 
-        static func dismissal(for viewController: UIViewController, isEnabled: Bool = true, textDidChange: Bool = false, accessibilityIdentifier: String = "keyboard.dismissButton") -> Self {
+        static func dismissal(for viewController: UIViewController, isEnabled: Bool = true, textDidChange: Bool = false, accessibilityIdentifier: AccessibilityID = .shared.dismissButton) -> Self {
             Configuration(image: UIImage(systemName: "xmark.circle")!, isEnabled: isEnabled, accessibilityIdentifier: accessibilityIdentifier) { [weak viewController] in
                 guard let viewController = viewController else { return }
                 if textDidChange {
@@ -44,14 +44,14 @@ final class TextEditorNavigationButton: GazeableButton {
             }
         }
 
-        static func save(isEnabled: Bool = false, accessibilityIdentifier: String = "keyboard.saveButton", action: @escaping Action) -> Self {
+        static func save(isEnabled: Bool = false, accessibilityIdentifier: AccessibilityID = .shared.keyboard.saveButton, action: @escaping Action) -> Self {
             Configuration(image: UIImage(systemName: "checkmark")!,
                           isEnabled: isEnabled,
                           accessibilityIdentifier: accessibilityIdentifier,
                           action: action)
         }
 
-        static func favorite(isFavorited: Bool, isEnabled: Bool = false, accessibilityIdentifier: String = "keyboard.favoriteButton", action: @escaping Action) -> Self {
+        static func favorite(isFavorited: Bool, isEnabled: Bool = false, accessibilityIdentifier: AccessibilityID = .shared.keyboard.favoriteButton, action: @escaping Action) -> Self {
             Configuration(image: isFavorited ? UIImage(systemName: "star.fill")! : UIImage(systemName: "star")!,
                           isEnabled: isEnabled,
                           accessibilityIdentifier: accessibilityIdentifier,
@@ -63,7 +63,7 @@ final class TextEditorNavigationButton: GazeableButton {
         guard let configuration = configuration else { return }
         setImage(configuration.image, for: .normal)
         isEnabled = configuration.isEnabled
-        accessibilityIdentifier = configuration.accessibilityIdentifier
+        accessibilityIdentifier = configuration.accessibilityIdentifier?.id
 
         enumerateEventHandlers { action, _, event, _ in
             if let action = action {

--- a/Vocable/Common/Views/TextEditorNavigationButton.swift
+++ b/Vocable/Common/Views/TextEditorNavigationButton.swift
@@ -27,10 +27,10 @@ final class TextEditorNavigationButton: GazeableButton {
     struct Configuration {
         let image: UIImage
         var isEnabled: Bool
-        let accessibilityIdentifier: AccessibilityID?
+        let accessibilityIdentifier: String?
         var action: Action?
 
-        static func dismissal(for viewController: UIViewController, isEnabled: Bool = true, textDidChange: Bool = false, accessibilityIdentifier: AccessibilityID = .shared.dismissButton) -> Self {
+        static func dismissal(for viewController: UIViewController, isEnabled: Bool = true, textDidChange: Bool = false, accessibilityIdentifier: String = AccessibilityID.shared.dismissButton.id) -> Self {
             Configuration(image: UIImage(systemName: "xmark.circle")!, isEnabled: isEnabled, accessibilityIdentifier: accessibilityIdentifier) { [weak viewController] in
                 guard let viewController = viewController else { return }
                 if textDidChange {
@@ -44,14 +44,14 @@ final class TextEditorNavigationButton: GazeableButton {
             }
         }
 
-        static func save(isEnabled: Bool = false, accessibilityIdentifier: AccessibilityID = .shared.keyboard.saveButton, action: @escaping Action) -> Self {
+        static func save(isEnabled: Bool = false, accessibilityIdentifier: String = AccessibilityID.shared.keyboard.saveButton.id, action: @escaping Action) -> Self {
             Configuration(image: UIImage(systemName: "checkmark")!,
                           isEnabled: isEnabled,
                           accessibilityIdentifier: accessibilityIdentifier,
                           action: action)
         }
 
-        static func favorite(isFavorited: Bool, isEnabled: Bool = false, accessibilityIdentifier: AccessibilityID = .shared.keyboard.favoriteButton, action: @escaping Action) -> Self {
+        static func favorite(isFavorited: Bool, isEnabled: Bool = false, accessibilityIdentifier: String = AccessibilityID.shared.keyboard.favoriteButton.id, action: @escaping Action) -> Self {
             Configuration(image: isFavorited ? UIImage(systemName: "star.fill")! : UIImage(systemName: "star")!,
                           isEnabled: isEnabled,
                           accessibilityIdentifier: accessibilityIdentifier,
@@ -63,7 +63,7 @@ final class TextEditorNavigationButton: GazeableButton {
         guard let configuration = configuration else { return }
         setImage(configuration.image, for: .normal)
         isEnabled = configuration.isEnabled
-        accessibilityIdentifier = configuration.accessibilityIdentifier?.id
+        accessibilityIdentifier = configuration.accessibilityIdentifier
 
         enumerateEventHandlers { action, _, event, _ in
             if let action = action {

--- a/Vocable/Features/Settings/EditCategories/CategoryNameEditorConfigurationProvider.swift
+++ b/Vocable/Features/Settings/EditCategories/CategoryNameEditorConfigurationProvider.swift
@@ -52,7 +52,7 @@ struct CategoryNameEditorConfigurationProvider: TextEditorConfigurationProviding
 
         let leftItem = TextEditorNavigationButton.Configuration.dismissal(for: viewController, textDidChange: textDidChange)
 
-        let rightItem = TextEditorNavigationButton.Configuration(image: UIImage(systemName: "checkmark")!, isEnabled: canConfirmEdit, accessibilityIdentifier: .shared.keyboard.saveButton) { [weak viewController] in
+        let rightItem = TextEditorNavigationButton.Configuration(image: UIImage(systemName: "checkmark")!, isEnabled: canConfirmEdit, accessibilityIdentifier: AccessibilityID.shared.keyboard.saveButton.id) { [weak viewController] in
             guard let currentName = currentName,
                   let viewController = viewController else { return }
             handleSavingCategory(with: currentName, in: viewController)

--- a/Vocable/Features/Settings/EditCategories/CategoryNameEditorConfigurationProvider.swift
+++ b/Vocable/Features/Settings/EditCategories/CategoryNameEditorConfigurationProvider.swift
@@ -52,7 +52,7 @@ struct CategoryNameEditorConfigurationProvider: TextEditorConfigurationProviding
 
         let leftItem = TextEditorNavigationButton.Configuration.dismissal(for: viewController, textDidChange: textDidChange)
 
-        let rightItem = TextEditorNavigationButton.Configuration(image: UIImage(systemName: "checkmark")!, isEnabled: canConfirmEdit, accessibilityIdentifier: "keyboard.saveButton") { [weak viewController] in
+        let rightItem = TextEditorNavigationButton.Configuration(image: UIImage(systemName: "checkmark")!, isEnabled: canConfirmEdit, accessibilityIdentifier: .shared.keyboard.saveButton) { [weak viewController] in
             guard let currentName = currentName,
                   let viewController = viewController else { return }
             handleSavingCategory(with: currentName, in: viewController)

--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -106,7 +106,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
         navigationBar.leftButton = {
             let button = GazeableButton()
             button.setImage(UIImage(systemName: "xmark.circle"), for: .normal)
-            button.accessibilityIdentifier = "settings.dismissButton"
+            button.accessibilityID = .shared.dismissButton
             button.addTarget(self, action: #selector(dismissVC), for: .primaryActionTriggered)
             return button
         }()

--- a/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Shared+Keyboard.swift
+++ b/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Shared+Keyboard.swift
@@ -1,0 +1,18 @@
+//
+//  AccessibilityID+Shared+Keyboard.swift
+//  Vocable
+//
+//  Created by Rudy Salas on 5/18/22.
+//  Copyright © 2022 WillowTree. All rights reserved.
+//
+
+import Foundation
+
+extension AccessibilityID.shared {
+    public struct keyboard {
+        public static let outputTextView: AccessibilityID = "keyboard-text-view"
+        public static let favoriteButton: AccessibilityID = "favorite-button"
+        public static let saveButton: AccessibilityID = "checkmark-save-button"
+        private init() {}
+    }
+}

--- a/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Shared.swift
+++ b/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Shared.swift
@@ -13,6 +13,7 @@ extension AccessibilityID {
         public static let keyboardButton: AccessibilityID = "shared-keyboard-button"
         public static let settingsButton: AccessibilityID = "shared-settings-button"
         public static let backButton: AccessibilityID = "shared-back-button"
+        public static let dismissButton: AccessibilityID = "shared-dismiss-button"
         public static let titleLabel: AccessibilityID = "shared-title-label"
         private init() {}
     }

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -20,7 +20,7 @@ class BaseScreen {
     static let paginationRightButton = XCUIApplication().buttons["bottomPagination.right_chevron"]
     static let alertMessageLabel = XCUIApplication().staticTexts["alert_message"]
     static let emptyStateAddPhraseButton = XCUIApplication().buttons["empty_state_addPhrase_button"]
-    static let navBarDismissButton = XCUIApplication().buttons.containing(NSPredicate(format: "identifier CONTAINS 'dismissButton'")).element
+    static let navBarDismissButton = XCUIApplication().buttons[.shared.dismissButton]
     
     /// From Pagination: the current page (X) being viewed from the "Page X of Y" pagination label.
     static var currentPageNumber: Int {

--- a/VocableUITests/Screens/KeyboardScreen.swift
+++ b/VocableUITests/Screens/KeyboardScreen.swift
@@ -11,9 +11,9 @@ import XCTest
 class KeyboardScreen: BaseScreen {
     private static let app = XCUIApplication()
     
-    static let keyboardTextView = XCUIApplication().textViews["keyboard.textView"]
-    static let favoriteButton = XCUIApplication().buttons["keyboard.favoriteButton"]
-    static let checkmarkAddButton = XCUIApplication().buttons["keyboard.saveButton"]
+    static let keyboardTextView = XCUIApplication().textViews[.shared.keyboard.outputTextView]
+    static let favoriteButton = XCUIApplication().buttons[.shared.keyboard.favoriteButton]
+    static let checkmarkAddButton = XCUIApplication().buttons[.shared.keyboard.saveButton]
     static let createDuplicateButton = XCUIApplication().buttons["Create Duplicate"]
     
     static func typeText(_ textToType: String) {


### PR DESCRIPTION
closes #670 

### Description:
Added a new AccessibilityIDs file `AccessibilityID+Shared+Keyboard` for the identifiers assigned to the keyboard screen elements. With these new identifiers, I was able to refactor our KeyboardScreen element queries and the accessibilityIdentifier assignments in the source code to use the new identifiers. 

---

### Notes to Test
All tests should continue to pass.
