### PR TITLE
Test/690 Adding the AX identifiers for the Base Screen and Keyboard Screen

### DIFF
--- a/Vocable/Common/Views/EmptyStateView.swift
+++ b/Vocable/Common/Views/EmptyStateView.swift
@@ -148,7 +148,7 @@ final class EmptyStateView: UIView {
             descriptionAttributedText = nil
         }
         button.setTitle(type.buttonTitle, for: .normal)
-        button.accessibilityIdentifier = "empty_state_addPhrase_button"
+        button.accessibilityIdentifier = AccessibilityID.shared.emptyStateAddPhraseButton.id
 
         if let yOffset = type.yOffset {
             self.yOffset = yOffset

--- a/Vocable/Common/Views/EmptyStateView.swift
+++ b/Vocable/Common/Views/EmptyStateView.swift
@@ -148,7 +148,7 @@ final class EmptyStateView: UIView {
             descriptionAttributedText = nil
         }
         button.setTitle(type.buttonTitle, for: .normal)
-        button.accessibilityIdentifier = AccessibilityID.shared.emptyStateAddPhraseButton.id
+        button.accessibilityID = .shared.emptyStateAddPhraseButton
 
         if let yOffset = type.yOffset {
             self.yOffset = yOffset

--- a/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
+++ b/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
@@ -293,7 +293,7 @@ final class GazeableAlertViewController: UIViewController, UIViewControllerTrans
         containerStackView.addArrangedSubview(actionButtonStackView)
 
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
-        messageLabel.accessibilityIdentifier = "alert_message"
+        messageLabel.accessibilityIdentifier = AccessibilityID.shared.alert.messageLabel.id
         titleContainerView.addSubview(messageLabel)
 
         NSLayoutConstraint.activate([

--- a/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
+++ b/Vocable/Common/Views/GazeableAlertController/GazeableAlertViewController.swift
@@ -293,7 +293,7 @@ final class GazeableAlertViewController: UIViewController, UIViewControllerTrans
         containerStackView.addArrangedSubview(actionButtonStackView)
 
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
-        messageLabel.accessibilityIdentifier = AccessibilityID.shared.alert.messageLabel.id
+        messageLabel.accessibilityID = .shared.alert.messageLabel
         titleContainerView.addSubview(messageLabel)
 
         NSLayoutConstraint.activate([

--- a/Vocable/Features/Settings/EditCategories/CategoryNameEditorConfigurationProvider.swift
+++ b/Vocable/Features/Settings/EditCategories/CategoryNameEditorConfigurationProvider.swift
@@ -133,7 +133,7 @@ struct CategoryNameEditorConfigurationProvider: TextEditorConfigurationProviding
 
         let alert = GazeableAlertViewController(alertTitle: title)
         alert.addAction(.cancel(withTitle: cancelButtonTitle))
-        alert.addAction(GazeableAlertAction(title: createButtonTitle, accessibilityIdentifier: "alert.button.create_duplicate", style: .destructive, handler: confirmationHandler))
+        alert.addAction(GazeableAlertAction(title: createButtonTitle, accessibilityIdentifier: AccessibilityID.shared.alert.createDuplicateButton.id, style: .destructive, handler: confirmationHandler))
         viewController.present(alert, animated: true)
     }
 }

--- a/Vocable/Features/Settings/EditPhrases/PhraseEditorConfigurationProvider.swift
+++ b/Vocable/Features/Settings/EditPhrases/PhraseEditorConfigurationProvider.swift
@@ -142,8 +142,8 @@ struct PhraseEditorConfigurationProvider: TextEditorConfigurationProviding {
         let createButtonTitle = String(localized: "phrase_editor.alert.phrase_name_exists.create.button")
 
         let alert = GazeableAlertViewController(alertTitle: title)
-        alert.addAction(GazeableAlertAction(title: cancelButtonTitle))
-        alert.addAction(GazeableAlertAction(title: createButtonTitle, style: .destructive, handler: confirmationHandler))
+        alert.addAction(.cancel(withTitle: cancelButtonTitle))
+        alert.addAction(GazeableAlertAction(title: createButtonTitle, accessibilityIdentifier: AccessibilityID.shared.alert.createDuplicateButton.id, style: .destructive, handler: confirmationHandler))
         viewController.present(alert, animated: true)
     }
 }

--- a/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Shared+Alert.swift
+++ b/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Shared+Alert.swift
@@ -14,6 +14,8 @@ extension AccessibilityID.shared {
         public static let discardButton: AccessibilityID = "alert-button-discard-changes"
         public static let deleteButton: AccessibilityID = "alert-button-delete"
         public static let cancelButton: AccessibilityID = "alert-button-cancel"
+        public static let createDuplicateButton: AccessibilityID = "alert-button-create-duplicate"
+        public static let messageLabel: AccessibilityID = "alert-message"
         private init() {}
     }
 }

--- a/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Shared.swift
+++ b/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Shared.swift
@@ -15,6 +15,7 @@ extension AccessibilityID {
         public static let backButton: AccessibilityID = "shared-back-button"
         public static let dismissButton: AccessibilityID = "shared-dismiss-button"
         public static let titleLabel: AccessibilityID = "shared-title-label"
+        public static let emptyStateAddPhraseButton: AccessibilityID = "empty-state-addPhrase-button"
         private init() {}
     }
 }

--- a/VocableUITests/Screens/BaseScreen.swift
+++ b/VocableUITests/Screens/BaseScreen.swift
@@ -15,14 +15,12 @@ import XCTest
 class BaseScreen {
     
     static let navBarBackButton = XCUIApplication().buttons[.shared.backButton]
+    static let navBarDismissButton = XCUIApplication().buttons[.shared.dismissButton]
+    static let title = XCUIApplication().staticTexts[.shared.titleLabel]
+    static let emptyStateAddPhraseButton = XCUIApplication().buttons[.shared.emptyStateAddPhraseButton]
     static let paginationLabel = XCUIApplication().staticTexts[.shared.pagination.pageLabel]
     static let paginationLeftButton = XCUIApplication().buttons[.shared.pagination.previousButton]
     static let paginationRightButton = XCUIApplication().buttons[.shared.pagination.nextButton]
-    
-    static let alertMessageLabel = XCUIApplication().staticTexts["alert_message"]
-    static let emptyStateAddPhraseButton = XCUIApplication().buttons["empty_state_addPhrase_button"]
-    static let navBarDismissButton = XCUIApplication().buttons[.shared.dismissButton]
-    static let title = XCUIApplication().staticTexts[.shared.titleLabel]
     
     // Alerts
     static let alertContinueButton = XCUIApplication().buttons[.shared.alert.continueButton]
@@ -30,6 +28,7 @@ class BaseScreen {
     static let alertDeleteButton = XCUIApplication().buttons[.shared.alert.deleteButton]
     static let alertRemoveButton = XCUIApplication().buttons[.shared.alert.deleteButton]
     static let alertCancelButton = XCUIApplication().buttons[.shared.alert.cancelButton]
+    static let alertMessageLabel = XCUIApplication().staticTexts[.shared.alert.messageLabel]
     
     /// From Pagination: the current page (X) being viewed from the "Page X of Y" pagination label.
     static var currentPageNumber: Int {

--- a/VocableUITests/Screens/KeyboardScreen.swift
+++ b/VocableUITests/Screens/KeyboardScreen.swift
@@ -14,7 +14,7 @@ class KeyboardScreen: BaseScreen {
     static let keyboardTextView = XCUIApplication().textViews[.shared.keyboard.outputTextView]
     static let favoriteButton = XCUIApplication().buttons[.shared.keyboard.favoriteButton]
     static let checkmarkAddButton = XCUIApplication().buttons[.shared.keyboard.saveButton]
-    static let createDuplicateButton = XCUIApplication().buttons["Create Duplicate"]
+    static let createDuplicateButton = XCUIApplication().buttons[.shared.alert.createDuplicateButton]
     
     static func typeText(_ textToType: String) {
         for char in textToType {


### PR DESCRIPTION
closes #690 

**Description:**
Refactored `emptyStateAddPhraseButton`, `createDuplicateButton`, and `alertMessageLabel`