### PR TITLE
[753] Localize version information in Settings screen

### DIFF
--- a/CrowdinExport/en.xliff
+++ b/CrowdinExport/en.xliff
@@ -576,6 +576,11 @@ Head tracking is supported on all devices with a %4$@ camera, and on most device
 Head tracking is supported on all devices with a %4$@ camera, and on most devices with %6$@.</target>
         <note>Additonal footer text noting heading tracking compatibility</note>
       </trans-unit>
+      <trans-unit id="settings.version_format" xml:space="preserve">
+        <source>Version %1$@</source>
+        <target state="new">Version %1$@</target>
+        <note>Version information displayed at the bottom of the Settings screen. Argument is the application version.</note>
+      </trans-unit>
       <trans-unit id="text_editor.alert.cancel_editing_confirmation.button.continue_editing.title" xml:space="preserve">
         <source>Continue Editing</source>
         <target state="translated">Continue Editing</target>

--- a/Vocable/Features/Settings/SettingsViewController.swift
+++ b/Vocable/Features/Settings/SettingsViewController.swift
@@ -124,11 +124,22 @@ final class SettingsViewController: VocableCollectionViewController, MFMailCompo
         }
     }
 
-    static private var versionAndBuildNumber: String {
-        let versionNumber = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
-        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
-        return "Version \(versionNumber)-\(buildNumber)"
-    }
+    static private let versionAndBuildNumber: String = {
+        guard
+            let infoDict = Bundle.main.infoDictionary,
+            let versionNumber = infoDict["CFBundleShortVersionString"] as? String,
+            let buildNumber = infoDict["CFBundleVersion"] as? String
+        else {
+            return ""
+        }
+        let joinedVersion = "\(versionNumber) (\(buildNumber))"
+        let format = String(
+            localized: "settings.version_format",
+            defaultValue: "Version %1$@",
+            comment: "Version information displayed at the bottom of the Settings screen. Argument is the application version."
+        )
+        return String(format: format, joinedVersion)
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Vocable/Supporting Files/Localizable.xcstrings
+++ b/Vocable/Supporting Files/Localizable.xcstrings
@@ -8406,6 +8406,18 @@
         }
       }
     },
+    "settings.version_format" : {
+      "comment" : "Version information displayed at the bottom of the Settings screen. Argument is the application version.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Version %1$@"
+          }
+        }
+      }
+    },
     "text_editor.alert.cancel_editing_confirmation.button.continue_editing.title" : {
       "comment" : "Button in the edit category title close confirmation. This button appears in an alert when there are edits made to the Category title and the user tries to close the keyboard without saving the changes. Pressing the button will allow editing the category title.",
       "localizations" : {


### PR DESCRIPTION
closes #753

Localizes the version information at the bottom of the settings screen.