### PR TITLE
[672] Unsupported Listening Mode Before Microphone Access

### DIFF
--- a/Vocable/Common/Views/EmptyStateView.swift
+++ b/Vocable/Common/Views/EmptyStateView.swift
@@ -44,6 +44,7 @@ protocol EmptyStateRepresentable {
     var description: String? { get }
     var buttonTitle: String? { get }
     var image: UIImage? { get }
+    var yOffset: CGFloat? { get }
 }
 
 enum EmptyStateType: EmptyStateRepresentable {
@@ -86,6 +87,8 @@ enum EmptyStateType: EmptyStateRepresentable {
             return nil
         }
     }
+
+    var yOffset: CGFloat? { nil }
 }
 
 final class EmptyStateView: UIView {
@@ -126,6 +129,7 @@ final class EmptyStateView: UIView {
     private let descriptionLabel = UILabel(frame: .zero)
     private let button = EmptyStateButton(frame: .zero)
     private var action: ButtonConfiguration
+    private var yOffset: CGFloat = 0
 
     private lazy var stackView = UIStackView(arrangedSubviews: [self.imageView, self.titleLabel, self.descriptionLabel])
 
@@ -145,6 +149,10 @@ final class EmptyStateView: UIView {
         }
         button.setTitle(type.buttonTitle, for: .normal)
         button.accessibilityIdentifier = "empty_state_addPhrase_button"
+
+        if let yOffset = type.yOffset {
+            self.yOffset = yOffset
+        }
 
         commonInit()
     }
@@ -179,7 +187,7 @@ final class EmptyStateView: UIView {
         addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            stackView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: yOffset),
             stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             stackView.widthAnchor.constraint(lessThanOrEqualTo: readableContentGuide.widthAnchor),
             stackView.widthAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.widthAnchor),

--- a/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
+++ b/Vocable/Features/Settings/ListeningMode/ListeningModeViewController.swift
@@ -98,7 +98,12 @@ final class ListeningModeViewController: VocableCollectionViewController {
     private func updateDataSource(animated: Bool = false) {
         var snapshot = Snapshot()
         if let state = authorizationController.state {
-            collectionView.backgroundView = EmptyStateView.listening(state.state, action: state.action)
+            if !ListenModeFeatureConfiguration.deviceSupportsListeningMode {
+                collectionView.backgroundView  = EmptyStateView(type: ListeningEmptyState.listeningModeUnsupported)
+            } else {
+                collectionView.backgroundView = EmptyStateView.listening(state.state, action: state.action)
+            }
+
             updateBackgroundViewLayoutMargins()
         } else {
             snapshot.appendSections([.listeningMode])

--- a/Vocable/Features/Voice/ListeningResponseEmptyStateViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseEmptyStateViewController.swift
@@ -16,6 +16,7 @@ extension EmptyStateView {
 
 enum ListeningEmptyState: EmptyStateRepresentable, Equatable {
 
+    case listeningModeUnsupported
     case listeningResponse
     case speechServiceUnavailable
     case speechPermissionDenied
@@ -26,6 +27,8 @@ enum ListeningEmptyState: EmptyStateRepresentable, Equatable {
 
     var title: String {
         switch self {
+        case .listeningModeUnsupported:
+            return String(localized: "listening_mode.empty_state.unsupported.title")
         case .microphonePermissionDenied:
             return String(localized: "listening_mode.empty_state.microphone_permission_denied.title")
         case .microphonePermissionUndetermined:
@@ -45,6 +48,15 @@ enum ListeningEmptyState: EmptyStateRepresentable, Equatable {
 
     var description: String? {
         switch self {
+        case .listeningModeUnsupported:
+            let model = UIDevice.current.localizedModel
+            let systemName = UIDevice.current.systemName
+            let systemVersion = UIDevice.current.systemVersion
+            let siriName = "Siri"
+
+            let format = String(localized: "listening_mode.empty_state.unsupported.message")
+
+            return String(format: format, model, systemName, systemVersion, siriName)
         case .microphonePermissionUndetermined:
             return String(localized: "listening_mode.empty_state.microphone_permission_undetermined.message")
         case .microphonePermissionDenied:
@@ -64,7 +76,7 @@ enum ListeningEmptyState: EmptyStateRepresentable, Equatable {
 
     var buttonTitle: String? {
         switch self {
-        case .listenModeFreeResponse, .listeningResponse, .speechServiceUnavailable:
+        case .listenModeFreeResponse, .listeningResponse, .speechServiceUnavailable, .listeningModeUnsupported:
             return nil
         case .microphonePermissionUndetermined:
             return String(localized: "listening_mode.empty_state.microphone_permission_undetermined.action")
@@ -79,6 +91,15 @@ enum ListeningEmptyState: EmptyStateRepresentable, Equatable {
 
     var image: UIImage? {
         return nil
+    }
+
+    var yOffset: CGFloat? {
+        switch self {
+        case .listeningModeUnsupported:
+            return -64
+        default:
+            return nil
+        }
     }
 }
 

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -274,6 +274,9 @@
 
 // MARK: Listening Mode Empty State Titles
 
+/* Listening mode empty state title for for when microphone permissions are required, but listening mode is unsupported */
+"listening_mode.empty_state.unsupported.title" = "Listening Mode Unsupported";
+
 /* Listening mode empty state title for when microphone permissions are required, but the user has denied them */
 "listening_mode.empty_state.microphone_permission_denied.title" = "Microphone Access";
 
@@ -298,6 +301,9 @@
 
 
 // MARK: Listening Mode Empty State Messages
+
+/* Listening mode empty state message for when microphone permissions are required, but listening mode is unsupported */
+"listening_mode.empty_state.unsupported.message" = "This %1$@ on %2$@ %3$@ does not support Listening Mode.\n\nListening Mode is currently only available in English and requires %5$@ to be enabled.";
 
 /* Listening mode empty state message for when microphone permissions are required, but the user has denied them */
 "listening_mode.empty_state.microphone_permission_denied.message" = "Vocable needs to use the microphone to enable Listening Mode. Please enable microphone access in the system Settings app.\n\nYou can also disable Listening Mode to hide this category in Vocable's settings.";


### PR DESCRIPTION
closes #672

# Description of Work
A new view now appears in the listening mode settings screen for a user that has not yet granted microphone access but how their device set to an unsupported language (any language other than English).

## Notes to Test
- Due to the nature of localization, when in a non-english language, you will only see the localized variable name rather the actual text like the screenshot below.
- We should also verify that the listen mode does not show up anywhere else in the app when in the non-english mode other than the settings screen

<img src=https://user-images.githubusercontent.com/37670742/170566220-1dba7828-cd7d-46d1-98a9-5a824c61ea2a.jpeg width=250>

---
