### PR TITLE
Bugfix for Listening Mode Empty View State

### DIFF
--- a/Vocable/Features/Voice/AudioPermissionPromptController.swift
+++ b/Vocable/Features/Voice/AudioPermissionPromptController.swift
@@ -31,7 +31,6 @@ final class AudioPermissionPromptController {
         let micStatusPublisher = controller.$microphonePermissionStatus.dropFirst().removeDuplicates()
         let speechStatusPublisher = controller.$speechPermissionStatus.dropFirst().removeDuplicates()
         Publishers.CombineLatest(micStatusPublisher, speechStatusPublisher)
-            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (micStatus, speechStatus) in
                 self?.authorizationStatusDidChange(micStatus, speechStatus)

--- a/Vocable/Features/Voice/AudioPermissionPromptController.swift
+++ b/Vocable/Features/Voice/AudioPermissionPromptController.swift
@@ -31,6 +31,7 @@ final class AudioPermissionPromptController {
         let micStatusPublisher = controller.$microphonePermissionStatus.dropFirst().removeDuplicates()
         let speechStatusPublisher = controller.$speechPermissionStatus.dropFirst().removeDuplicates()
         Publishers.CombineLatest(micStatusPublisher, speechStatusPublisher)
+            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (micStatus, speechStatus) in
                 self?.authorizationStatusDidChange(micStatus, speechStatus)

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -265,8 +265,15 @@ final class ListeningResponseViewController: VocableViewController {
             .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newValue in
+                guard let self = self else { return }
                 if let newValue = newValue {
-                    self?.setContent(.empty(newValue.state, action: newValue.action), animated: true)
+                    self.setContent(.empty(newValue.state, action: newValue.action), animated: true)
+                } else {
+                    if self.speechRecognizerController.isAvailable {
+                        self.setContent(.empty(.listeningResponse), animated: true)
+                    } else {
+                        self.setContent(.empty(.speechServiceUnavailable), animated: true)
+                    }
                 }
             }
     }

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -267,8 +267,6 @@ final class ListeningResponseViewController: VocableViewController {
             .sink { [weak self] newValue in
                 if let newValue = newValue {
                     self?.setContent(.empty(newValue.state, action: newValue.action), animated: true)
-                } else {
-                    self?.setContent(.empty(.speechServiceUnavailable), animated: true)
                 }
             }
     }

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -268,7 +268,7 @@ final class ListeningResponseViewController: VocableViewController {
                 if let newValue = newValue {
                     self?.setContent(.empty(newValue.state, action: newValue.action), animated: true)
                 } else {
-                    self?.setContent(.empty(.listeningResponse), animated: true)
+                    self?.setContent(.empty(.speechServiceUnavailable), animated: true)
                 }
             }
     }


### PR DESCRIPTION
# Description of Work
There was an issue where the listening mode screen would sometimes say it's listening when it should say "Speech Services Unavailable" This was because when there was a nil permissions state, the default was set to the listening response empty state instead of the speech services unavailable state.

---
