### PR TITLE
[747] Prospective UI test stability improvements

### DIFF
--- a/VocableUITests/Screens/CustomCategoriesScreen.swift
+++ b/VocableUITests/Screens/CustomCategoriesScreen.swift
@@ -24,62 +24,99 @@ class CustomCategoriesScreen: BaseScreen {
         return XCUIApplication().cells.matching(identifier: phraseId)
     }
     
-    static func createCustomCategory(categoryName: String) {
-        SettingsScreen.addCategoryButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
-        KeyboardScreen.typeText(categoryName)
-        KeyboardScreen.checkmarkAddButton.tap(afterWaitingForExistenceWithTimeout: 0.75)
+    static func createCustomCategory(
+        categoryName: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        try SettingsScreen.addCategoryButton.tapWhenExists(file: file, line: line)
+        try KeyboardScreen.typeText(categoryName, file: file, line: line)
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists(file: file, line: line)
     }
     
-    static func createAndLocateCustomCategory(_ categoryName: String) -> CategoryIdentifier {
-        createCustomCategory(categoryName: categoryName)
-        let customCategoryIdentifier = SettingsScreen.locateCategoryCell(categoryName).element.identifier
+    static func createAndLocateCustomCategory(
+        _ categoryName: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> CategoryIdentifier {
+        try createCustomCategory(categoryName: categoryName, file: file, line: line)
+        let customCategoryIdentifier = try SettingsScreen.locateCategoryCell(categoryName, file: file, line: line).identifier
         return CategoryIdentifier(customCategoryIdentifier)
     }
     
-    static func addPhrase(_ phrase: String) {
-        categoriesPageAddPhraseButton.tap()
-        _ = KeyboardScreen.checkmarkAddButton.waitForExistence(timeout: 0.75)
-        KeyboardScreen.typeText(phrase)
-        KeyboardScreen.checkmarkAddButton.tap()
-        _ = categoriesPageAddPhraseButton.waitForExistence(timeout: 0.5)
+    static func addPhrase(
+        _ phrase: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        try categoriesPageAddPhraseButton.tapWhenExists(file: file, line: line)
+        try KeyboardScreen.checkmarkAddButton.assertExistence(timeout: 1.0, file: file, line: line)
+        try KeyboardScreen.typeText(phrase, file: file, line: line)
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists(file: file, line: line)
     }
     
-    static func addRandomPhrases(numberOfPhrases: Int) {
+    static func addRandomPhrases(
+        numberOfPhrases: Int,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
         for _ in 1...numberOfPhrases {
             let randomPhrase = KeyboardScreen.randomString(length: 2)
-            categoriesPageAddPhraseButton.tap()
-            KeyboardScreen.typeText(randomPhrase)
-            KeyboardScreen.checkmarkAddButton.tap()
+            try categoriesPageAddPhraseButton.tapWhenExists(file: file, line: line)
+            try KeyboardScreen.typeText(randomPhrase, file: file, line: line)
+            try KeyboardScreen.checkmarkAddButton.tapWhenExists(file: file, line: line)
         }
-        _ = categoriesPageAddPhraseButton.waitForExistence(timeout: 0.5)
+        try categoriesPageAddPhraseButton.assertExistence(timeout: 1.0, file: file, line: line)
     }
     
-    static func returnToMainScreenFromCategoriesList() {
+    static func returnToMainScreenFromCategoriesList(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
         // Exit the Edit Categories and Settings Screens
-        navBarBackButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
-        navBarDismissButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
+        try navBarBackButton.tapWhenExists(file: file, line: line)
+        try navBarDismissButton.tapWhenExists(file: file, line: line)
         
         // Wait for the Main Screen to appear
-        XCTAssert(MainScreen.settingsButton.waitForExistence(timeout: 0.5), "Did not return to Main Screen as expected.")
+        try MainScreen.settingsButton.assertExistence(
+            timeout: 1.0,
+            "Did not return to main screen as expected",
+            file: file,
+            line: line
+        )
     }
     
-    static func returnToMainScreenFromCategoryDetails() {
-        navBarBackButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
-        returnToMainScreenFromCategoriesList()
+    static func returnToMainScreenFromCategoryDetails(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        try navBarBackButton.tapWhenExists(file: file, line: line)
+        try returnToMainScreenFromCategoriesList(file: file, line: line)
     }
     
-    static func returnToMainScreenFromEditPhrases() {
-        navBarBackButton.tap()
-        returnToMainScreenFromCategoryDetails()
+    static func returnToMainScreenFromEditPhrases(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        try navBarBackButton.tapWhenExists(file: file, line: line)
+        try returnToMainScreenFromCategoryDetails(file: file, line: line)
     }
     
-    static func navigateToSettingsCategoryScreenFromCategoryEditPhrases() {
+    static func navigateToSettingsCategoryScreenFromCategoryEditPhrases(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
         // Exit the Edit Phrases and Category Detail Screens
-        navBarBackButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
-        navBarBackButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
+        try navBarBackButton.tapWhenExists(file: file, line: line)
+        try navBarBackButton.tapWhenExists(file: file, line: line)
         
         // Wait for the Categories Screen to appear
-        XCTAssert(SettingsScreen.addCategoryButton.waitForExistence(timeout: 0.5), "Did not return to Settings Categories Screen as expected.")
+        try SettingsScreen.addCategoryButton.assertExistence(
+            timeout: 1.0,
+            "Did not return to Settings Categories Screen as expected.",
+            file: file,
+            line: line
+        )
     }
     
 }

--- a/VocableUITests/Screens/KeyboardScreen.swift
+++ b/VocableUITests/Screens/KeyboardScreen.swift
@@ -21,13 +21,18 @@ class KeyboardScreen: BaseScreen {
         _ textToType: String,
         file: StaticString = #file,
         line: UInt = #line
-    ) {
+    ) throws {
         // Ensure the keyboard is visible on screen before tapping any cells
-        if !keyboardCollectionView.waitForExistence(timeout: 0.5) {
-            XCTFail("Failed to locate keyboard", file: file, line: line)
-            return
-        }
+        try keyboardCollectionView.assertExistence(
+            timeout: 0.5,
+            "Failed to locate keyboard",
+            file: file,
+            line: line
+        )
         
+        // The entire keyboard is visible by design, so it is okay to
+        // not wait for the existence of each cell before tapping. It's
+        // a minor optimization, but the savings add up.
         for char in textToType {
             keyboardCollectionView.cells[.shared.keyboard.key("\(char)")].tap()
         }

--- a/VocableUITests/Screens/MainScreen.swift
+++ b/VocableUITests/Screens/MainScreen.swift
@@ -82,7 +82,11 @@ class MainScreen: BaseScreen {
     }
     
     /// Assuming there is at least one page of phrases within a category, locate the cell containing the given phrase.
-    static func locatePhraseCell(phrase: String) -> XCUIElement {
+    static func locatePhraseCell(
+        phrase: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> XCUIElement {
         let predicate = NSPredicate(format: "label MATCHES %@", phrase)
         
         // Loop through each custom category page to find our phrase
@@ -90,16 +94,20 @@ class MainScreen: BaseScreen {
             if app.cells.staticTexts.containing(predicate).element.exists {
                 break
             } else {
-                paginationRightButton.tap()
+                try paginationRightButton.tapWhenExists(file: file, line: line)
             }
         }
         return app.cells.staticTexts.containing(predicate).element
     }
     
-    static func navigateToSettingsAndOpenCategory(name: String) {
-        MainScreen.settingsButton.tap()
-        SettingsScreen.categoriesAndPhrasesCell.tap()
-        SettingsScreen.openCategorySettings(category: name)
+    static func navigateToSettingsAndOpenCategory(
+        name: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        try MainScreen.settingsButton.tapWhenExists(file: file, line: line)
+        try SettingsScreen.categoriesAndPhrasesCell.tapWhenExists(file: file, line: line)
+        try SettingsScreen.openCategorySettings(category: name, file: file, line: line)
     }
 
 }

--- a/VocableUITests/Screens/SettingsScreen.swift
+++ b/VocableUITests/Screens/SettingsScreen.swift
@@ -34,23 +34,35 @@ class SettingsScreen: BaseScreen {
 
     // MARK: Helpers
     
-    static func openCategorySettings(category: String) {
-        locateCategoryCell(category).staticTexts[category].tap()
+    static func openCategorySettings(
+        category: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        let categoryCell = try locateCategoryCell(category, file: file, line: line)
+        try categoryCell.buttons[.settings.editCategories.categoryButton]
+            .tapWhenExists(file: file, line: line)
     }
     
     @discardableResult
-    static func locateCategoryCell(_ category: String) -> XCUIElementQuery {
+    static func locateCategoryCell(
+        _ category: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> XCUIElement {
         let predicate = NSPredicate(format: "label CONTAINS %@", category)
         // Loop through each page to find our category
         for _ in 1...totalPageCount {
-            if cells.staticTexts.containing(predicate).element.exists{
-                break
+            let query = cells.containing(predicate)
+            let element = query.firstMatch
+            if element.waitForExistence(timeout: 0.5) {
+                return element
             } else {
-                paginationRightButton.tap()
+                try paginationRightButton.tapWhenExists(file: file, line: line)
             }
         }
-        
-        return categoryCellQuery(category)
+        XCTFail("Failed to locate cell for category named \"\(category)\"", file: file, line: line)
+        throw XCTestError(.timeoutWhileWaiting)
     }
     
     private static func categoryCellQuery(_ category: String) -> XCUIElementQuery {
@@ -60,7 +72,11 @@ class SettingsScreen: BaseScreen {
         return XCUIApplication().cells.containing(.staticText, identifier: cellLabel)
     }
     
-    static func doesCategoryExist(_ category: String) -> Bool {
+    static func doesCategoryExist(
+        _ category: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> Bool {
         var flag = false
         let predicate = NSPredicate(format: "label CONTAINS %@", category)
         
@@ -70,30 +86,40 @@ class SettingsScreen: BaseScreen {
                 flag = true
                 break
             } else {
-                MainScreen.paginationRightButton.tap()
+                try MainScreen.paginationRightButton.tapWhenExists(file: file, line: line)
             }
         }
         
         return flag
     }
     
-    static func navigateToCategory(category: String) {
+    static func navigateToCategory(
+        category: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
         while !otherElements.containing(.staticText, identifier: category).element.exists {
-            paginationRightButton.tap()
+            try paginationRightButton.tapWhenExists(file: file, line: line)
             if MainScreen.pageNumberText.label.contains("Page 1") {
                 break
             }
         }
     }
     
-    static func navigateToSettingsCategoryScreen() {
-        MainScreen.settingsButton.tap(afterWaitingForExistenceWithTimeout: 2)
-        categoriesAndPhrasesCell.tap(afterWaitingForExistenceWithTimeout: 3)
-        _ = addCategoryButton.waitForExistence(timeout: 0.5)
+    static func navigateToSettingsCategoryScreen(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        try MainScreen.settingsButton.tapWhenExists(timeout: 1.0, file: file, line: line)
+        try categoriesAndPhrasesCell.tapWhenExists(timeout: 1.0, file: file, line: line)
+        try addCategoryButton.assertExistence(timeout: 0.5, "Failed to locate add category button", file: file, line: line)
     }
     
-    static func returnToMainScreen() {
-        navBarDismissButton.tap()
+    static func returnToMainScreen(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        try navBarDismissButton.tapWhenExists(file: file, line: line)
     }
     
 }

--- a/VocableUITests/Tests/BaseTest.swift
+++ b/VocableUITests/Tests/BaseTest.swift
@@ -13,7 +13,7 @@ let app = XCUIApplication()
 
 class BaseTest: XCTestCase {
     
-    override func setUp() {
+    override func setUpWithError() throws {
         
         app.configure {
             Arguments(.resetAppDataOnLaunch, .enableListeningMode, .disableAnimations)
@@ -25,6 +25,9 @@ class BaseTest: XCTestCase {
             alert.buttons["OK"].tap()
             return true
         }
+        
+        // Ensure the main screen has loaded before continuing
+        try MainScreen.outputText.assertExistence(timeout: 2.0, "Did not arrive on main screen")
     }
     
     override func tearDown() {

--- a/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
+++ b/VocableUITests/Tests/CategoryPhrasesPaginationTests.swift
@@ -10,10 +10,10 @@ import XCTest
 
 class CategoryPhrasesPaginationTests: PaginationBaseTest {
     
-    func testCanNavigatePages() {
+    func testCanNavigatePages() throws {
         // Navigate to our test category
-        MainScreen.navigateToSettingsAndOpenCategory(name: ninePhrasesCategory.presetCategory.utterance)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        try MainScreen.navigateToSettingsAndOpenCategory(name: ninePhrasesCategory.presetCategory.utterance)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
         
         // Verify that the user is on the first page and the next page buttons are enabled.
         VTAssertPaginationEquals(1, of: 2, enabledArrows: .both)
@@ -21,28 +21,28 @@ class CategoryPhrasesPaginationTests: PaginationBaseTest {
         // Use the RIGHT pagination button to traverse the pages, ending back on "Page 1 of X"
         for pageNumber in 1...CustomCategoriesScreen.totalPageCount {
             XCTAssertEqual(CustomCategoriesScreen.currentPageNumber, pageNumber)
-            CustomCategoriesScreen.paginationRightButton.tap()
+            try CustomCategoriesScreen.paginationRightButton.tapWhenExists()
         }
         XCTAssertEqual(CustomCategoriesScreen.currentPageNumber, 1) // Confirm we return to the first page
         
         // Use the LEFT pagination button to traverse the pages, ending back on "Page 1 of X"
         for pageNumber in stride(from: CustomCategoriesScreen.totalPageCount, through: 1, by: -1) {
-            CustomCategoriesScreen.paginationLeftButton.tap()
+            try CustomCategoriesScreen.paginationLeftButton.tapWhenExists()
             XCTAssertEqual(CustomCategoriesScreen.currentPageNumber, pageNumber)
         }
     }
     
-    func testPagesAdjustToNewPhrases() {
+    func testPagesAdjustToNewPhrases() throws {
         // Verify that the user is on the first page.
-        MainScreen.navigateToSettingsAndOpenCategory(name: twoPhrasesCategory.presetCategory.utterance)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
+        try MainScreen.navigateToSettingsAndOpenCategory(name: twoPhrasesCategory.presetCategory.utterance)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
         
         // Pagination should be disabled when this scenario begins
         VTAssertPaginationArrowsEqual(.none)
         
         // Add phrases and ensure that the page counts update when a page overflows
         let pageCountBeforeAdditions = BaseScreen.totalPageCount
-        CustomCategoriesScreen.addRandomPhrases(numberOfPhrases: 10)
+        try CustomCategoriesScreen.addRandomPhrases(numberOfPhrases: 10)
         XCTAssertGreaterThan(BaseScreen.totalPageCount, pageCountBeforeAdditions)
         
         // Pagination should be enabled after the overflow
@@ -51,8 +51,8 @@ class CategoryPhrasesPaginationTests: PaginationBaseTest {
         // Remove the additional phrases to verify that the page count reduces and arrows become disabled
         let pageCountBeforeDeletions = BaseScreen.totalPageCount
         for _ in 1...10 {
-            CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
-            SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
+            try CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tapWhenExists()
+            try SettingsScreen.alertDeleteButton.tapWhenExists()
         }
         XCTAssertLessThan(BaseScreen.totalPageCount, pageCountBeforeDeletions)
         
@@ -61,10 +61,10 @@ class CategoryPhrasesPaginationTests: PaginationBaseTest {
     }
     
     // It is expected that the pagination left and right arrows are disabled when there is only 1 total page
-    func testNextPageButtonsDisabled() {
+    func testNextPageButtonsDisabled() throws {
         // Navigate to our test category and open the 'Edit Phrases' screen
-        MainScreen.navigateToSettingsAndOpenCategory(name: twoPhrasesCategory.presetCategory.utterance)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        try MainScreen.navigateToSettingsAndOpenCategory(name: twoPhrasesCategory.presetCategory.utterance)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
         
         // Verify the page counts and that buttons appear; both buttons are disabled.
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)

--- a/VocableUITests/Tests/CustomCategoryAppRestartTests.swift
+++ b/VocableUITests/Tests/CustomCategoryAppRestartTests.swift
@@ -15,7 +15,7 @@ class CustomCategoryAppRestartTests: XCTestCase {
     let secondCustomCategory: String = "Second"
     let phrase: String = "Test"
 
-    override func setUp() {
+    override func setUpWithError() throws {
         let app = XCUIApplication()
         app.configure {
             Arguments(.resetAppDataOnLaunch, .disableAnimations)
@@ -24,45 +24,45 @@ class CustomCategoryAppRestartTests: XCTestCase {
         app.launch()
         
         // Create a custom category
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        CustomCategoriesScreen.createCustomCategory(categoryName: firstCustomCategory)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try CustomCategoriesScreen.createCustomCategory(categoryName: firstCustomCategory)
     }
     
-    func testCategoryAndPhraseCustomizationPersists() {
+    func testCategoryAndPhraseCustomizationPersists() throws {
         // Verify that custom category exists
-        XCTAssertTrue(SettingsScreen.doesCategoryExist(firstCustomCategory))
+        XCTAssertTrue(try SettingsScreen.doesCategoryExist(firstCustomCategory))
         
         // Add a custom phrase to the custom category and verify that it exists
-        SettingsScreen.openCategorySettings(category: firstCustomCategory)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
-        CustomCategoriesScreen.addPhrase(phrase)
+        try SettingsScreen.openCategorySettings(category: firstCustomCategory)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
+        try CustomCategoriesScreen.addPhrase(phrase)
         XCTAssertTrue(CustomCategoriesScreen.phraseDoesExist(phrase))
      
         // Restart the app
         Utilities.restartApp()
         
         // Navigate to Settings Category Screen
-        SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
         
         // Verify that the custom category and phrase persist after restarting
-        XCTAssertTrue(SettingsScreen.doesCategoryExist(firstCustomCategory))
+        XCTAssertTrue(try SettingsScreen.doesCategoryExist(firstCustomCategory))
         
-        SettingsScreen.openCategorySettings(category: firstCustomCategory)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        try SettingsScreen.openCategorySettings(category: firstCustomCategory)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
         XCTAssertTrue(CustomCategoriesScreen.phraseDoesExist(phrase))
     }
     
-    func testHideCategoryPersists() {
+    func testHideCategoryPersists() throws {
         // Verify that custom category exists
-        XCTAssertTrue(SettingsScreen.doesCategoryExist(firstCustomCategory))
+        XCTAssertTrue(try SettingsScreen.doesCategoryExist(firstCustomCategory))
         
         // Verify that when the custom category is shown (last in the list), up button is enabled and down button is disabled
         VTAssertReorderArrowsEqual(.upEnabledOnly, for: firstCustomCategory)
         
         // Hide the custom category
-        SettingsScreen.openCategorySettings(category: firstCustomCategory)
-        SettingsScreen.showCategoryButton.tap()
-        SettingsScreen.navBarBackButton.tap()
+        try SettingsScreen.openCategorySettings(category: firstCustomCategory)
+        try SettingsScreen.showCategoryButton.tapWhenExists()
+        try SettingsScreen.navBarBackButton.tapWhenExists()
         
         // Verify that when the category is hidden, up and down buttons are disabled
         VTAssertReorderArrowsEqual(.none, for: firstCustomCategory)
@@ -71,18 +71,18 @@ class CustomCategoryAppRestartTests: XCTestCase {
         Utilities.restartApp()
         
         // Verify that after restart, hidden category's up and down buttons are disabled
-        SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
         VTAssertReorderArrowsEqual(.none, for: firstCustomCategory)
     }
     
-    func testReorderPersists() {
+    func testReorderPersists() throws {
         // Verify that first custom category exists
-        XCTAssertTrue(SettingsScreen.doesCategoryExist(firstCustomCategory))
+        XCTAssertTrue(try SettingsScreen.doesCategoryExist(firstCustomCategory))
         
         // Create second custom category and verify that it exists
-        CustomCategoriesScreen.createCustomCategory(categoryName: secondCustomCategory)
-        let _ = SettingsScreen.navBarBackButton.waitForExistence(timeout: 1)
-        XCTAssertTrue(SettingsScreen.doesCategoryExist(secondCustomCategory))
+        try CustomCategoriesScreen.createCustomCategory(categoryName: secondCustomCategory)
+        try SettingsScreen.navBarBackButton.assertExistence(timeout: 1.0)
+        XCTAssertTrue(try SettingsScreen.doesCategoryExist(secondCustomCategory))
         
         // Verify that first custom category's up and down buttons are enabled
         VTAssertReorderArrowsEqual(.both, for: firstCustomCategory)
@@ -91,9 +91,9 @@ class CustomCategoryAppRestartTests: XCTestCase {
         VTAssertReorderArrowsEqual(.upEnabledOnly, for: secondCustomCategory)
         
         // Reorder custom categories, move first custom category to the end of the list
-        let firstCategory = SettingsScreen.locateCategoryCell(firstCustomCategory)
-        firstCategory.buttons[.settings.editCategories.moveDownButton].tap()
-        let _ = SettingsScreen.navBarBackButton.waitForExistence(timeout: 1)
+        let firstCategory = try SettingsScreen.locateCategoryCell(firstCustomCategory)
+        try firstCategory.buttons[.settings.editCategories.moveDownButton].tapWhenExists()
+        try SettingsScreen.navBarBackButton.assertExistence(timeout: 1.0)
         
         // Verify that first custom category's (last in the list), up button is enabled and down button is disabled
         VTAssertReorderArrowsEqual(.upEnabledOnly, for: firstCustomCategory)
@@ -103,7 +103,7 @@ class CustomCategoryAppRestartTests: XCTestCase {
         
         // Restart the app and navigate to Settings Category Screen
         Utilities.restartApp()
-        SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
         
         // Verify that first custom category's (last in the list), up button is enabled and down button is disabled
         VTAssertReorderArrowsEqual(.upEnabledOnly, for: firstCustomCategory)

--- a/VocableUITests/Tests/CustomCategoryBaseTest.swift
+++ b/VocableUITests/Tests/CustomCategoryBaseTest.swift
@@ -13,10 +13,9 @@ class CustomCategoryBaseTest: BaseTest {
     private(set) var customCategoryName: String = "Test"
     private(set) var nameSuffix: String = "add"
     
-    override func setUp() {
-        super.setUp()
-        
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        CustomCategoriesScreen.createCustomCategory(categoryName: customCategoryName)
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try CustomCategoriesScreen.createCustomCategory(categoryName: customCategoryName)
     }
 }

--- a/VocableUITests/Tests/CustomCategoryTests.swift
+++ b/VocableUITests/Tests/CustomCategoryTests.swift
@@ -10,100 +10,100 @@ import XCTest
 
 class CustomCategoryTests: CustomCategoryBaseTest {
     
-    func testAddCustomCategory() {
-        XCTAssertTrue(SettingsScreen.locateCategoryCell(customCategoryName).element.isEnabled)
-        XCTAssertTrue(SettingsScreen.locateCategoryCell(customCategoryName).element.exists)
+    func testAddCustomCategory() throws {
+        let categoryCell = try SettingsScreen.locateCategoryCell(customCategoryName)
+        XCTAssertTrue(categoryCell.isEnabled)
     }
     
-    func testCanContinueEditingCategoryName() {
+    func testCanContinueEditingCategoryName() throws {
         let renamedCategory = customCategoryName + nameSuffix
         
-        SettingsScreen.openCategorySettings(category: customCategoryName)
-        SettingsScreen.renameCategoryButton.tap()
-        KeyboardScreen.typeText(nameSuffix)
-        KeyboardScreen.navBarDismissButton.tap()
-        XCTAssertTrue(KeyboardScreen.alertMessageLabel.exists)
+        try SettingsScreen.openCategorySettings(category: customCategoryName)
+        try SettingsScreen.renameCategoryButton.tapWhenExists()
+        try KeyboardScreen.typeText(nameSuffix)
+        try KeyboardScreen.navBarDismissButton.tapWhenExists()
+        try KeyboardScreen.alertMessageLabel.assertExistence()
         
-        SettingsScreen.alertContinueButton.tap()
-        XCTAssertTrue(KeyboardScreen.keyboardTextView.staticTexts[renamedCategory].exists)
+        try SettingsScreen.alertContinueButton.tapWhenExists()
+        try KeyboardScreen.keyboardTextView.staticTexts[renamedCategory].assertExistence()
 
-        KeyboardScreen.checkmarkAddButton.tap()
-        SettingsScreen.navBarBackButton.tap()
-        XCTAssertTrue(SettingsScreen.locateCategoryCell(renamedCategory).element.isEnabled)
-        XCTAssertTrue(SettingsScreen.locateCategoryCell(renamedCategory).element.exists)
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists()
+        try SettingsScreen.navBarBackButton.tapWhenExists()
+        let renamedCategoryCell = try SettingsScreen.locateCategoryCell(renamedCategory)
+        XCTAssertTrue(renamedCategoryCell.isEnabled)
    }
     
-    func testCanDiscardEditingCategoryName() {
-        SettingsScreen.openCategorySettings(category: customCategoryName)
-        SettingsScreen.renameCategoryButton.tap()
-        KeyboardScreen.typeText(nameSuffix)
-        KeyboardScreen.navBarDismissButton.tap()
-        XCTAssertTrue(KeyboardScreen.alertMessageLabel.exists)
+    func testCanDiscardEditingCategoryName() throws {
+        try SettingsScreen.openCategorySettings(category: customCategoryName)
+        try SettingsScreen.renameCategoryButton.tapWhenExists()
+        try KeyboardScreen.typeText(nameSuffix)
+        try KeyboardScreen.navBarDismissButton.tapWhenExists()
+        try KeyboardScreen.alertMessageLabel.assertExistence()
         
-        SettingsScreen.alertDiscardButton.tap()
+        try SettingsScreen.alertDiscardButton.tapWhenExists()
         XCTAssertEqual(SettingsScreen.title.label, customCategoryName)
         
-        SettingsScreen.navBarBackButton.tap()
-        XCTAssertTrue(SettingsScreen.locateCategoryCell(customCategoryName).element.exists)
+        try SettingsScreen.navBarBackButton.tapWhenExists()
+        try SettingsScreen.locateCategoryCell(customCategoryName).assertExistence()
     }
     
-    func testCanRenameCategory() {
+    func testCanRenameCategory() throws {
         let renamedCategory = customCategoryName + nameSuffix
         
-        SettingsScreen.openCategorySettings(category: customCategoryName)
-        SettingsScreen.renameCategoryButton.tap()
-        KeyboardScreen.typeText(nameSuffix)
-        KeyboardScreen.checkmarkAddButton.tap()
+        try SettingsScreen.openCategorySettings(category: customCategoryName)
+        try SettingsScreen.renameCategoryButton.tapWhenExists()
+        try KeyboardScreen.typeText(nameSuffix)
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists()
         XCTAssertEqual(SettingsScreen.title.label, renamedCategory)
         
-        SettingsScreen.navBarBackButton.tap()
-        XCTAssertTrue(SettingsScreen.locateCategoryCell(renamedCategory).element.exists)
+        try SettingsScreen.navBarBackButton.tapWhenExists()
+        try SettingsScreen.locateCategoryCell(renamedCategory).assertExistence()
     }
     
-    func testCanRemoveCategory() {
-        XCTAssertTrue(SettingsScreen.doesCategoryExist(customCategoryName))
+    func testCanRemoveCategory() throws {
+        XCTAssertTrue(try SettingsScreen.doesCategoryExist(customCategoryName))
         
-        SettingsScreen.openCategorySettings(category: customCategoryName)
-        SettingsScreen.removeCategoryButton.tap()
-        SettingsScreen.alertRemoveButton.tap()
-        _ = SettingsScreen.addCategoryButton.waitForExistence(timeout: 0.5)
-        XCTAssertFalse(SettingsScreen.doesCategoryExist(customCategoryName))
+        try SettingsScreen.openCategorySettings(category: customCategoryName)
+        try SettingsScreen.removeCategoryButton.tapWhenExists()
+        try SettingsScreen.alertRemoveButton.tapWhenExists()
+        try SettingsScreen.addCategoryButton.assertExistence(timeout: 1.0)
+        XCTAssertFalse(try SettingsScreen.doesCategoryExist(customCategoryName))
     }
   
-    func testCanHideCategory() {
+    func testCanHideCategory() throws {
         // Verify that custom category is created
-        XCTAssertTrue(SettingsScreen.doesCategoryExist(customCategoryName))
+        XCTAssertTrue(try SettingsScreen.doesCategoryExist(customCategoryName))
         
         // Verify that custom category appears on the main screen
-        CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
+        try CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
         XCTAssertTrue(MainScreen.locateAndSelectCustomCategory(customCategoryName))
         
         // Hide the custom category
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: customCategoryName)
-        SettingsScreen.showCategoryButton.tap()
-        SettingsScreen.navBarBackButton.tap()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: customCategoryName)
+        try SettingsScreen.showCategoryButton.tapWhenExists()
+        try SettingsScreen.navBarBackButton.tapWhenExists()
         
         // Verify that when the category is hidden, up and down buttons are disabled.
-        let hiddenCategory = SettingsScreen.locateCategoryCell(customCategoryName)
+        let hiddenCategory = try SettingsScreen.locateCategoryCell(customCategoryName)
         XCTAssertFalse(hiddenCategory.buttons[.settings.editCategories.moveUpButton].isEnabled)
         XCTAssertFalse(hiddenCategory.buttons[.settings.editCategories.moveDownButton].isEnabled)
-        XCTAssertTrue(hiddenCategory.element.isEnabled)
+        XCTAssertTrue(hiddenCategory.isEnabled)
 
         // Verify that custom category doesn't appear on the main screen
-        CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
+        try CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
         XCTAssertFalse(MainScreen.locateAndSelectCustomCategory(customCategoryName))
         
         // Show the custom category
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: customCategoryName)
-        SettingsScreen.showCategoryButton.tap()
-        SettingsScreen.navBarBackButton.tap()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: customCategoryName)
+        try SettingsScreen.showCategoryButton.tapWhenExists()
+        try SettingsScreen.navBarBackButton.tapWhenExists()
         
         // Verify that when the category is shown, up button is enabled and down button is disabled.
-        let shownCategory = SettingsScreen.locateCategoryCell(customCategoryName)
+        let shownCategory = try SettingsScreen.locateCategoryCell(customCategoryName)
         XCTAssertTrue(shownCategory.buttons[.settings.editCategories.moveUpButton].isEnabled)
         XCTAssertFalse(shownCategory.buttons[.settings.editCategories.moveDownButton].isEnabled)
-        XCTAssertTrue(shownCategory.element.isEnabled)
+        XCTAssertTrue(shownCategory.isEnabled)
     }
 }

--- a/VocableUITests/Tests/CustomPhraseTests.swift
+++ b/VocableUITests/Tests/CustomPhraseTests.swift
@@ -33,75 +33,75 @@ class CustomPhraseTests: XCTestCase {
         app.launch()
     }
     
-    func testAddNewPhrase() {
+    func testAddNewPhrase() throws {
         let customPhrase = "dd"
         
         // Navigate to our test category
-        MainScreen.navigateToSettingsAndOpenCategory(name: emptyCategory.presetCategory.utterance)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        try MainScreen.navigateToSettingsAndOpenCategory(name: emptyCategory.presetCategory.utterance)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
 
         // Verify Phrase is not added if edits are discarded
-        CustomCategoriesScreen.categoriesPageAddPhraseButton.tap()
-        KeyboardScreen.typeText("A")
-        KeyboardScreen.navBarDismissButton.tap()
-        XCTAssertTrue(KeyboardScreen.alertMessageLabel.exists)
+        try CustomCategoriesScreen.categoriesPageAddPhraseButton.tapWhenExists()
+        try KeyboardScreen.typeText("A")
+        try KeyboardScreen.navBarDismissButton.tapWhenExists()
+        try KeyboardScreen.alertMessageLabel.assertExistence()
 
-        SettingsScreen.alertDiscardButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
-        XCTAssertTrue(CustomCategoriesScreen.emptyStateAddPhraseButton.exists)
+        try SettingsScreen.alertDiscardButton.tapWhenExists()
+        try CustomCategoriesScreen.emptyStateAddPhraseButton.assertExistence()
 
         // Verify Phrase can be added if continuing edit
-        CustomCategoriesScreen.categoriesPageAddPhraseButton.tap()
-        KeyboardScreen.typeText("A")
-        KeyboardScreen.navBarDismissButton.tap()
-        XCTAssertTrue(KeyboardScreen.alertMessageLabel.exists)
-        SettingsScreen.alertContinueButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
+        try CustomCategoriesScreen.categoriesPageAddPhraseButton.tapWhenExists()
+        try KeyboardScreen.typeText("A")
+        try KeyboardScreen.navBarDismissButton.tapWhenExists()
+        try KeyboardScreen.alertMessageLabel.assertExistence()
+        try SettingsScreen.alertContinueButton.tapWhenExists()
 
-        KeyboardScreen.typeText(customPhrase)
-        KeyboardScreen.checkmarkAddButton.tap()
+        try KeyboardScreen.typeText(customPhrase)
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists()
 
         XCTAssert(MainScreen.isTextDisplayed("A"+customPhrase), "Expected the phrase \("A"+customPhrase) to be displayed")
     }
 
-    func testCustomPhraseEdit() {
+    func testCustomPhraseEdit() throws {
         let editSuffix = "test"
         let phraseId = editableCategory.presetPhrases[0].id
         let updatedPhrase = editableCategory.presetPhrases[0].utterance + editSuffix
         
         // Navigate to our test category
-        MainScreen.navigateToSettingsAndOpenCategory(name: editableCategory.presetCategory.utterance)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        try MainScreen.navigateToSettingsAndOpenCategory(name: editableCategory.presetCategory.utterance)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
         
         // Edit an existing phrase
-        CustomCategoriesScreen.phraseCell(phraseId).buttons[.settings.editPhrases.editPhraseButton].tap()
-        KeyboardScreen.typeText("test")
-        KeyboardScreen.checkmarkAddButton.tap()
+        try CustomCategoriesScreen.phraseCell(phraseId).buttons[.settings.editPhrases.editPhraseButton].tapWhenExists()
+        try KeyboardScreen.typeText("test")
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists()
         
         // Verify phrase has been updated
         XCTAssert(MainScreen.isTextDisplayed(updatedPhrase), "Expected the phrase \(updatedPhrase) to be displayed")
     }
     
-    func testDeleteCustomPhrase() {
-        MainScreen.navigateToSettingsAndOpenCategory(name: editableCategory.presetCategory.utterance)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+    func testDeleteCustomPhrase() throws {
+        try MainScreen.navigateToSettingsAndOpenCategory(name: editableCategory.presetCategory.utterance)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
         
-        CustomCategoriesScreen.categoriesPageDeletePhraseButton.tap()
-        SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
-        XCTAssertTrue(CustomCategoriesScreen.emptyStateAddPhraseButton.exists, "Expected the phrase to be deleted")
+        try CustomCategoriesScreen.categoriesPageDeletePhraseButton.tapWhenExists()
+        try SettingsScreen.alertDeleteButton.tapWhenExists()
+        try CustomCategoriesScreen.emptyStateAddPhraseButton.assertExistence(timeout: 0.5, "Expected the phrase to be deleted")
     }
     
-    func testCanAddDuplicatePhrasesToCategories() {
+    func testCanAddDuplicatePhrasesToCategories() throws {
         // Navigate to our test category.
-        MainScreen.navigateToSettingsAndOpenCategory(name: editableCategory.presetCategory.utterance)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        try MainScreen.navigateToSettingsAndOpenCategory(name: editableCategory.presetCategory.utterance)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
 
         // Duplicate the phrase in this category.
         let originalPhraseId = editableCategory.presetPhrases[0].id
         let duplicatedPhrase = editableCategory.presetPhrases[0].utterance
-        CustomCategoriesScreen.addPhrase(duplicatedPhrase)
-        KeyboardScreen.createDuplicateButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
+        try CustomCategoriesScreen.addPhrase(duplicatedPhrase)
+        try KeyboardScreen.createDuplicateButton.tapWhenExists()
         
         // Wait for the keyboard to dismiss.
-        _ = CustomCategoriesScreen.navBarBackButton.waitForExistence(timeout: 0.5)
+        try CustomCategoriesScreen.navBarBackButton.assertExistence(timeout: 1.0)
         
         // Verify we now have 2 phrases, with matching labels, but unique identifiers.
         let allPhraseCells = XCUIApplication().cells

--- a/VocableUITests/Tests/KeyboardScreenTests.swift
+++ b/VocableUITests/Tests/KeyboardScreenTests.swift
@@ -11,48 +11,50 @@ import XCTest
 
 class KeyboardScreenTests: BaseTest {
     
-    func testKeyboardOutputIsDisplayed() {
+    func testKeyboardOutputIsDisplayed() throws {
         let testPhrase = "Test"
         
-        MainScreen.keyboardButton.tap()
-        KeyboardScreen.typeText(testPhrase)
+        try MainScreen.keyboardButton.tapWhenExists()
+        try KeyboardScreen.typeText(testPhrase)
        
-        XCTAssertTrue(KeyboardScreen.keyboardTextView.staticTexts[testPhrase].exists, "Expected the text \(testPhrase) to be displayed")
+        try KeyboardScreen.keyboardTextView.staticTexts[testPhrase]
+            .assertExistence("Expected the text \(testPhrase) to be displayed")
     }
   
-    func testAddPhraseToMySayingsFromKeyboard() {
+    func testAddPhraseToMySayingsFromKeyboard() throws {
         let testPhrase = "Test"
         
-        MainScreen.keyboardButton.tap()
-        KeyboardScreen.typeText(testPhrase)
-        KeyboardScreen.favoriteButton.tap()
-        KeyboardScreen.navBarDismissButton.tap()
+        try MainScreen.keyboardButton.tapWhenExists()
+        try KeyboardScreen.typeText(testPhrase)
+        try KeyboardScreen.favoriteButton.tapWhenExists()
+        try KeyboardScreen.navBarDismissButton.tapWhenExists()
         
         MainScreen.locateAndSelectDestinationCategory(.mySayings)
 
-        XCTAssertTrue(MainScreen.locatePhraseCell(phrase: testPhrase).exists, "Expected the phrase \(testPhrase) to be added to and displayed in 'My Sayings'")
+        try MainScreen.locatePhraseCell(phrase: testPhrase)
+            .assertExistence("Expected the phrase \(testPhrase) to be added to and displayed in 'My Sayings'")
     }
     
-    func testRemovePhraseFromMySayingsFromKeyboard() {
-       let testPhrase = "Test"
-       
-        MainScreen.keyboardButton.tap()
-        KeyboardScreen.typeText(testPhrase)
-        KeyboardScreen.favoriteButton.tap()
-        KeyboardScreen.navBarDismissButton.tap()
-       
-        MainScreen.locateAndSelectDestinationCategory(.mySayings)
-       
-        XCTAssertTrue(MainScreen.locatePhraseCell(phrase: testPhrase).exists, "Expected the phrase \(testPhrase) to be added to and displayed in 'My Sayings'")
+    func testRemovePhraseFromMySayingsFromKeyboard() throws {
+        let testPhrase = "Test"
         
-        MainScreen.keyboardButton.tap()
-        KeyboardScreen.typeText(testPhrase)
-        KeyboardScreen.favoriteButton.tap()
-        KeyboardScreen.navBarDismissButton.tap()
+        try MainScreen.keyboardButton.tapWhenExists()
+        try KeyboardScreen.typeText(testPhrase)
+        try KeyboardScreen.favoriteButton.tapWhenExists()
+        try KeyboardScreen.navBarDismissButton.tapWhenExists()
+        
+        MainScreen.locateAndSelectDestinationCategory(.mySayings)
+        
+        try MainScreen.locatePhraseCell(phrase: testPhrase).assertExistence("Expected the phrase \(testPhrase) to be added to and displayed in 'My Sayings'")
+        
+        try MainScreen.keyboardButton.tapWhenExists()
+        try KeyboardScreen.typeText(testPhrase)
+        try KeyboardScreen.favoriteButton.tapWhenExists()
+        try KeyboardScreen.navBarDismissButton.tapWhenExists()
         MainScreen.locateAndSelectDestinationCategory(.mySayings)
         
         // We expect 'My Sayings' to be empty now.
-        XCTAssertTrue(MainScreen.emptyStateAddPhraseButton.exists, "Expected the phrase \(testPhrase) to be deleted from 'My Sayings'")
+        try MainScreen.emptyStateAddPhraseButton.assertExistence("Expected the phrase \(testPhrase) to be deleted from 'My Sayings'")
     }
-     
+    
 }

--- a/VocableUITests/Tests/MainScreenPaginationTests.swift
+++ b/VocableUITests/Tests/MainScreenPaginationTests.swift
@@ -10,30 +10,30 @@ import XCTest
 
 class MainScreenPaginationTests: PaginationBaseTest {
     
-    func testDeletingPhrasesAdjustsPagination() {
+    func testDeletingPhrasesAdjustsPagination() throws {
         // Navigate to main screen to verify page numbers; expected to be "Page 1 of 2"
         VTAssertPaginationEquals(1, of: 2)
         
         // Delete one of the phrases to reduce the total number of pages to 1.
-        MainScreen.navigateToSettingsAndOpenCategory(name: eightPhrasesCategory.presetCategory.utterance)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
+        try MainScreen.navigateToSettingsAndOpenCategory(name: eightPhrasesCategory.presetCategory.utterance)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
         CustomCategoriesScreen.categoriesPageDeletePhraseButton.firstMatch.tap()
-        SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.5)
+        try SettingsScreen.alertDeleteButton.tapWhenExists()
         
         // Navigate back to the home screen to verify that the total pages reduced from 2 to 1.
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
+        try CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
     }
     
-    func testAddingPhrasesAdjustsPagination() {
+    func testAddingPhrasesAdjustsPagination() throws {
         // Navigate to our test category to verify initial page numbers; expected to be "Page 1 of 1"
         MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(sevenPhrasesCategory.presetCategory.id))
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
         
         // Use the '+ Add Phrase' button to add a new phrase
-        MainScreen.addPhraseButton.tap()
-        KeyboardScreen.typeText("A")
-        KeyboardScreen.checkmarkAddButton.tap()
+        try MainScreen.addPhraseButton.tapWhenExists()
+        try KeyboardScreen.typeText("A")
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists()
         
         // Verify that the pagination adjusts as expected
         VTAssertPaginationEquals(1, of: 2, enabledArrows: .both)
@@ -63,21 +63,21 @@ class MainScreenPaginationTests: PaginationBaseTest {
         VTAssertPaginationEquals(1, of: 2)
     }
     
-    func testPaginationAdjustsToDeviceOrientation() {        
+    func testPaginationAdjustsToDeviceOrientation() throws {
         // Verify we're on the first page
         MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(sevenPhrasesCategory.presetCategory.id))
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)
         
         // Rotate the device
         XCUIDevice.shared.orientation = .landscapeLeft
-        _ = MainScreen.settingsButton.waitForExistence(timeout: 1) // Wait for rotation to complete
+        try MainScreen.settingsButton.assertExistence(timeout: 1) // Wait for rotation to complete
         
         // Ensure that the total number of pages increases and the current page stays the same
         VTAssertPaginationEquals(1, of: 2, enabledArrows: .both)
         
         // Rotate back to Portrait
         XCUIDevice.shared.orientation = .portrait
-        _ = MainScreen.settingsButton.waitForExistence(timeout: 1) // Wait for rotation to complete
+        try MainScreen.settingsButton.assertExistence(timeout: 1) // Wait for rotation to complete
         
         // Verify that the pagination returns to initial state
         VTAssertPaginationEquals(1, of: 1, enabledArrows: .none)

--- a/VocableUITests/Tests/MainScreenTests.swift
+++ b/VocableUITests/Tests/MainScreenTests.swift
@@ -53,30 +53,30 @@ class MainScreenTests: XCTestCase {
         XCTAssertEqual(phraseTwo, secondTestCategory.presetPhrases[0].utterance)
     }
     
-    func testWhenTappingPhrase_ThenThatPhraseDisplaysOnOutputLabel() {
+    func testWhenTappingPhrase_ThenThatPhraseDisplaysOnOutputLabel() throws {
         let customTestCategories = [firstTestCategory,
                                     secondTestCategory,
                                     thirdTestCategory]
         for category in customTestCategories {
             let phrase = category.presetPhrases[0]
             MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(category.presetCategory.id))
-            _ = XCUIApplication().collectionViews.staticTexts.element(boundBy: 0).waitForExistence(timeout: 0.5)
-            XCUIApplication().cells[phrase.id].tap()
+            try app.collectionViews.staticTexts.element(boundBy: 0).assertExistence(timeout: 1.0)
+            try app.cells[phrase.id].tapWhenExists()
             XCTAssertEqual(MainScreen.outputText.label, phrase.utterance)
         }
     }
     
-    func testDisablingCategory() {
+    func testDisablingCategory() throws {
         let hiddenCategory = secondTestCategory
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        XCTAssertTrue(SettingsScreen.locateCategoryCell(hiddenCategory.presetCategory.utterance).element.exists)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.locateCategoryCell(hiddenCategory.presetCategory.utterance)
 
         // Navigate to the category and hide it.
-        SettingsScreen.openCategorySettings(category: hiddenCategory.presetCategory.utterance)
-        SettingsScreen.showCategoryButton.tap()
+        try SettingsScreen.openCategorySettings(category: hiddenCategory.presetCategory.utterance)
+        try SettingsScreen.showCategoryButton.tapWhenExists()
         
         // Return to the main screen
-        CustomCategoriesScreen.returnToMainScreenFromCategoryDetails()
+        try CustomCategoriesScreen.returnToMainScreenFromCategoryDetails()
         
         // Confirm that the category is no longer accessible.
         let isVisible = MainScreen.locateAndSelectDestinationCategory(CategoryIdentifier(hiddenCategory.presetCategory.id))

--- a/VocableUITests/Tests/PresetCategoryAppRestartTests.swift
+++ b/VocableUITests/Tests/PresetCategoryAppRestartTests.swift
@@ -27,18 +27,18 @@ class PresetCategoryAppRestartTests: XCTestCase {
         app.launch()
     }
     
-    func testAddedPhrasePersists() {
+    func testAddedPhrasePersists() throws {
         // Navigate to our test category and add a phrase
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: category)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: category)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
-        CustomCategoriesScreen.addPhrase(phrase)
+        try CustomCategoriesScreen.addPhrase(phrase)
         
         // Verify that phrase does exist in Category Details Screen
         XCTAssertTrue(CustomCategoriesScreen.phraseDoesExist(phrase))
         
         // Verify that phrase does exist in Main Screen
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
+        try CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.general)
         XCTAssertTrue(MainScreen.phraseDoesExist(phrase))
         
@@ -50,19 +50,19 @@ class PresetCategoryAppRestartTests: XCTestCase {
         XCTAssertTrue(MainScreen.phraseDoesExist(phrase))
     }
     
-    func testMySayingsAddedPhrasePersists() {
+    func testMySayingsAddedPhrasePersists() throws {
         let category = "My Sayings"
         // Navigate to our test category and add a phrase
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: category)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: category)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
-        CustomCategoriesScreen.addPhrase(phrase)
+        try CustomCategoriesScreen.addPhrase(phrase)
         
         // Verify that phrase does exist in Category Details Screen
         XCTAssertTrue(CustomCategoriesScreen.phraseDoesExist(phrase))
         
         // Verify that phrase does exist in Main Screen
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
+        try CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.mySayings)
         XCTAssertTrue(MainScreen.phraseDoesExist(phrase))
         
@@ -92,15 +92,15 @@ class PresetCategoryAppRestartTests: XCTestCase {
         XCTAssertTrue(MainScreen.phraseDoesExist(firstPhrase))
     }
     
-    func testHideCategoryPersists() {
+    func testHideCategoryPersists() throws {
         // Navigate to our test category
-        SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
         
         // Verify that when the first preset category is shown, up button is disabled and down button is enabled
         VTAssertReorderArrowsEqual(.downEnabledOnly, for: category)
         
         // Hide the preset category
-        SettingsScreen.openCategorySettings(category: category)
+        try SettingsScreen.openCategorySettings(category: category)
         SettingsScreen.showCategoryButton.tap()
         SettingsScreen.navBarBackButton.tap()
         
@@ -111,13 +111,13 @@ class PresetCategoryAppRestartTests: XCTestCase {
         Utilities.restartApp(withLaunchArguments: disableAnimationsOnly)
         
         // Verify that after restart, hidden category's up and down buttons are disabled
-        SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
         VTAssertReorderArrowsEqual(.none, for: category)
     }
     
-    func testReorderPersists() {
+    func testReorderPersists() throws {
         // Navigate to our test category
-        SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
         
         // Verify that first preset category's up button is disabled and down button is enabled
         VTAssertReorderArrowsEqual(.downEnabledOnly, for: category)
@@ -126,9 +126,9 @@ class PresetCategoryAppRestartTests: XCTestCase {
         VTAssertReorderArrowsEqual(.both, for: secondCategory)
         
         // Reorder categories, move first preset category to the second of the list
-        let firstCategory = SettingsScreen.locateCategoryCell(category)
+        let firstCategory = try SettingsScreen.locateCategoryCell(category)
         firstCategory.buttons[.settings.editCategories.moveDownButton].tap()
-        let _ = SettingsScreen.navBarBackButton.waitForExistence(timeout: 1)
+        try SettingsScreen.navBarBackButton.assertExistence(timeout: 1.0)
         
         // Verify that first preset category's (now second in the list) up and down buttons are enabled
         VTAssertReorderArrowsEqual(.both, for: category)
@@ -138,7 +138,7 @@ class PresetCategoryAppRestartTests: XCTestCase {
         
         // Restart the app and navigate to Settings Category Screen
         Utilities.restartApp(withLaunchArguments: disableAnimationsOnly)
-        SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
         
         // Verify that first preset category's (now second in the list) up and down buttons are enabled
         VTAssertReorderArrowsEqual(.both, for: category)
@@ -147,26 +147,26 @@ class PresetCategoryAppRestartTests: XCTestCase {
         VTAssertReorderArrowsEqual(.downEnabledOnly, for: secondCategory)
     }
     
-    func testRenameCategory() {
+    func testRenameCategory() throws {
         let categoryName = "Basic Needs"
         let nameSuffix = "add"
         let renamedCategory = categoryName + nameSuffix
         let categoryIdentifier = (CategoryIdentifier.basicNeeds).identifier
         
         //Rename the preset category
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: categoryName)
-        SettingsScreen.renameCategoryButton.tap()
-        KeyboardScreen.typeText(nameSuffix)
-        KeyboardScreen.checkmarkAddButton.tap()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: categoryName)
+        try SettingsScreen.renameCategoryButton.tapWhenExists()
+        try KeyboardScreen.typeText(nameSuffix)
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists()
         XCTAssertEqual(SettingsScreen.title.label, renamedCategory)
         
         // Confirm that the category is renamed from categories list
-        SettingsScreen.navBarBackButton.tap()
-        XCTAssertTrue(SettingsScreen.doesCategoryExist(renamedCategory))
+        try SettingsScreen.navBarBackButton.tapWhenExists()
+        XCTAssertTrue(try SettingsScreen.doesCategoryExist(renamedCategory))
         
         // Confirm that the category is renamed from main screen
-        CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
+        try CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
         MainScreen.locateAndSelectDestinationCategory(.basicNeeds)
         let isSelectedPredicate = NSPredicate(format: "isSelected == true")
         let query = XCUIApplication().cells.containing(isSelectedPredicate)
@@ -175,10 +175,10 @@ class PresetCategoryAppRestartTests: XCTestCase {
         
         // Restart the app and navigate to Settings Category Screen
         Utilities.restartApp(withLaunchArguments: disableAnimationsOnly)
-        SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
         
         // Confirm that the renamed category name persists
-        CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
+        try CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
         MainScreen.locateAndSelectDestinationCategory(.basicNeeds)
         XCTAssertEqual(query.staticTexts.element.label, renamedCategory)
     }

--- a/VocableUITests/Tests/PresetCategoryTests.swift
+++ b/VocableUITests/Tests/PresetCategoryTests.swift
@@ -11,25 +11,25 @@ import XCTest
 class PresetCategoryTests: BaseTest {
     let nameSuffix = "test"
     
-    func testRenameCategory() {
+    func testRenameCategory() throws {
         let categoryName = "General"
         let renamedCategory = categoryName + nameSuffix
         let categoryIdentifier = (CategoryIdentifier.general).identifier
         
         //Rename the preset category
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: categoryName)
-        SettingsScreen.renameCategoryButton.tap()
-        KeyboardScreen.typeText(nameSuffix)
-        KeyboardScreen.checkmarkAddButton.tap()
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: categoryName)
+        try SettingsScreen.renameCategoryButton.tapWhenExists()
+        try KeyboardScreen.typeText(nameSuffix)
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists()
         XCTAssertEqual(SettingsScreen.title.label, renamedCategory)
         
         // Confirm that the category is renamed from categories list
-        SettingsScreen.navBarBackButton.tap()
-        XCTAssertTrue(SettingsScreen.doesCategoryExist(renamedCategory))
+        try SettingsScreen.navBarBackButton.tapWhenExists()
+        XCTAssertTrue(try SettingsScreen.doesCategoryExist(renamedCategory))
         
         // Confirm that the category is renamed from main screen
-        CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
+        try CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
         MainScreen.locateAndSelectDestinationCategory(.general)
         let isSelectedPredicate = NSPredicate(format: "isSelected == true")
         let query = XCUIApplication().cells.containing(isSelectedPredicate)
@@ -37,34 +37,34 @@ class PresetCategoryTests: BaseTest {
         XCTAssertEqual(MainScreen.selectedCategoryCell.identifier, categoryIdentifier)
     }
     
-    func testRemoveCategory() {
+    func testRemoveCategory() throws {
         let categoryName = "Environment"
         
         //Remove the preset category
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: categoryName)
-        SettingsScreen.removeCategoryButton.tap()
-        SettingsScreen.alertRemoveButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: categoryName)
+        try SettingsScreen.removeCategoryButton.tapWhenExists()
+        try SettingsScreen.alertRemoveButton.tapWhenExists()
         
         // Confirm that the category is removed from categories list
-        _ = SettingsScreen.addCategoryButton.waitForExistence(timeout: 0.5)
-        XCTAssertFalse(SettingsScreen.doesCategoryExist(categoryName))
+        try SettingsScreen.addCategoryButton.assertExistence(timeout: 0.5)
+        XCTAssertFalse(try SettingsScreen.doesCategoryExist(categoryName))
         
         // Confirm that the category is removed from main screen
-        CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
+        try CustomCategoriesScreen.returnToMainScreenFromCategoriesList()
         XCTAssertFalse(MainScreen.locateAndSelectDestinationCategory(.environment))
     }
     
-    func testShowHideButtonIsDisabledForMySayingsCategory() {
+    func testShowHideButtonIsDisabledForMySayingsCategory() throws {
         let categoryName = "My Sayings"
         
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: categoryName)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: categoryName)
         XCTAssertFalse(SettingsScreen.showCategoryButton.isEnabled)
     }
     
     // For the first 5 preset categories, tap() the top left phrase, then verify that all selected phrases appear in "Recents"
-    func testRecentScreen_ShowsPressedButtons(){
+    func testRecentScreen_ShowsPressedButtons() throws {
         var listOfSelectedPhrases: [String] = []
         var firstPhrase = ""
         let listOfCategoriesToSkip: [String] = [CategoryIdentifier.keyPad.identifier,
@@ -86,7 +86,8 @@ class PresetCategoryTests: BaseTest {
         MainScreen.locateAndSelectDestinationCategory(.recents)
         
         for phrase in listOfSelectedPhrases {
-            XCTAssertTrue(MainScreen.locatePhraseCell(phrase: phrase).exists, "Expected \(phrase) to appear in Recents category")
+            try MainScreen.locatePhraseCell(phrase: phrase)
+                .assertExistence("Expected \(phrase) to appear in Recents category")
         }
     }
     

--- a/VocableUITests/Tests/PresetPhraseTests.swift
+++ b/VocableUITests/Tests/PresetPhraseTests.swift
@@ -9,40 +9,40 @@ import XCTest
 
 class PresetPhraseTests: BaseTest {
     
-    func testAddNewPhrase() {
+    func testAddNewPhrase() throws {
         let customPhrase = "Add"
         let category = "Environment"
                 
         // Navigate to our test category and Add a phrase
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: category)
-        CustomCategoriesScreen.editCategoryPhrasesButton.tap()
-        CustomCategoriesScreen.addPhrase(customPhrase)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: category)
+        try CustomCategoriesScreen.editCategoryPhrasesButton.tapWhenExists()
+        try CustomCategoriesScreen.addPhrase(customPhrase)
         
         // Verify that phrase does exist in Category Details Screen
         XCTAssertTrue(CustomCategoriesScreen.phraseDoesExist(customPhrase))
         
         // Verify that phrase does exist in Main Screen
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
+        try CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.environment)
         XCTAssertTrue(MainScreen.phraseDoesExist(customPhrase))
     }
     
-    func testEditPresetPhrase() {
+    func testEditPresetPhrase() throws {
         let customPhrase = "ab"
         let category = "Personal Care"
                 
         // Navigate to our test category
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: category)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: category)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Define the query that gives us the first phrase listed
         let originalPhrase = CustomCategoriesScreen.firstPhraseCell.staticTexts.firstMatch.label
         
-        CustomCategoriesScreen.firstPhraseCell.staticTexts[originalPhrase].tap()
-        KeyboardScreen.typeText(customPhrase)
-        KeyboardScreen.checkmarkAddButton.tap()
+        try CustomCategoriesScreen.firstPhraseCell.staticTexts[originalPhrase].tapWhenExists()
+        try KeyboardScreen.typeText(customPhrase)
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists()
    
         // Verify that the original phrase doesn't exist in Category Details Screen
         XCTAssertFalse(CustomCategoriesScreen.phraseDoesExist(originalPhrase))
@@ -52,71 +52,71 @@ class PresetPhraseTests: BaseTest {
         XCTAssertTrue(CustomCategoriesScreen.phraseDoesExist(updatedPhrase))
         
         // Verify that updated phrase exists in Main Screen
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
+        try CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.personalCare)
         XCTAssertTrue(MainScreen.phraseDoesExist(updatedPhrase))
     }
     
-    func testDeletePresetPhrase() {
+    func testDeletePresetPhrase() throws {
         let category = "Basic Needs"
                 
         // Navigate to our test category
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: category)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: category)
         CustomCategoriesScreen.editCategoryPhrasesButton.tap()
         
         // Define the query that gives us the first phrase listed
         let firstPhrase = CustomCategoriesScreen.firstPhraseCell.staticTexts.firstMatch.label
         
         CustomCategoriesScreen.firstPhraseCell.buttons[.settings.editPhrases.deletePhraseButton].tap()
-        SettingsScreen.alertDeleteButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
+        try SettingsScreen.alertDeleteButton.tapWhenExists()
         
         // Verify that phrase doesn't exist in Category Details Screen
         XCTAssertFalse(CustomCategoriesScreen.phraseDoesExist(firstPhrase))
         
         // Verify that phrase doesn't exist in Main Screen
-        CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
+        try CustomCategoriesScreen.returnToMainScreenFromEditPhrases()
         MainScreen.locateAndSelectDestinationCategory(.basicNeeds)
         XCTAssertFalse(MainScreen.phraseDoesExist(firstPhrase))
     }
     
-    func testEditPhrasesButtonIsDisabledForNumberPadCategory() {
+    func testEditPhrasesButtonIsDisabledForNumberPadCategory() throws {
         let categoryName = "123"
            
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: categoryName)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: categoryName)
         XCTAssertFalse(CustomCategoriesScreen.editCategoryPhrasesButton.isEnabled)
     }
         
-    func testEditPhrasesButtonIsDisabledForRecentsCategory() {
+    func testEditPhrasesButtonIsDisabledForRecentsCategory() throws {
         let categoryName = "Recents"
        
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        SettingsScreen.openCategorySettings(category: categoryName)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.openCategorySettings(category: categoryName)
         XCTAssertFalse(CustomCategoriesScreen.editCategoryPhrasesButton.isEnabled)
     }
         
-    func testAddDuplicatePhrasesToMySayings() {
+    func testAddDuplicatePhrasesToMySayings() throws {
         let testPhrase = "Test"
         
-        MainScreen.keyboardButton.tap()
-        KeyboardScreen.typeText(testPhrase)
-        KeyboardScreen.favoriteButton.tap()
-        KeyboardScreen.navBarDismissButton.tap()
+        try MainScreen.keyboardButton.tapWhenExists()
+        try KeyboardScreen.typeText(testPhrase)
+        try KeyboardScreen.favoriteButton.tapWhenExists()
+        try KeyboardScreen.navBarDismissButton.tapWhenExists()
        
         MainScreen.locateAndSelectDestinationCategory(.mySayings)
         XCTAssertTrue(MainScreen.phraseDoesExist(testPhrase), "Expected the first phrase \(testPhrase) to be added to and displayed in 'My Sayings'")
         
         // Add the same phrase again to the My Sayings
-        MainScreen.addPhraseButton.tap()
-        KeyboardScreen.typeText(testPhrase)
-        KeyboardScreen.checkmarkAddButton.tap()
-        KeyboardScreen.createDuplicateButton.tap(afterWaitingForExistenceWithTimeout: 0.25)
+        try MainScreen.addPhraseButton.tapWhenExists()
+        try KeyboardScreen.typeText(testPhrase)
+        try KeyboardScreen.checkmarkAddButton.tapWhenExists()
+        try KeyboardScreen.createDuplicateButton.tapWhenExists()
         
         // Assert that now we have two cells containing the same phrase
         let phrasePredicate = NSPredicate(format: "label MATCHES %@", testPhrase)
-        let phraseQuery = XCUIApplication().staticTexts.containing(phrasePredicate)
-        _ = phraseQuery.element.waitForExistence(timeout: 1)
+        let phraseQuery = app.staticTexts.containing(phrasePredicate)
+        try phraseQuery.element.assertExistence(timeout: 1.0)
         XCTAssertEqual(phraseQuery.count, 2, "Expected both phrases to be present in 'My Sayings'")
     }
 }

--- a/VocableUITests/Tests/SettingsScreenTests.swift
+++ b/VocableUITests/Tests/SettingsScreenTests.swift
@@ -11,29 +11,29 @@ import XCTest
 
 class SettingsScreenTests: BaseTest {
 
-    func testHideShowToggle() {
+    func testHideShowToggle() throws {
         let category = "Environment"
 
-        SettingsScreen.navigateToSettingsCategoryScreen()
-        XCTAssertTrue(SettingsScreen.locateCategoryCell(category).element.exists)
+        try SettingsScreen.navigateToSettingsCategoryScreen()
+        try SettingsScreen.locateCategoryCell(category).assertExistence()
 
         // Verify that when the category is hidden, up and down buttons are disabled.
-        SettingsScreen.openCategorySettings(category: category)
-        SettingsScreen.showCategoryButton.tap()
-        SettingsScreen.navBarBackButton.tap()
+        try SettingsScreen.openCategorySettings(category: category)
+        try SettingsScreen.showCategoryButton.tapWhenExists()
+        try SettingsScreen.navBarBackButton.tapWhenExists()
         
         VTAssertReorderArrowsEqual(.none, for: category)
 
         // Verify that when the category is shown, up and down buttons are enabled.
-        SettingsScreen.openCategorySettings(category: category)
-        SettingsScreen.showCategoryButton.tap()
-        SettingsScreen.navBarBackButton.tap()
+        try SettingsScreen.openCategorySettings(category: category)
+        try SettingsScreen.showCategoryButton.tapWhenExists()
+        try SettingsScreen.navBarBackButton.tapWhenExists()
         
         VTAssertReorderArrowsEqual(.both, for: category)
     }
 
-    func testReorder() {
-        SettingsScreen.navigateToSettingsCategoryScreen()
+    func testReorder() throws {
+        try SettingsScreen.navigateToSettingsCategoryScreen()
         
         // Define the query that gives us the first category listed
         let currentFirstCategory = XCUIApplication().cells.allElementsBoundByIndex[0]
@@ -51,7 +51,7 @@ class SettingsScreenTests: BaseTest {
         XCTAssertTrue(currentSecondCategory.buttons[.settings.editCategories.moveDownButton].isEnabled)
         
         // Move the first category down one
-        currentFirstCategory.buttons[.settings.editCategories.moveDownButton].tap()
+        try currentFirstCategory.buttons[.settings.editCategories.moveDownButton].tapWhenExists()
         
         // Using the query for the first category (i.e. top most cell in list) confirm the category name matches expectations
         XCTAssertEqual(currentFirstCategory.label, originalSecondCategoryName)
@@ -60,7 +60,7 @@ class SettingsScreenTests: BaseTest {
         XCTAssertEqual(currentSecondCategory.label, originalFirstCategoryName)
         
         // Move the second category back up
-        currentSecondCategory.buttons[.settings.editCategories.moveUpButton].tap()
+        try currentSecondCategory.buttons[.settings.editCategories.moveUpButton].tapWhenExists()
         
         // Using the query for the first category (i.e. top most cell in list) confirm the category name matches expectations
         XCTAssertEqual(currentFirstCategory.label, originalFirstCategoryName)

--- a/VocableUITests/VocableTestAsserts.swift
+++ b/VocableUITests/VocableTestAsserts.swift
@@ -69,7 +69,10 @@ func VTAssertReorderArrowsEqual(
     file: StaticString = #file,
     line: UInt = #line
 ) {
-    let categoryCell = SettingsScreen.locateCategoryCell(categoryName)
-    XCTAssertEqual(categoryCell.buttons[.settings.editCategories.moveUpButton].isEnabled, enabledArrows.contains(.up), file: file, line: line)
-    XCTAssertEqual(categoryCell.buttons[.settings.editCategories.moveDownButton].isEnabled, enabledArrows.contains(.down), file: file, line: line)
+    guard let query = try? SettingsScreen.locateCategoryCell(categoryName, file: file, line: line) else {
+        XCTFail("Failed to locate category cell: \"\(categoryName)\"", file: file, line: line)
+        return
+    }
+    XCTAssertEqual(query.buttons[.settings.editCategories.moveUpButton].isEnabled, enabledArrows.contains(.up), file: file, line: line)
+    XCTAssertEqual(query.buttons[.settings.editCategories.moveDownButton].isEnabled, enabledArrows.contains(.down), file: file, line: line)
 }

--- a/VocableUITests/XCUIElement.swift
+++ b/VocableUITests/XCUIElement.swift
@@ -15,15 +15,26 @@ extension XCUIElement {
     ///
     /// Returns false if the timeout expires without the element coming into existence. In this case, the `tap` action
     /// will not occur.
-    func tap(afterWaitingForExistenceWithTimeout timeout: TimeInterval,
-             file: StaticString = #file,
-             line: UInt = #line)
-    {
-        guard self.waitForExistence(timeout: timeout) else {
-            XCTFail("Element did not come into existence before timeout.", file: file, line: line)
-            return
-        }
+    func tapWhenExists(
+        timeout: TimeInterval = 0.5,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        try assertExistence(timeout: timeout, file: file, line: line)
         self.tap()
+    }
+    
+    func assertExistence(
+        timeout: TimeInterval = 0.5,
+        _ message: String? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        guard self.waitForExistence(timeout: timeout) else {
+            let message = message ?? "Element did not come into existence before timeout."
+            XCTFail(message, file: file, line: line)
+            throw XCTestError(.timeoutWhileWaiting)
+        }
     }
     
 }


### PR DESCRIPTION
This PR doesn't quite normalize the _entire_ suite (yet), but it attempts to improve the underpinnings of the `testPagesAdjustToNewPhrases` test, which currently fails intermittently. Any other tests that share those underpinnings have been updated to match.

1. `throws` has been introduced into many helper functions. This may not be strictly necessary, but it allows the Swift code to read more clearly, showing how/when a failure might occur. We can dial that back as it makes sense.
2. `tap(afterWaitingForExistenceWithTimeout:)` has been replaced with `tapWhenExists(timeout: TimeInterval = 0.5)`. This makes the call site more concise and provides a default timeout value.
3. File/line parameters for XCT* assertions are more consistently propagated to improve diagnostics when a failure does occur. There may be a few calls I missed along the way, but the situation should be generally improved.
