### PR TITLE
[677] Listening Mode Responses Update Every New Phrase

### DIFF
--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -103,12 +103,6 @@ final class ListeningResponseViewController: VocableViewController {
     }
 
     private func setContent(_ content: Content, animated: Bool = true) {
-
-        if self.contentViewController != nil {
-            guard content != self.content else {
-                return
-            }
-        }
         let previousContent = self.content
         self.content = content
         let outgoingTransition: TransitionStyle


### PR DESCRIPTION
closes #677

# Description of Work
This change fixes an issue where the `Share with Developers` button would only send the phrase that last triggered a new response state (i.e. sounds complicated, yes/no). For this change, a new view animates in whenever a new phrase is finalized, even if it's the same state as before.

---
