### PR TITLE
[755] Fix Please Move Closer to Device warning denied camera access

### DIFF
--- a/Vocable/HeadTracking/HeadGazeWindow.swift
+++ b/Vocable/HeadTracking/HeadGazeWindow.swift
@@ -64,7 +64,7 @@ class HeadGazeWindow: UIWindow {
     }
 
     func presentHeadTrackingErrorToastIfNeeded() {
-        guard !UIApplication.shared.isGazeTrackingActive, AppConfig.isHeadTrackingEnabled, !trackingDisabledByTouch else {
+        guard UIApplication.shared.isGazeTrackingActive, AppConfig.isHeadTrackingEnabled, !trackingDisabledByTouch else {
             return
         }
         let title = String(localized: "gaze_tracking.error.excessive_head_distance.title")


### PR DESCRIPTION
Closes [755](https://github.com/willowtreeapps/vocable-ios/issues/755)

Fixes the `Please move closer to the Device` warning displayed unnecessarily after camera access was denied. 