### PR TITLE
Compact QWERTY Layout

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		A96D61D524229F6400577144 /* SettingsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96D61D424229F6400577144 /* SettingsCollectionViewCell.swift */; };
 		A96D61D724229F7400577144 /* SettingsCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A96D61D624229F7400577144 /* SettingsCollectionViewCell.xib */; };
 		A97814FA23FF3B1200ECC609 /* CategorySectionBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97814F923FF3B1200ECC609 /* CategorySectionBackground.swift */; };
+		A982D11E2A2690B5004190D8 /* KeyboardLayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A982D11D2A2690B5004190D8 /* KeyboardLayoutViewController.swift */; };
 		A987416C280DADA40011C359 /* ListeningResponseFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A987416B280DADA40011C359 /* ListeningResponseFeedbackViewController.swift */; };
 		A987416E280DB20A0011C359 /* ListeningFeedbackSubmitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A987416D280DB20A0011C359 /* ListeningFeedbackSubmitView.swift */; };
 		A9874170280DFD0B0011C359 /* ListeningFeedbackSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A987416F280DFD0B0011C359 /* ListeningFeedbackSuccessView.swift */; };
@@ -537,6 +538,7 @@
 		A96D61D424229F6400577144 /* SettingsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCollectionViewCell.swift; sourceTree = "<group>"; };
 		A96D61D624229F7400577144 /* SettingsCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsCollectionViewCell.xib; sourceTree = "<group>"; };
 		A97814F923FF3B1200ECC609 /* CategorySectionBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySectionBackground.swift; sourceTree = "<group>"; };
+		A982D11D2A2690B5004190D8 /* KeyboardLayoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayoutViewController.swift; sourceTree = "<group>"; };
 		A987416B280DADA40011C359 /* ListeningResponseFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningResponseFeedbackViewController.swift; sourceTree = "<group>"; };
 		A987416D280DB20A0011C359 /* ListeningFeedbackSubmitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningFeedbackSubmitView.swift; sourceTree = "<group>"; };
 		A987416F280DFD0B0011C359 /* ListeningFeedbackSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningFeedbackSuccessView.swift; sourceTree = "<group>"; };
@@ -1010,6 +1012,7 @@
 				714EFD412419636500DC773C /* EditPhrases */,
 				A9B696002433C33F004E6960 /* EditCategories */,
 				6B6A4D8F25B7607800A7F489 /* ListeningMode */,
+				A982D11C2A269092004190D8 /* KeyboardLayout */,
 				A9DFCC21242D3A5000136136 /* TimingSensitivity */,
 				A9DFCC22242D3CF500136136 /* SelectionMode */,
 			);
@@ -1045,6 +1048,14 @@
 				A944D00A2406D55F00F3863E /* SettingsToggleCollectionViewCell.xib */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		A982D11C2A269092004190D8 /* KeyboardLayout */ = {
+			isa = PBXGroup;
+			children = (
+				A982D11D2A2690B5004190D8 /* KeyboardLayoutViewController.swift */,
+			);
+			path = KeyboardLayout;
 			sourceTree = "<group>";
 		};
 		A9B696002433C33F004E6960 /* EditCategories */ = {
@@ -1603,6 +1614,7 @@
 				A9FD68A528008AD3006ABA3F /* AddPhraseCollectionViewCell.swift in Sources */,
 				A9CF2AF9242D4F0A005633A7 /* SensitivityCollectionViewCell.swift in Sources */,
 				0E969128281C5F520097A3CC /* AccessibilityID.swift in Sources */,
+				A982D11E2A2690B5004190D8 /* KeyboardLayoutViewController.swift in Sources */,
 				6BE7E9842459D328007B01F2 /* PagingCarouselViewController.swift in Sources */,
 				6B9DFA6223E889DB0037673E /* UIVirtualCursorView.swift in Sources */,
 				DC753162284143C200A84989 /* AccessibilityID+Shared+Alert.swift in Sources */,

--- a/Vocable/Analytics/Analytics.swift
+++ b/Vocable/Analytics/Analytics.swift
@@ -190,4 +190,5 @@ extension Analytics.Event {
     static let heyVocableModeChanged = Self(name: "'Hey Vocable' Settings Changed")
 
     static let headingTrackingChanged = Self(name: "Head Tracking Settings Changed")
+    static let compactQWERTYKeyboardChanged = Self(name: "Compact QWERTY Keyboard Changed")
 }

--- a/Vocable/AppConfig/AppConfig.swift
+++ b/Vocable/AppConfig/AppConfig.swift
@@ -50,5 +50,5 @@ struct AppConfig {
     static let listeningMode = ListenModeFeatureConfiguration.shared
 
     @PublishedDefault(.isCompactPortraitQWERTYKeyboardEnabled)
-    static var isCompactPortraitQWERTYKeyboardEnabled: Bool = true
+    static var isCompactPortraitQWERTYKeyboardEnabled: Bool = false
 }

--- a/Vocable/AppConfig/AppConfig.swift
+++ b/Vocable/AppConfig/AppConfig.swift
@@ -17,6 +17,7 @@ extension UserDefaultsKey {
     static let sensitivitySetting: UserDefaultsKey = "sensitivitySetting"
     static let dwellDuration: UserDefaultsKey = "dwellDuration"
     static let isHeadTrackingEnabled: UserDefaultsKey = "isHeadTrackingEnabled"
+    static let isCompactPortraitQWERTYKeyboardEnabled: UserDefaultsKey = "isCompactPortraitQWERTYKeyboardEnabled"
 }
 
 struct AppConfig {
@@ -47,4 +48,7 @@ struct AppConfig {
     }
 
     static let listeningMode = ListenModeFeatureConfiguration.shared
+
+    @PublishedDefault(.isCompactPortraitQWERTYKeyboardEnabled)
+    static var isCompactPortraitQWERTYKeyboardEnabled: Bool = true
 }

--- a/Vocable/AppConfig/AppConfig.swift
+++ b/Vocable/AppConfig/AppConfig.swift
@@ -17,7 +17,7 @@ extension UserDefaultsKey {
     static let sensitivitySetting: UserDefaultsKey = "sensitivitySetting"
     static let dwellDuration: UserDefaultsKey = "dwellDuration"
     static let isHeadTrackingEnabled: UserDefaultsKey = "isHeadTrackingEnabled"
-    static let isCompactPortraitQWERTYKeyboardEnabled: UserDefaultsKey = "isCompactPortraitQWERTYKeyboardEnabled"
+    static let isCompactQWERTYKeyboardEnabled: UserDefaultsKey = "isCompactQWERTYKeyboardEnabled"
 }
 
 struct AppConfig {
@@ -49,6 +49,6 @@ struct AppConfig {
 
     static let listeningMode = ListenModeFeatureConfiguration.shared
 
-    @PublishedDefault(.isCompactPortraitQWERTYKeyboardEnabled)
+    @PublishedDefault(.isCompactQWERTYKeyboardEnabled)
     static var isCompactQWERTYKeyboardEnabled: Bool = false
 }

--- a/Vocable/AppConfig/AppConfig.swift
+++ b/Vocable/AppConfig/AppConfig.swift
@@ -50,5 +50,5 @@ struct AppConfig {
     static let listeningMode = ListenModeFeatureConfiguration.shared
 
     @PublishedDefault(.isCompactPortraitQWERTYKeyboardEnabled)
-    static var isCompactPortraitQWERTYKeyboardEnabled: Bool = false
+    static var isCompactQWERTYKeyboardEnabled: Bool = false
 }

--- a/Vocable/Features/Keyboard/KeyboardKeyCollectionViewCell.swift
+++ b/Vocable/Features/Keyboard/KeyboardKeyCollectionViewCell.swift
@@ -11,6 +11,25 @@ import AVFoundation
 
 class KeyboardKeyCollectionViewCell: VocableCollectionViewCell {
     @IBOutlet fileprivate weak var textLabel: UILabel!
+
+    var font: UIFont {
+        switch sizeClass {
+        case .hCompact_vCompact, .hRegular_vCompact:
+            return .boldSystemFont(ofSize: 28)
+        case .hCompact_vRegular:
+            if AppConfig.isCompactPortraitQWERTYKeyboardEnabled {
+                return .boldSystemFont(ofSize: 13)
+            }
+            return .boldSystemFont(ofSize: 28)
+        default:
+            return .boldSystemFont(ofSize: 48)
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateContent()
+    }
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -26,6 +45,7 @@ class KeyboardKeyCollectionViewCell: VocableCollectionViewCell {
         textLabel.textColor = isSelected ? .selectedTextColor : .defaultTextColor
         textLabel.backgroundColor = borderedView.fillColor
         textLabel.isOpaque = true
+        textLabel.font = font
     }
 
     func setup(title: String) {
@@ -33,7 +53,7 @@ class KeyboardKeyCollectionViewCell: VocableCollectionViewCell {
     }
     
     func setup(with image: UIImage?) {
-        guard let image = image, let font = textLabel.font else {
+        guard let image = image else {
             return
         }
         

--- a/Vocable/Features/Keyboard/KeyboardKeyCollectionViewCell.swift
+++ b/Vocable/Features/Keyboard/KeyboardKeyCollectionViewCell.swift
@@ -18,7 +18,7 @@ class KeyboardKeyCollectionViewCell: VocableCollectionViewCell {
             return .boldSystemFont(ofSize: 28)
         case .hCompact_vRegular:
             if AppConfig.isCompactPortraitQWERTYKeyboardEnabled {
-                return .boldSystemFont(ofSize: 13)
+                return .boldSystemFont(ofSize: 16)
             }
             return .boldSystemFont(ofSize: 28)
         default:

--- a/Vocable/Features/Keyboard/KeyboardKeyCollectionViewCell.swift
+++ b/Vocable/Features/Keyboard/KeyboardKeyCollectionViewCell.swift
@@ -17,7 +17,7 @@ class KeyboardKeyCollectionViewCell: VocableCollectionViewCell {
         case .hCompact_vCompact, .hRegular_vCompact:
             return .boldSystemFont(ofSize: 28)
         case .hCompact_vRegular:
-            if AppConfig.isCompactPortraitQWERTYKeyboardEnabled {
+            if AppConfig.isCompactQWERTYKeyboardEnabled {
                 return .boldSystemFont(ofSize: 16)
             }
             return .boldSystemFont(ofSize: 28)

--- a/Vocable/Features/Keyboard/KeyboardViewController.swift
+++ b/Vocable/Features/Keyboard/KeyboardViewController.swift
@@ -152,7 +152,7 @@ class KeyboardViewController: UICollectionViewController {
         }
         
         snapshot.appendSections([.keyboard])
-        if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular {
+        if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular && !AppConfig.isCompactPortraitQWERTYKeyboardEnabled {
             snapshot.appendItems(KeyboardLocale.current.compactPortraitKeyMapping.map { ItemWrapper.key("\($0)") })
         } else {
             snapshot.appendItems(KeyboardLocale.current.landscapeKeyMapping.map { ItemWrapper.key("\($0)") })

--- a/Vocable/Features/Keyboard/KeyboardViewController.swift
+++ b/Vocable/Features/Keyboard/KeyboardViewController.swift
@@ -152,7 +152,7 @@ class KeyboardViewController: UICollectionViewController {
         }
         
         snapshot.appendSections([.keyboard])
-        if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular && !AppConfig.isCompactPortraitQWERTYKeyboardEnabled {
+        if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular && !AppConfig.isCompactQWERTYKeyboardEnabled {
             snapshot.appendItems(KeyboardLocale.current.compactPortraitKeyMapping.map { ItemWrapper.key("\($0)") })
         } else {
             snapshot.appendItems(KeyboardLocale.current.landscapeKeyMapping.map { ItemWrapper.key("\($0)") })

--- a/Vocable/Features/Keyboard/LegacyLayoutSupport.swift
+++ b/Vocable/Features/Keyboard/LegacyLayoutSupport.swift
@@ -15,7 +15,7 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
     private static let totalSize = CGSize(width: 1130, height: 834)
 
     private static var compactHeight: CGFloat {
-        AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 0.375 : 0.8
+        AppConfig.isCompactQWERTYKeyboardEnabled ? 0.375 : 0.8
     }
     
     // MARK: - Section Layouts
@@ -358,7 +358,7 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
         let code = KeyboardLocale.current.languageCode
         switch code {
         case .en:
-            if isCompactPortrait && !AppConfig.isCompactPortraitQWERTYKeyboardEnabled {
+            if isCompactPortrait && !AppConfig.isCompactQWERTYKeyboardEnabled {
                 dimensions = (rows: 5, columns: 6)
             } else {
                 dimensions = (rows: 3, columns: 10)
@@ -389,7 +389,7 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
 
         let characterKeyFractionalHeight: CGFloat
         if sizeClass == .hCompact_vRegular {
-            characterKeyFractionalHeight = AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 4.7 / 6 : 5.0 / 6
+            characterKeyFractionalHeight = AppConfig.isCompactQWERTYKeyboardEnabled ? 4.7 / 6 : 5.0 / 6
         } else {
             characterKeyFractionalHeight = 3.0 / 4.0
         }
@@ -399,15 +399,15 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
             subitem: characterKeyGroup, count: dimensions.rows)
         
         // Function Key Group (bottom row)
-        let leadingKeyFractionalWidth = sizeClass == .hCompact_vRegular && AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 2.0 : 1.0
+        let leadingKeyFractionalWidth = sizeClass == .hCompact_vRegular && AppConfig.isCompactQWERTYKeyboardEnabled ? 2.0 : 1.0
         let leadingKeyItem = PresetCollectionViewCompositionalLayout.keyboardCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(leadingKeyFractionalWidth / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)), sizeClass: sizeClass)
 
-        let spaceKeyFractionalWidth = sizeClass == .hCompact_vRegular && AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 4.0 : 3.0
+        let spaceKeyFractionalWidth = sizeClass == .hCompact_vRegular && AppConfig.isCompactQWERTYKeyboardEnabled ? 4.0 : 3.0
         let spaceKeyItem = PresetCollectionViewCompositionalLayout.keyboardCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(spaceKeyFractionalWidth / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)), sizeClass: sizeClass)
 
-        let trailingKeyFractionalWidth = sizeClass == .hCompact_vRegular && AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 2.0 : 1.0
+        let trailingKeyFractionalWidth = sizeClass == .hCompact_vRegular && AppConfig.isCompactQWERTYKeyboardEnabled ? 2.0 : 1.0
         let trailingKeyItem = PresetCollectionViewCompositionalLayout.keyboardCollectionLayoutItem(
             layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(trailingKeyFractionalWidth / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)), sizeClass: sizeClass)
         
@@ -422,7 +422,7 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
         }
         
         var compactPortraitFunctionKeyGroup: NSCollectionLayoutGroup {
-            let fractionalHeight = AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 0.215 : 0.15
+            let fractionalHeight = AppConfig.isCompactQWERTYKeyboardEnabled ? 0.215 : 0.15
             let compactFunctionKeyGroup = NSCollectionLayoutGroup.horizontal(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(fractionalHeight)),
                 subitems: [leadingKeyItem, spaceKeyItem, trailingKeyItem, trailingKeyItem])
@@ -448,7 +448,7 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
     private static func keyboardCollectionLayoutItem(layoutSize: NSCollectionLayoutSize, sizeClass: SizeClass) -> NSCollectionLayoutItem {
         let item = NSCollectionLayoutItem(layoutSize: layoutSize)
         let contentInset: CGFloat
-        if sizeClass == .hCompact_vRegular && AppConfig.isCompactPortraitQWERTYKeyboardEnabled {
+        if sizeClass == .hCompact_vRegular && AppConfig.isCompactQWERTYKeyboardEnabled {
             contentInset = 2
         } else {
             contentInset = 4

--- a/Vocable/Features/Keyboard/LegacyLayoutSupport.swift
+++ b/Vocable/Features/Keyboard/LegacyLayoutSupport.swift
@@ -381,14 +381,14 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
     }
     
     static private func keyboardGroupLayout(environment: NSCollectionLayoutEnvironment, dimensions: (rows: Int, columns: Int), fractionalHeights: (compactHeight: CGFloat, defaultHeight: CGFloat)) -> NSCollectionLayoutGroup {
-        let traitCollection = environment.traitCollection
-        let keyItem = PresetCollectionViewCompositionalLayout.keyboardCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0 / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)))
+        let sizeClass = SizeClass(environment.traitCollection)
+        let keyItem = PresetCollectionViewCompositionalLayout.keyboardCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0 / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)), sizeClass: sizeClass)
         
         // Character key group (Top 3 rows)
         let characterKeyGroup = NSCollectionLayoutGroup.horizontal(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1)), subitem: keyItem, count: dimensions.columns)
 
         let characterKeyFractionalHeight: CGFloat
-        if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular {
+        if sizeClass == .hCompact_vRegular {
             characterKeyFractionalHeight = AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 4.7 / 6 : 5.0 / 6
         } else {
             characterKeyFractionalHeight = 3.0 / 4.0
@@ -399,17 +399,17 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
             subitem: characterKeyGroup, count: dimensions.rows)
         
         // Function Key Group (bottom row)
-        let leadingKeyFractionalWidth = AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 2.0 : 1.0
+        let leadingKeyFractionalWidth = sizeClass == .hCompact_vRegular && AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 2.0 : 1.0
         let leadingKeyItem = PresetCollectionViewCompositionalLayout.keyboardCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(leadingKeyFractionalWidth / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)))
+            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(leadingKeyFractionalWidth / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)), sizeClass: sizeClass)
 
-        let spaceKeyFractionalWidth = AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 4.0 : 3.0
+        let spaceKeyFractionalWidth = sizeClass == .hCompact_vRegular && AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 4.0 : 3.0
         let spaceKeyItem = PresetCollectionViewCompositionalLayout.keyboardCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(spaceKeyFractionalWidth / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)))
+            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(spaceKeyFractionalWidth / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)), sizeClass: sizeClass)
 
-        let trailingKeyFractionalWidth = AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 2.0 : 1.0
+        let trailingKeyFractionalWidth = sizeClass == .hCompact_vRegular && AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 2.0 : 1.0
         let trailingKeyItem = PresetCollectionViewCompositionalLayout.keyboardCollectionLayoutItem(
-            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(trailingKeyFractionalWidth / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)))
+            layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(trailingKeyFractionalWidth / CGFloat(dimensions.columns)), heightDimension: .fractionalHeight(1)), sizeClass: sizeClass)
         
         var defaultFunctionKeyGroup: NSCollectionLayoutGroup {
             let flexibleSpacing = (environment.container.contentSize.width / CGFloat(dimensions.columns)) * 2.0
@@ -430,7 +430,7 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
             return compactFunctionKeyGroup
         }
         
-        if traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular {
+        if sizeClass == .hCompact_vRegular {
             let overallContainerGroup = NSCollectionLayoutGroup.vertical(
                 layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(fractionalHeights.compactHeight)),
                 subitems: [characterKeyContainerGroup, compactPortraitFunctionKeyGroup])
@@ -445,9 +445,15 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
         return overallContainerGroup
     }
     
-    private static func keyboardCollectionLayoutItem(layoutSize: NSCollectionLayoutSize) -> NSCollectionLayoutItem {
+    private static func keyboardCollectionLayoutItem(layoutSize: NSCollectionLayoutSize, sizeClass: SizeClass) -> NSCollectionLayoutItem {
         let item = NSCollectionLayoutItem(layoutSize: layoutSize)
-        item.contentInsets = .init(top: 4, leading: 4, bottom: 4, trailing: 4)
+        let contentInset: CGFloat
+        if sizeClass == .hCompact_vRegular && AppConfig.isCompactPortraitQWERTYKeyboardEnabled {
+            contentInset = 2
+        } else {
+            contentInset = 4
+        }
+        item.contentInsets = .init(top: contentInset, leading: contentInset, bottom: contentInset, trailing: contentInset)
         return item
     }
 }

--- a/Vocable/Features/Keyboard/LegacyLayoutSupport.swift
+++ b/Vocable/Features/Keyboard/LegacyLayoutSupport.swift
@@ -15,7 +15,7 @@ class PresetCollectionViewCompositionalLayout: UICollectionViewCompositionalLayo
     private static let totalSize = CGSize(width: 1130, height: 834)
 
     private static var compactHeight: CGFloat {
-        AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 0.375 : 0.6
+        AppConfig.isCompactPortraitQWERTYKeyboardEnabled ? 0.375 : 0.8
     }
     
     // MARK: - Section Layouts

--- a/Vocable/Features/Settings/KeyboardLayout/KeyboardLayoutViewController.swift
+++ b/Vocable/Features/Settings/KeyboardLayout/KeyboardLayoutViewController.swift
@@ -34,7 +34,7 @@ final class KeyboardLayoutViewController: VocableCollectionViewController {
         var accessory: VocableListCellAccessory {
             switch self {
             case .compactQWERTY:
-                return .toggle(isOn: AppConfig.isCompactPortraitQWERTYKeyboardEnabled)
+                return .toggle(isOn: AppConfig.isCompactQWERTYKeyboardEnabled)
             }
         }
     }
@@ -196,7 +196,7 @@ final class KeyboardLayoutViewController: VocableCollectionViewController {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
         switch item {
         case .compactQWERTY:
-            AppConfig.isCompactPortraitQWERTYKeyboardEnabled.toggle()
+            AppConfig.isCompactQWERTYKeyboardEnabled.toggle()
             Analytics.shared.track(.compactQWERTYKeyboardChanged)
         }
 

--- a/Vocable/Features/Settings/KeyboardLayout/KeyboardLayoutViewController.swift
+++ b/Vocable/Features/Settings/KeyboardLayout/KeyboardLayoutViewController.swift
@@ -1,0 +1,225 @@
+//
+//  KeyboardLayoutViewController.swift
+//  Vocable
+//
+//  Created by Jesse Morgan on 5/30/23.
+//  Copyright © 2023 WillowTree. All rights reserved.
+//
+
+import UIKit
+
+final class KeyboardLayoutViewController: VocableCollectionViewController {
+
+    private enum Section: Int {
+        case compactQWERTY
+    }
+
+    private enum ContentItem: Int {
+        case compactQWERTY
+
+        var title: String {
+            switch self {
+            case .compactQWERTY:
+                return String(localized: "settings.cell.qwerty_layout.title")
+            }
+        }
+
+        var accessibilityID: String {
+            switch self {
+            case .compactQWERTY:
+                return "compact_qwerty_toggle"
+            }
+        }
+
+        var accessory: VocableListCellAccessory {
+            switch self {
+            case .compactQWERTY:
+                return .toggle(isOn: AppConfig.isCompactPortraitQWERTYKeyboardEnabled)
+            }
+        }
+    }
+
+    private typealias Snapshot = NSDiffableDataSourceSnapshot<Section, ContentItem>
+    private typealias Datasource = UICollectionViewDiffableDataSource<Section, ContentItem>
+
+    private var dataSource: Datasource!
+
+    private var cellRegistration: UICollectionView.CellRegistration<VocableListCell, ContentItem>!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupNavigationBar()
+        setupCollectionView()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateDataSource()
+    }
+
+    private func setupNavigationBar() {
+        navigationBar.title = String(localized: "settings.keyboard_layout.header.title")
+    }
+
+    override func viewLayoutMarginsDidChange() {
+        super.viewLayoutMarginsDidChange()
+        collectionView.collectionViewLayout.invalidateLayout()
+        updateBackgroundViewLayoutMargins()
+    }
+
+    private func updateBackgroundViewLayoutMargins() {
+        guard let backgroundView = collectionView.backgroundView else { return }
+        backgroundView.directionalLayoutMargins.leading = view.directionalLayoutMargins.leading
+        backgroundView.directionalLayoutMargins.trailing = view.directionalLayoutMargins.trailing
+    }
+
+    // MARK: UICollectionViewDataSource
+
+    private func updateDataSource(animated: Bool = false) {
+        var snapshot = Snapshot()
+        snapshot.appendSections([.compactQWERTY])
+        snapshot.appendItems([.compactQWERTY])
+        collectionView.backgroundView = nil
+
+        if #available(iOS 15.0, *) {
+            let reconfigurableItems = [.compactQWERTY].filter(snapshot.itemIdentifiers.contains)
+            snapshot.reconfigureItems(reconfigurableItems)
+        }
+
+        dataSource.apply(snapshot, animatingDifferences: animated) { [weak self] in
+            // Workaround for diffable datasource not auto-reconfiguring on iOS 14
+            if #unavailable(iOS 15) {
+                self?.updateVisibleCellConfigurations()
+            }
+        }
+    }
+
+    private func setupCollectionView() {
+
+        collectionView.backgroundColor = .collectionViewBackgroundColor
+        collectionView.register(UINib(nibName: "SettingsFooterTextSupplementaryView", bundle: nil),
+                                forSupplementaryViewOfKind: "footerText",
+                                withReuseIdentifier: "footerText")
+
+        let cellRegistration = UICollectionView.CellRegistration<VocableListCell, ContentItem>(handler: { [weak self] cell, indexPath, item in
+            self?.updateContentConfiguration(for: cell, at: indexPath, item: item)
+        })
+
+        let dataSource = Datasource(collectionView: collectionView) { (collectionView, indexPath, item) in
+            collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item)
+        }
+
+        dataSource.supplementaryViewProvider = { [weak self] (collectionView, elementKind, indexPath) in
+            let footerView = collectionView.dequeueReusableSupplementaryView(ofKind: elementKind, withReuseIdentifier: elementKind, for: indexPath) as! SettingsFooterTextSupplementaryView
+            guard let self = self else { return footerView }
+
+            let text: String
+            let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
+            switch section {
+            case .compactQWERTY:
+                let iPhoneName = "iPhone"
+                let localizedString = String(localized: "settings.keyboard_layout.qwerty_layout.explanation_footer")
+                text = String(format: localizedString, iPhoneName)
+            }
+
+            let fontSize: CGFloat = self.sizeClass.contains(any: .compact) ? 18 : 26
+            footerView.textLabel.font = .systemFont(ofSize: fontSize)
+            footerView.textLabel.text = text
+            return footerView
+        }
+
+        let configuration = UICollectionViewCompositionalLayoutConfiguration()
+        let interSectionSpacing: CGFloat = self.sizeClass.contains(any: .compact) ? 16 : 44
+        configuration.interSectionSpacing = interSectionSpacing
+        let layout = UICollectionViewCompositionalLayout(sectionProvider: { [weak self] (_, environment) -> NSCollectionLayoutSection? in
+            return self?.layoutSection(environment: environment)
+        }, configuration: configuration)
+        collectionView.collectionViewLayout = layout
+
+        self.cellRegistration = cellRegistration
+        self.dataSource = dataSource
+    }
+
+    private func updateContentConfiguration(for cell: VocableListCell, at indexPath: IndexPath, item: ContentItem) {
+        let config = VocableListContentConfiguration(title: item.title,
+                                                     accessory: item.accessory,
+                                                     accessibilityIdentifier: item.accessibilityID) { [weak self] in
+            guard let self = self, let indexPath = self.dataSource.indexPath(for: item) else { return }
+            self.collectionView(self.collectionView, didSelectItemAt: indexPath)
+        }
+        cell.contentConfiguration = config
+    }
+
+    private func layoutSection(environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+
+        let itemHeightDimension: NSCollectionLayoutDimension
+        if sizeClass.contains(any: .compact) {
+            itemHeightDimension = NSCollectionLayoutDimension.absolute(50)
+        } else {
+            itemHeightDimension = NSCollectionLayoutDimension.absolute(100)
+        }
+
+        let itemWidthDimension = NSCollectionLayoutDimension.fractionalWidth(1.0)
+        let columnCount = 1
+
+        let itemSize = NSCollectionLayoutSize(widthDimension: itemWidthDimension, heightDimension: itemHeightDimension)
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(widthDimension: itemWidthDimension, heightDimension: itemHeightDimension)
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: columnCount)
+        group.interItemSpacing = .fixed(8)
+
+        let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(1))
+        let footerItem = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: footerSize, elementKind: "footerText", alignment: .bottom)
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 8
+        section.contentInsets = sectionInsets(for: environment)
+        section.contentInsets.top = 16
+        section.contentInsets.bottom = sizeClass.contains(any: .compact) ? 16 : 32
+        section.boundarySupplementaryItems = [footerItem]
+        return section
+    }
+
+    private func sectionInsets(for environment: NSCollectionLayoutEnvironment) -> NSDirectionalEdgeInsets {
+        return NSDirectionalEdgeInsets(top: 0,
+                                       leading: max(view.layoutMargins.left - environment.container.contentInsets.leading, 0),
+                                       bottom: 0,
+                                       trailing: max(view.layoutMargins.right - environment.container.contentInsets.trailing, 0))
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+
+        if collectionView.indexPathForGazedItem != indexPath {
+            collectionView.deselectItem(at: indexPath, animated: true)
+        }
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+        switch item {
+        case .compactQWERTY:
+            AppConfig.isCompactPortraitQWERTYKeyboardEnabled.toggle()
+            Analytics.shared.track(.compactQWERTYKeyboardChanged)
+        }
+
+        updateDataSource(animated: true)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
+    func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
+    @available(iOS, obsoleted: 15, message: "Use snapshot-based reconfiguring instead")
+    private func updateVisibleCellConfigurations() {
+        for indexPath in self.collectionView.indexPathsForVisibleItems {
+            if let cell = self.collectionView.cellForItem(at: indexPath) as? VocableListCell {
+                guard let item = self.dataSource.itemIdentifier(for: indexPath) else {
+                    continue
+                }
+                self.updateContentConfiguration(for: cell, at: indexPath, item: item)
+            }
+        }
+    }
+}

--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -24,6 +24,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
         case timingSensitivity
         case resetAppSettings
         case selectionMode
+        case keyboardLayout
         case privacyPolicy
         case contactDevs
         case pidTuner
@@ -36,6 +37,8 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
                 return String(localized: "settings.cell.categories.title")
             case .timingSensitivity:
                 return String(localized: "settings.cell.timing_sensitivity.title")
+            case .keyboardLayout:
+                return String(localized: "settings.cell.keyboard_layout.title")
             case .resetAppSettings:
                 return String(localized: "settings.cell.reset_all.title")
             case .selectionMode:
@@ -90,7 +93,7 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
         .init(collectionView: collectionView) {(collectionView, indexPath, item) -> UICollectionViewCell in
 
         switch item {
-        case .categories, .timingSensitivity, .resetAppSettings, .selectionMode, .listeningMode:
+        case .categories, .timingSensitivity, .resetAppSettings, .selectionMode, .listeningMode, .keyboardLayout:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SettingsCollectionViewCell.reuseIdentifier, for: indexPath) as! SettingsCollectionViewCell
             cell.setup(title: item.title, image: UIImage(systemName: "chevron.right"))
             cell.accessibilityID = item.accessibiltyId
@@ -171,10 +174,10 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
         snapshot.appendSections([.internalSettings])
         snapshot.appendItems([.categories,
                               .timingSensitivity,
+                              .keyboardLayout,
                               .resetAppSettings,
                               .listeningMode,
-                              .selectionMode,
-                              .pidTuner].filter(\.isFeatureEnabled))
+                              .selectionMode].filter(\.isFeatureEnabled))
         snapshot.appendSections([.externalURL])
         snapshot.appendItems([.privacyPolicy,
                               .contactDevs].filter(\.isFeatureEnabled))
@@ -281,6 +284,10 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
             presentPidTuner()
         case .resetAppSettings:
             presentAppResetPrompt()
+
+        case .keyboardLayout:
+            let viewController = KeyboardLayoutViewController()
+            show(viewController, sender: nil)
         default:
             break
         }

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -81,6 +81,9 @@
 /* edit cursor timing and sensititivy settings menu item */
 "settings.cell.timing_sensitivity.title" = "Timing and Sensitivity";
 
+/* edit keyboard layout settings menu item */
+"settings.cell.keyboard_layout.title" = "Keyboard Layout";
+
 /* reset all settings menu item */
 "settings.cell.reset_all.title" = "Reset App Settings";
 
@@ -211,6 +214,17 @@
 
 /* Option within Selectin Mode.  This option is to enable to disable head tracking via a toggle. */
 "settings.cell.head_tracking.title" = "Head Tracking";
+
+// MARK: Keyboard Layout Settings Strings
+
+/* Keyboard Layout setting header title*/
+"settings.keyboard_layout.header.title" = "Keyboard Layout";
+
+/* Option within Keyboard Layout. This option is to enable or disable QWERTY keyboard on portrait iPhone. */
+"settings.cell.qwerty_layout.title" = "Compact QWERTY";
+
+/* Option within Keyboard Layout. This option is to enable or disable QWERTY keyboard on portrait iPhone. */
+"settings.keyboard_layout.qwerty_layout.explanation_footer" = "Enabling this will show a QWERTY keyboard layout for portrait mode on %@. This keyboard layout may cause issues with head tracking due to small key size.";
 
 
 // MARK: Category Empty State Strings


### PR DESCRIPTION
# Description of Work
There has been user feedback that requested a QWERTY keyboard layout when in portrait mode on an iPhone. A new mode has been added called `Compact QWERTY` where the keyboard layout is QWERTY for portrait iPhones. A new page in settings was added called `Keyboard Layout` which allows the user to turn on and off this feature. It includes a disclaimer saying that head tracking may be affected due to the small key size. 

This is implemented by adding a boolean flag called `isCompactQWERTYKeyboardEnabled` in `AppConfig`. By default this value is turned off, where the portrait iPhone keyboard layout is alphabetical.

Screenshots & video are attached. 

---
<img src="https://github.com/willowtreeapps/vocable-ios/assets/37670742/83b393aa-7b63-43a8-aaa7-04ccea66ba79" height=500>
<img src="https://github.com/willowtreeapps/vocable-ios/assets/37670742/279335f2-4ce1-4682-9055-b0199ad6b039" height=500>

https://github.com/willowtreeapps/vocable-ios/assets/37670742/0305064f-1650-44d4-9f89-f1f8d1371fe2
