### PR TITLE
[728] Add support for iOS 17 Personal Voice

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -279,6 +279,8 @@
 		B2BC6CB12BDAA83400D459F6 /* VoiceProfilePreviewDataSource+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BC6CB02BDAA83400D459F6 /* VoiceProfilePreviewDataSource+Filter.swift */; };
 		B2BC6CB32BDAB2A600D459F6 /* VoiceSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BC6CB22BDAB2A600D459F6 /* VoiceSettingsViewController.swift */; };
 		B2BC6CB52BDAD1B500D459F6 /* VoiceProfileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BC6CB42BDAD1B500D459F6 /* VoiceProfileItem.swift */; };
+		B2BC6CB72BDBFCC100D459F6 /* PersonalVoiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BC6CB62BDBFCC100D459F6 /* PersonalVoiceViewController.swift */; };
+		B2BC6CB92BDC241200D459F6 /* PersonalVoicePermissionPromptController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BC6CB82BDC241200D459F6 /* PersonalVoicePermissionPromptController.swift */; };
 		B838200F23F4B011005A79CD /* VocableCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B838200E23F4B011005A79CD /* VocableCollectionViewCell.swift */; };
 		B879831523E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */; };
 		B8DA9DE823EB833200FEBE19 /* BorderedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA9DE723EB833200FEBE19 /* BorderedView.swift */; };
@@ -593,6 +595,8 @@
 		B2BC6CB02BDAA83400D459F6 /* VoiceProfilePreviewDataSource+Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VoiceProfilePreviewDataSource+Filter.swift"; sourceTree = "<group>"; };
 		B2BC6CB22BDAB2A600D459F6 /* VoiceSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoiceSettingsViewController.swift; sourceTree = "<group>"; };
 		B2BC6CB42BDAD1B500D459F6 /* VoiceProfileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceProfileItem.swift; sourceTree = "<group>"; };
+		B2BC6CB62BDBFCC100D459F6 /* PersonalVoiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalVoiceViewController.swift; sourceTree = "<group>"; };
+		B2BC6CB82BDC241200D459F6 /* PersonalVoicePermissionPromptController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalVoicePermissionPromptController.swift; sourceTree = "<group>"; };
 		B838200E23F4B011005A79CD /* VocableCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableCollectionViewCell.swift; sourceTree = "<group>"; };
 		B879831323E0DA8300DC1A81 /* PresetItemCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetItemCollectionViewCell.swift; sourceTree = "<group>"; };
 		B8D55689242FE8B900B0F6FE /* Phrases v2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Phrases v2.xcdatamodel"; sourceTree = "<group>"; };
@@ -839,6 +843,8 @@
 			children = (
 				B2BC6CB22BDAB2A600D459F6 /* VoiceSettingsViewController.swift */,
 				6432696B2BD16F46005F5AF7 /* VoicePickerViewController.swift */,
+				B2BC6CB62BDBFCC100D459F6 /* PersonalVoiceViewController.swift */,
+				B2BC6CB82BDC241200D459F6 /* PersonalVoicePermissionPromptController.swift */,
 				B2BC6CA82BD94F5A00D459F6 /* VocableListContentConfiguration+VoiceProfileItem.swift */,
 				B2BC6CB42BDAD1B500D459F6 /* VoiceProfileItem.swift */,
 				B2BC6CAA2BD94FB500D459F6 /* VoiceProfilePreviewSynthesizer.swift */,
@@ -1547,6 +1553,7 @@
 				6BB56BA82422AC2500EA787E /* ToastView.swift in Sources */,
 				A9DFCC20242D020100136136 /* PublishedValue.swift in Sources */,
 				6B5C73A727DFE61600004713 /* PredicateBuilders.swift in Sources */,
+				B2BC6CB92BDC241200D459F6 /* PersonalVoicePermissionPromptController.swift in Sources */,
 				A9C32CFF242271F3000EC6F7 /* Phrase+Helpers.swift in Sources */,
 				64981D7C258A8014007EFA82 /* VocableChoicesModel.mlmodel in Sources */,
 				64F49906245B40BC00348592 /* SettingsViewController.swift in Sources */,
@@ -1583,6 +1590,7 @@
 				A916F33E28490B2E00557CA2 /* UIApplication+Helpers.swift in Sources */,
 				A9DE16FE23F48FD30094DB64 /* TextSuggestionController.swift in Sources */,
 				A91030B227E3BF6600281C97 /* VocableListCellContentView.swift in Sources */,
+				B2BC6CB72BDBFCC100D459F6 /* PersonalVoiceViewController.swift in Sources */,
 				220DDD612A53CAC30058C7A9 /* ListenAPIClient.swift in Sources */,
 				6BE7E9882459DFD5007B01F2 /* VocableNavigationBar.swift in Sources */,
 				6B5C490D245CB92700A4433C /* CategoryDetailViewController.swift in Sources */,

--- a/Vocable/Common/Views/EmptyStateView.swift
+++ b/Vocable/Common/Views/EmptyStateView.swift
@@ -47,6 +47,14 @@ protocol EmptyStateRepresentable {
     var yOffset: CGFloat? { get }
 }
 
+// Default implementations of optional properties
+extension EmptyStateRepresentable {
+    var description: String? { nil }
+    var buttonTitle: String? { nil }
+    var image: UIImage? { nil }
+    var yOffset: CGFloat? { nil }
+}
+
 enum EmptyStateType: EmptyStateRepresentable {
 
     case recents

--- a/Vocable/Features/Settings/VoiceSettings/PersonalVoicePermissionPromptController.swift
+++ b/Vocable/Features/Settings/VoiceSettings/PersonalVoicePermissionPromptController.swift
@@ -1,0 +1,67 @@
+//
+//  PersonalVoicePermissionPromptController.swift
+//  Vocable
+//
+//  Created by Chris Stroud on 4/26/24.
+//  Copyright © 2024 WillowTree. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+import Combine
+import UIKit
+
+@available(iOS 17.0, *)
+final class PersonalVoicePermissionPromptController {
+    
+    private typealias AuthorizationStatus = AVSpeechSynthesizer.PersonalVoiceAuthorizationStatus
+    
+    struct PersonalVoicePermissionEmptyState {
+        let state: PersonalVoiceEmptyState
+        let action: EmptyStateView.ButtonConfiguration
+    }
+
+    @Published private(set) var state: PersonalVoicePermissionEmptyState? = .none
+
+    private var cancellables = Set<AnyCancellable>()
+
+    private var authorizationStatus: AuthorizationStatus {
+        AVSpeechSynthesizer.personalVoiceAuthorizationStatus
+    }
+    
+    init() {
+        self.authorizationStatusDidChange(authorizationStatus)
+        NotificationCenter.default
+            .publisher(
+                for: AVSpeechSynthesizer.availableVoicesDidChangeNotification,
+                object: nil
+            )
+            .compactMap { [weak self] _ in
+                self?.authorizationStatus
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] (status) in
+                self?.authorizationStatusDidChange(status)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func authorizationStatusDidChange(_ status: AuthorizationStatus) {
+        switch status {
+        case .authorized:
+            self.state = nil
+        case .denied: // Need to go to settings
+            self.state = .init(state: .denied) {
+                UIApplication.openSettingsURL()
+            }
+        case .notDetermined: // Need to present alert
+            self.state = .init(state: .notAuthorized) { [weak self] in
+                AVSpeechSynthesizer.requestPersonalVoiceAuthorization { status in
+                    self?.authorizationStatusDidChange(status)
+                }
+            }
+        default:
+            self.state = nil
+        }
+    }
+}

--- a/Vocable/Features/Settings/VoiceSettings/PersonalVoiceViewController.swift
+++ b/Vocable/Features/Settings/VoiceSettings/PersonalVoiceViewController.swift
@@ -1,0 +1,182 @@
+//
+//  PersonalVoiceViewController.swift
+//  Vocable
+//
+//  Created by Chris Stroud on 4/26/24.
+//  Copyright © 2024 WillowTree. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import AVFoundation
+import Combine
+
+@available(iOS 17.0, *)
+final class PersonalVoiceViewController: PagingCarouselViewController {
+        
+    private typealias DataSource = CarouselCollectionViewDataSourceProxy<Int, VoiceProfileItem>
+    private typealias CellRegistration = UICollectionView.CellRegistration<VocableListCell, VoiceProfileItem>
+    
+    private var dataSource: DataSource!
+    private var cellRegistration: CellRegistration!
+    private let authorizationController = PersonalVoicePermissionPromptController()
+    
+    private let previewController = VoiceProfilePreviewController(context: .personalVoice)
+    private var cancellables: Set<AnyCancellable> = []
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        updateLayoutForCurrentTraitCollection()
+
+        setupNavigationBar()
+        setupCollectionView()
+        updateDataSource()
+        
+        Publishers.CombineLatest(previewController.$items, authorizationController.$state)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] (items, state) in
+                self?.updateDataSource(items: items, authorizationState: state)
+            }
+            .store(in: &cancellables)
+    }
+        
+    override func viewLayoutMarginsDidChange() {
+        super.viewLayoutMarginsDidChange()
+        updateBackgroundViewLayoutMargins()
+    }
+
+    private func setupNavigationBar() {
+        navigationBar.title = String(localized: "personal_voices.title")
+    }
+
+    private func setupCollectionView() {
+        collectionView.allowsMultipleSelection = true
+        collectionView.allowsMultipleSelectionDuringEditing = true
+        collectionView.backgroundColor = .collectionViewBackgroundColor
+        
+        let cellRegistration = CellRegistration { [weak self] cell, _, item in
+            guard let self else { return }
+            cell.contentConfiguration = VocableListContentConfiguration.voiceProfileItem(
+                item,
+                controller: self.previewController
+            ) { [weak self] in
+                self?.handleVoiceSelection(item.voice)
+            }
+        }
+        
+        let dataSource = DataSource(collectionView: collectionView) { (collectionView, indexPath, voice) -> UICollectionViewCell? in
+            collectionView.dequeueConfiguredReusableCell(
+                using: cellRegistration,
+                for: indexPath,
+                item: voice
+            )
+        }
+        self.dataSource = dataSource
+        self.cellRegistration = cellRegistration
+    }
+    
+    private func updateDataSource(
+        items: [VoiceProfileItem]? = nil,
+        previewing previewVoice: AVSpeechSynthesisVoice? = nil,
+        authorizationState: PersonalVoicePermissionPromptController.PersonalVoicePermissionEmptyState? = nil
+    ) {
+        let authorizationState = authorizationState ?? authorizationController.state
+        let items = items ?? previewController.items
+        var snapshot = NSDiffableDataSourceSnapshot<Int, VoiceProfileItem>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(items)
+        dataSource.apply(snapshot, animatingDifferences: false)
+        
+        if let authorizationState {
+            setBackgroundView(EmptyStateView(type: authorizationState.state, action: authorizationState.action))
+        } else if snapshot.itemIdentifiers.isEmpty {
+            setBackgroundView(EmptyStateView(type: PersonalVoiceEmptyState.noContent))
+        } else {
+            setBackgroundView(nil)
+        }
+    }
+    
+    private func setBackgroundView(_ view: UIView?) {
+        collectionView.backgroundView = view
+        updateBackgroundViewLayoutMargins()
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateLayoutForCurrentTraitCollection()
+    }
+
+    private func updateLayoutForCurrentTraitCollection() {
+        collectionView.layout.interItemSpacing = .init(interRowSpacing: 8, interColumnSpacing: 30)
+
+        switch sizeClass {
+        case .hRegular_vRegular:
+            collectionView.layout.numberOfColumns = .fixedCount(2)
+            collectionView.layout.numberOfRows = .flexible(minHeight: .absolute(100))
+        case .hCompact_vRegular:
+            collectionView.layout.numberOfColumns = .fixedCount(1)
+            collectionView.layout.numberOfRows = .flexible(minHeight: .absolute(64))
+        case .hCompact_vCompact, .hRegular_vCompact:
+            collectionView.layout.numberOfColumns = .fixedCount(2)
+            collectionView.layout.numberOfRows = .flexible(minHeight: .absolute(64))
+        default:
+            break
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+    
+    private func updateBackgroundViewLayoutMargins() {
+        guard let backgroundView = collectionView.backgroundView else { return }
+        backgroundView.directionalLayoutMargins.leading = view.directionalLayoutMargins.leading
+        backgroundView.directionalLayoutMargins.trailing = view.directionalLayoutMargins.trailing
+    }
+    
+    fileprivate func handleVoiceSelection(_ voice: AVSpeechSynthesisVoice) {
+        AppConfig.selectedVoiceIdentifier = voice.identifier
+        updateDataSource()
+    }
+}
+
+enum PersonalVoiceEmptyState: EmptyStateRepresentable {
+    
+    case denied
+    case notAuthorized
+    case noContent
+    
+    var title: String {
+        return switch self {
+        case .denied: String(localized: "personal_voices.empty_state.denied.title")
+        case .notAuthorized: String(localized: "personal_voices.empty_state.not_authorized.title")
+        case .noContent: String(localized: "personal_voices.empty_state.no_content.title")
+        }
+    }
+    
+    var description: String? {
+        switch self {
+        case .denied:
+            let format = String(localized: "personal_voices.empty_state.denied.description")
+            return String(format: format, UIDevice.current.model)
+        case .noContent:
+            let format = String(localized: "personal_voices.empty_state.no_content.description")
+            return String(format: format, UIDevice.current.model)
+        case .notAuthorized:
+            return String(localized: "personal_voices.empty_state.not_authorized.description")
+        }
+    }
+    
+    var buttonTitle: String? {
+        return switch self {
+        case .denied: String(localized: "personal_voices.empty_state.denied.button.title")
+        case .notAuthorized: String(localized: "personal_voices.empty_state.not_authorized.button.title")
+        case .noContent: String(localized: "personal_voices.empty_state.no_content.button.title")
+        }
+    }
+}

--- a/Vocable/Features/Settings/VoiceSettings/VoiceProfilePreviewController.swift
+++ b/Vocable/Features/Settings/VoiceSettings/VoiceProfilePreviewController.swift
@@ -16,6 +16,7 @@ final class VoiceProfilePreviewController {
     enum PresentationContext {
         case selectedProfilePreview
         case voiceSelection
+        case personalVoice
     }
     
     let context: PresentationContext
@@ -34,6 +35,8 @@ final class VoiceProfilePreviewController {
             self.dataSource = .init(filter: .selectedVoice)
         case .voiceSelection:
             self.dataSource = .init(filter: .systemVoices)
+        case .personalVoice:
+            self.dataSource = .init(filter: .personalVoices)
         }
         
         synthesizer.delegate = self

--- a/Vocable/Features/Settings/VoiceSettings/VoiceProfilePreviewDataSource+Filter.swift
+++ b/Vocable/Features/Settings/VoiceSettings/VoiceProfilePreviewDataSource+Filter.swift
@@ -50,4 +50,14 @@ extension VoiceProfilePreviewDataSource.Filter {
             }
         }
     }
+
+    static var personalVoices: Self {
+        Self { (voice: AVSpeechSynthesisVoice, isSelected: Bool) in
+            if #available(iOS 17.0, *) {
+                return voice.voiceTraits.contains(.isPersonalVoice)
+            } else {
+                return false
+            }
+        }
+    }
 }

--- a/Vocable/Features/Settings/VoiceSettings/VoiceSettingsViewController.swift
+++ b/Vocable/Features/Settings/VoiceSettings/VoiceSettingsViewController.swift
@@ -14,11 +14,13 @@ final class VoiceSettingsViewController: VocableCollectionViewController {
 
     private enum Section: Hashable {
         case voicePreview
+        case personalVoice
     }
     
     private enum Item: Hashable {
         case selectedProfile(VoiceProfileItem)
         case voicePicker
+        case personalVoice
     }
     
     private enum SupplementaryKind: String {
@@ -66,6 +68,13 @@ final class VoiceSettingsViewController: VocableCollectionViewController {
         snapshot.appendSections([.voicePreview])
         snapshot.appendItems(items.map{.selectedProfile($0)})
         snapshot.appendItems([.voicePicker])
+        if #available(iOS 17.0, *) {
+            // Don't show the row if the device doesn't support the feature
+            if AVSpeechSynthesizer.personalVoiceAuthorizationStatus != .unsupported {
+                snapshot.appendSections([.personalVoice])
+                snapshot.appendItems([.personalVoice])
+            }
+        }
         dataSource.apply(snapshot, animatingDifferences: false)
     }
 
@@ -94,6 +103,15 @@ final class VoiceSettingsViewController: VocableCollectionViewController {
                     trailingAccessory: .disclosureIndicator()
                 ) { [weak self] in
                     self?.show(VoicePickerViewController(), sender: nil)
+                }
+            case .personalVoice:
+                if #available(iOS 17.0, *) {
+                    cell.contentConfiguration = VocableListContentConfiguration(
+                        title: String(localized: "voice_settings.cell.personal_voice.title"),
+                        trailingAccessory: .disclosureIndicator()
+                    ) { [weak self] in
+                        self?.show(PersonalVoiceViewController(), sender: nil)
+                    }
                 }
             }
         }
@@ -165,13 +183,11 @@ final class VoiceSettingsViewController: VocableCollectionViewController {
         section.contentInsets.top = 16
         section.contentInsets.bottom = 32
         
-        let footerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: sizeClass.contains(any: .compact) ? .estimated(50) : .estimated(100)
-        )
-        
-        switch sectionItem {
-        case .voicePreview:
+        if case .voicePreview = sectionItem {
+            let footerSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: sizeClass.contains(any: .compact) ? .estimated(50) : .estimated(100)
+            )
             let footer = NSCollectionLayoutBoundarySupplementaryItem(
                 layoutSize: footerSize,
                 elementKind: SupplementaryKind.voicePickerFooter.rawValue,
@@ -200,7 +216,7 @@ final class VoiceSettingsViewController: VocableCollectionViewController {
     
     func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
         let item = dataSource.itemIdentifier(for: indexPath)
-        if case .voicePicker = item {
+        if [.voicePicker, .personalVoice].contains(item) {
             return true
         }
         return false
@@ -208,7 +224,7 @@ final class VoiceSettingsViewController: VocableCollectionViewController {
 
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         let item = dataSource.itemIdentifier(for: indexPath)
-        if case .voicePicker = item {
+        if [.voicePicker, .personalVoice].contains(item) {
             return true
         }
         return false

--- a/Vocable/Supporting Files/en.lproj/Localizable.strings
+++ b/Vocable/Supporting Files/en.lproj/Localizable.strings
@@ -88,11 +88,43 @@ fails to return any viable voice profiles that the user could select from.*/
 /* Footer title that accompanies the button that will present the voice picker. This is meant to inform the user that additional voices can be downloaded from the system settings app. The parameter variable is substituted with the device model e.g. "iPad" or "iPhone". */
 "voice_settings.voice_picker_footer.title" = "Additional voices and voice quality enhancements may be available for download in %1$@ Settings.";
 
-/* In the voice configuration screen within the app's settings, this format is used to construct the phrase read aloud when the user selects a button to preview a voice profile. Each voice profile has a human-friendly name provided by the operating system, so the phrase is currently structured as if the voice profile is introducing itself. */
-"voice_preview.sample_audio.introducion_format" = "Hello, my name is %1$@";
+/* In the voice configuration screen within the app's settings, this format is used to construct the phrase read aloud when the user selects a button to preview a voice profile. Each voice profile has a name provided by the operating system, so the phrase is currently structured as if the voice profile is introducing itself. */
+"voice_preview.sample_audio.introducion_format" = "Hello, this is %1$@";
 
-/* Voice Configuration - Voice Picker - Voices */
+/* Button in the Voice Settings screen that will navigate the user to the voice picker/Change Voice screen */
 "voice_settings.cell.change_voice.title" = "Change Voice";
+
+/* Button in the Voice Settings screen that will navigate the user to the Personal Voice screen */
+"voice_settings.cell.personal_voice.title" = "Personal Voices";
+
+// MARK: Personal Voices detail screen
+
+/* Title of the Personal Voices screen */
+"personal_voices.title" = "Personal Voices";
+
+/* Title of the Personal Voices screen empty state when a user must grant access to the app. */
+"personal_voices.empty_state.denied.title" = "Personal Voice Access";
+
+/* Title of the Personal Voices screen empty state when a user has denied access to the app. */
+"personal_voices.empty_state.not_authorized.title" = "Personal Voice Access";
+
+/* Title of the Personal Voices screen empty state when there are no voices available on the device. */
+"personal_voices.empty_state.no_content.title" = "No Personal Voices";
+
+/* Empty state description for when Personal Voice access has been denied by the user. It informs the user how to re-enable access by navigating to system settings. The placeholder is the device model (e.g. "iPhone" or "iPad") */
+"personal_voices.empty_state.denied.description" = "Vocable needs permission to access Personal Voices on this device.\n\nYou can enable access in %1$@ Settings.";
+
+/* Empty state description for when Personal Voice access has not yet been prompted to the user. Below this text will be a button that will prompt the user for access. */
+"personal_voices.empty_state.not_authorized.description" = "Allow Vocable to access Personal Voices stored on this device.";
+
+/* Empty state description for when there are not personal voices to display. This is typically because the user has not created any yet. The placeholder is the device model (e.g. "iPhone" or "iPad"). */
+"personal_voices.empty_state.no_content.description" = "You can create a new Personal Voice in %1$@ Settings. Once created, you can set your Personal Voice as Vocable's voice.";
+
+/* Action button for the personal voices screen allowing the user to open the system settings app to resolve an error. */
+"personal_voices.empty_state.denied.button.title" = "Open Settings";
+
+/* Action button for the personal voices screen that will display a system prompt allowing access to their Personal Voice profiles stored on their device. */
+"personal_voices.empty_state.not_authorized.button.title" = "Grant Access";
 
 // MARK: Settings Screen Options strings
 


### PR DESCRIPTION
closes #728 

Extends the work from #730 and adds the option to use a Personal Voice. These two are meant to be taken together as one body of work, but they're being submitted as separate PRs to narrow the scope a little and also mirror the backlog tickets.