### PR TITLE
#666 | Fix doublespeak bug

### DIFF
--- a/Vocable/Common/CarouselGridCollectionViewController.swift
+++ b/Vocable/Common/CarouselGridCollectionViewController.swift
@@ -60,7 +60,7 @@ class CarouselGridCollectionView: UICollectionView {
     override var contentSize: CGSize {
         didSet {
             defer {
-                if !needsInitialScrollToMiddle {
+                if needsInitialScrollToMiddle {
                     lastInvalidatedContentSize = contentSize
                 }
             }

--- a/Vocable/Common/CarouselGridCollectionViewController.swift
+++ b/Vocable/Common/CarouselGridCollectionViewController.swift
@@ -57,20 +57,10 @@ class CarouselGridCollectionView: UICollectionView {
     }
 
     private var lastInvalidatedContentSize: CGSize = .zero
+
     override var contentSize: CGSize {
         didSet {
-            defer {
-                if needsInitialScrollToMiddle {
-                    lastInvalidatedContentSize = contentSize
-                }
-            }
-            guard contentSize != lastInvalidatedContentSize else { return }
-            if needsInitialScrollToMiddle {
-                layoutIfNeeded()
-                needsInitialScrollToMiddle = !scrollToMiddleSection(animated: false)
-            } else {
-                snapToBoundaryIfNeeded()
-            }
+            adjustScrollPositionIfNeeded()
         }
     }
 
@@ -98,6 +88,19 @@ class CarouselGridCollectionView: UICollectionView {
         delaysContentTouches = false
         allowsMultipleSelection = true
         backgroundColor = .collectionViewBackgroundColor
+    }
+
+    private func adjustScrollPositionIfNeeded() {
+        defer { lastInvalidatedContentSize = contentSize }
+
+        guard contentSize != lastInvalidatedContentSize else { return }
+
+        if needsInitialScrollToMiddle {
+            layoutIfNeeded()
+            needsInitialScrollToMiddle = !scrollToMiddleSection(animated: false)
+        } else {
+            snapToBoundaryIfNeeded()
+        }
     }
 
     @objc func scrollToNextPage() {


### PR DESCRIPTION
Closes #666

This bug fixes an issue where the first phrase spoken in any category would be spoken twice (only reproduces if you select via head-gaze)

### Testing Notes

This PR touches some code in the `CarouselGridCollectionViewController`, which controls the paging functionality throughout the home screen of the app. Please pay special attention to the following area while testing, to ensure we catch any possible regressions:

- Phrase selection via head-gaze AND touch
- Phrase selection after switching categories
- Phrase selection after changing pages within a category
- Multiple page changes (e.g. pressing the back button numerous times to cycle through the pages)