### PR TITLE
Gets the app building on CI again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 13.3.0
+      xcode: 14.3.1
+    resource_class: macos.m1.medium.gen1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -21,7 +22,8 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 13.3.0
+      xcode: 14.3.1
+    resource_class: macos.m1.medium.gen1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
@@ -38,7 +40,8 @@ jobs:
 
   buildanddeploytotestflight:
     macos:
-      xcode: 13.3.0
+      xcode: 14.3.1
+    resource_class: macos.m1.medium.gen1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: buildanddeploytotestflight
@@ -54,7 +57,8 @@ jobs:
           path: output
   export-localizations-for-crowdin:
     macos: 
-      xcode: 13.3.0
+      xcode: 14.3.1
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - run: rm ~/.ssh/id_rsa || true
@@ -76,7 +80,8 @@ jobs:
             
   update-localizations-test-deploy:
     macos: 
-      xcode: 13.3.0
+      xcode: 14.3.1
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - run: rm ~/.ssh/id_rsa || true

--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -1229,7 +1229,6 @@
 				2631B3FF251191C500B94402 /* Frameworks */,
 				130C00B220D2AD2A007C3163 /* Resources */,
 				54481D4823E9CBF000ECF249 /* Swift Lint */,
-				2631B40F2511939600B94402 /* Initialize Crashlytics */,
 			);
 			buildRules = (
 			);
@@ -1393,26 +1392,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2631B40F2511939600B94402 /* Initialize Crashlytics */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}\n",
-				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
-			);
-			name = "Initialize Crashlytics";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# This locates the crashlytics framework downloaded by the SPM in order to execute the included script\n\n\"${PROJECT_DIR}/scripts/run\"\n";
-		};
 		54481D4823E9CBF000ECF249 /* Swift Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -34,23 +34,25 @@ class CategoryPhrasesPaginationTests: PaginationBaseTest {
     
     func testPagesAdjustToNewPhrases() {
         // Verify that the user is on the first page.
-        MainScreen.navigateToSettingsAndOpenCategory(name: eightPhrasesCategory.presetCategory.utterance)
+        MainScreen.navigateToSettingsAndOpenCategory(name: twoPhrasesCategory.presetCategory.utterance)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Add 1 more phrase to push the total number of pages to 2.
-        CustomCategoriesScreen.addRandomPhrases(numberOfPhrases: 1)
+        CustomCategoriesScreen.addRandomPhrases(numberOfPhrases: 10)
         VTAssertPaginationEquals(1, of: 2, enabledArrows: .both)
         
         // Remove the additional phrase to verify that the page count reduces, back to the original count
-        CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
-        SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
+        for _ in 1...10 {
+            CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
+            SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
+        }
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
     }
     
     // It is expected that the pagination left and right arrows are disabled when there is only 1 total page
     func testNextPageButtonsDisabled() {
         // Navigate to our test category and open the 'Edit Phrases' screen
-        MainScreen.navigateToSettingsAndOpenCategory(name: eightPhrasesCategory.presetCategory.utterance)
+        MainScreen.navigateToSettingsAndOpenCategory(name: twoPhrasesCategory.presetCategory.utterance)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Verify the page counts and that buttons appear; both buttons are disabled.

--- a/VocableUITests/Tests/PaginationBaseTest.swift
+++ b/VocableUITests/Tests/PaginationBaseTest.swift
@@ -19,6 +19,7 @@ class PaginationBaseTest: XCTestCase {
     let eightPhrasesCategory = Category(id: "first_category", "Category 1", phrases: PaginationBaseTest.phrases(count: 8))
     let ninePhrasesCategory = Category(id: "second_category", "Category 2", phrases: PaginationBaseTest.phrases(count: 9))
     let sevenPhrasesCategory = Category(id: "third_category", "Category 3", phrases: PaginationBaseTest.phrases(count: 7))
+    let twoPhrasesCategory = Category(id: "fourth_category", "Category 4", phrases: PaginationBaseTest.phrases(count: 2))
     
     override func setUp() {
         let app = XCUIApplication()
@@ -29,6 +30,7 @@ class PaginationBaseTest: XCTestCase {
                     eightPhrasesCategory
                     ninePhrasesCategory
                     sevenPhrasesCategory
+                    twoPhrasesCategory
                 }
             }
         }


### PR DESCRIPTION
# Description

For some upcoming work I'd like to get builds succeeding again.

There have been some moves internally to prefer using GitHub actions for projects like this and internal projects - for the time being I think remaining on circle is easiest. Once we get some of the work we have planned done and released we can look into a potential change.

# Changes

* Updates circle ci to use current version of Xcode
* Switching to use M1 agents on circle.
* Removes crashlytics build phase
* Resolves some failing UI tests
