### PR TITLE
#695 | Output Text After Speech Services Unavailable

### DIFF
--- a/Vocable/Features/Root/RootViewController.swift
+++ b/Vocable/Features/Root/RootViewController.swift
@@ -291,4 +291,8 @@ import SwiftUI
         updateOutputLabelText(text, isDictated: (text != nil))
     }
 
+    func shouldResetOutputText() {
+        updateOutputLabelText(nil, isDictated: false)
+    }
+
 }

--- a/Vocable/Features/Root/RootViewController.swift
+++ b/Vocable/Features/Root/RootViewController.swift
@@ -291,7 +291,7 @@ import SwiftUI
         updateOutputLabelText(text, isDictated: (text != nil))
     }
 
-    func shouldResetOutputText() {
+    func resetOutputText() {
         updateOutputLabelText(nil, isDictated: false)
     }
 

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -13,6 +13,7 @@ import VocableListenCore
 
 protocol ListeningResponseViewControllerDelegate: AnyObject {
     func didUpdateSpeechResponse(_ text: String?)
+    func shouldResetOutputText()
 }
 
 @available(iOS 14.0, *)
@@ -159,6 +160,7 @@ final class ListeningResponseViewController: VocableViewController {
             default:
                 let viewController = ListeningResponseEmptyStateViewController(state: state, action: action)
                 setContentViewController(viewController, outgoingTransition: outgoingTransition, incomingTransition: incomingTransition)
+                delegate?.shouldResetOutputText()
             }
         }
     }

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -13,7 +13,7 @@ import VocableListenCore
 
 protocol ListeningResponseViewControllerDelegate: AnyObject {
     func didUpdateSpeechResponse(_ text: String?)
-    func shouldResetOutputText()
+    func resetOutputText()
 }
 
 @available(iOS 14.0, *)
@@ -160,7 +160,7 @@ final class ListeningResponseViewController: VocableViewController {
             default:
                 let viewController = ListeningResponseEmptyStateViewController(state: state, action: action)
                 setContentViewController(viewController, outgoingTransition: outgoingTransition, incomingTransition: incomingTransition)
-                delegate?.shouldResetOutputText()
+                delegate?.resetOutputText()
             }
         }
     }


### PR DESCRIPTION
closes #695

# Description of Work
The output text at the top of the screen will now reset to the default "Select something below to speak" when navigating back to the app after disabling Dictation or Siri.

---
