### PR TITLE
[679] Repeated Listening Mode Phrase Bugfix 🐛 🧹 

### DIFF
--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -195,7 +195,6 @@ final class ListeningResponseViewController: VocableViewController {
         guard classificationCancellable == nil else { return }
         classificationCancellable = classifier.classificationPublisher
             .dropFirst()
-            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newValue in
                 self?.updateResponses(for: newValue)


### PR DESCRIPTION
closes #679

# Description of Work
When repeating the same phrase twice, the listening mode view should now present a new list of answers.

---
