### PR TITLE
Fixing Mixpanel Prod Token Default

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -1828,7 +1828,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-w",
@@ -1861,7 +1861,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-w",
@@ -2062,7 +2062,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-w",

--- a/Vocable/Analytics/Analytics.swift
+++ b/Vocable/Analytics/Analytics.swift
@@ -55,8 +55,7 @@ class Analytics {
         return tokens.staging
         #endif
 
-        #warning("Change token selection to prod once everything is validated")
-        return tokens.staging
+        return tokens.production
     }()
 
     static let shared = Analytics()


### PR DESCRIPTION
# Description of Work
The mixpanel token was defaulting to the `staging` token even when it wasn't a debug build, causing mixpanel data to never be sent to the prod environment. Also increasing version number since new changes would be added to the production build.

## Notes to Test
This needs to be merged before it can be merged since it requires a TestFlight build to be created to check that it's sending up data to Mixpanel prod.

---
