### PR TITLE
BugFix - GH-826: Add compatibility error for personal voice.

### DIFF
--- a/Vocable/AppConfig/AppConfig.swift
+++ b/Vocable/AppConfig/AppConfig.swift
@@ -39,6 +39,39 @@ struct AppConfig {
         return ARFaceTrackingConfiguration.isSupported
     }
 
+    /// Personal Voice is supported when the device and OS support it (e.g. iPhone 12+, iOS 17+).
+    /// Note: `personalVoiceAuthorizationStatus` only returns `.unsupported` in the Simulator or on
+    /// non-iPhone platforms — NOT on older iPhones (e.g. iPhone 11) running iOS 17. Hardware support
+    /// is detected separately via the device model identifier.
+    static var isPersonalVoiceSupported: Bool {
+        if #available(iOS 17.0, *) {
+            let status = AVSpeechSynthesizer.personalVoiceAuthorizationStatus
+            if status == .unsupported {
+                return false
+            }
+            return isPersonalVoiceHardwareSupported
+        }
+        return false
+    }
+
+    /// Returns `true` if the device hardware supports Personal Voice (iPhone 12 or later).
+    /// Personal Voice model identifiers start at "iPhone13,x" (iPhone 12). The Simulator and
+    /// non-iPhone platforms are already handled by the `.unsupported` auth status check above.
+    private static var isPersonalVoiceHardwareSupported: Bool {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machine = withUnsafePointer(to: &systemInfo.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+                String(cString: $0)
+            }
+        }
+        guard machine.hasPrefix("iPhone") else { return true }
+        let version = machine.dropFirst("iPhone".count)
+        guard let major = version.split(separator: ",").first.flatMap({ Int($0) }) else { return true }
+        // iPhone 12 starts at "iPhone13,x"; iPhone 11 Pro Max is "iPhone12,5"
+        return major >= 13
+    }
+
     @PublishedDefault(.dwellDuration)
     static var selectionHoldDuration: TimeInterval = 1
 

--- a/Vocable/Features/Settings/VoiceSettings/PersonalVoicePermissionPromptController.swift
+++ b/Vocable/Features/Settings/VoiceSettings/PersonalVoicePermissionPromptController.swift
@@ -60,7 +60,9 @@ final class PersonalVoicePermissionPromptController {
                     self?.authorizationStatusDidChange(status)
                 }
             }
-        default:
+        case .unsupported: // Device or OS does not support Personal Voice
+            self.state = .init(state: .unsupported) { }
+        @unknown default:
             self.state = nil
         }
     }

--- a/Vocable/Features/Settings/VoiceSettings/PersonalVoiceViewController.swift
+++ b/Vocable/Features/Settings/VoiceSettings/PersonalVoiceViewController.swift
@@ -40,7 +40,13 @@ final class PersonalVoiceViewController: PagingCarouselViewController {
             }
             .store(in: &cancellables)
     }
-        
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Re-evaluate status when the screen appears (e.g. after returning from Settings or when API state updates)
+        updateDataSource()
+    }
+
     override func viewLayoutMarginsDidChange() {
         super.viewLayoutMarginsDidChange()
         updateBackgroundViewLayoutMargins()
@@ -87,7 +93,16 @@ final class PersonalVoiceViewController: PagingCarouselViewController {
         snapshot.appendSections([0])
         snapshot.appendItems(items)
         dataSource.apply(snapshot, animatingDifferences: false)
-        
+
+        // Show device/OS incompatibility when Personal Voice is not supported (same pattern as Listening Mode / head tracking)
+        if !AppConfig.isPersonalVoiceSupported {
+            isPaginationViewHidden = true
+            setBackgroundView(EmptyStateView(type: PersonalVoiceEmptyState.unsupported))
+            return
+        }
+
+        isPaginationViewHidden = false
+
         if let authorizationState {
             setBackgroundView(EmptyStateView(type: authorizationState.state, action: authorizationState.action))
         } else if snapshot.itemIdentifiers.isEmpty {

--- a/Vocable/Features/Settings/VoiceSettings/PersonalVoiceViewController.swift
+++ b/Vocable/Features/Settings/VoiceSettings/PersonalVoiceViewController.swift
@@ -146,19 +146,21 @@ final class PersonalVoiceViewController: PagingCarouselViewController {
 }
 
 enum PersonalVoiceEmptyState: EmptyStateRepresentable {
-    
+
     case denied
     case notAuthorized
     case noContent
-    
+    case unsupported
+
     var title: String {
         return switch self {
         case .denied: String(localized: "personal_voices.empty_state.denied.title")
         case .notAuthorized: String(localized: "personal_voices.empty_state.not_authorized.title")
         case .noContent: String(localized: "personal_voices.empty_state.no_content.title")
+        case .unsupported: String(localized: "personal_voices.empty_state.unsupported.title")
         }
     }
-    
+
     var description: String? {
         switch self {
         case .denied:
@@ -169,14 +171,20 @@ enum PersonalVoiceEmptyState: EmptyStateRepresentable {
             return String(format: format, UIDevice.current.model)
         case .notAuthorized:
             return String(localized: "personal_voices.empty_state.not_authorized.description")
+        case .unsupported:
+            let model = UIDevice.current.localizedModel
+            let systemName = UIDevice.current.systemName
+            let systemVersion = UIDevice.current.systemVersion
+            let format = String(localized: "personal_voices.empty_state.unsupported.description")
+            return String(format: format, model, systemName, systemVersion)
         }
     }
-    
+
     var buttonTitle: String? {
         return switch self {
         case .denied: String(localized: "personal_voices.empty_state.denied.button.title")
         case .notAuthorized: String(localized: "personal_voices.empty_state.not_authorized.button.title")
-        case .noContent: nil
+        case .noContent, .unsupported: nil
         }
     }
 }

--- a/Vocable/Features/Settings/VoiceSettings/VoiceSettingsViewController.swift
+++ b/Vocable/Features/Settings/VoiceSettings/VoiceSettingsViewController.swift
@@ -69,11 +69,9 @@ final class VoiceSettingsViewController: VocableCollectionViewController {
         snapshot.appendItems(items.map { .selectedProfile($0) })
         snapshot.appendItems([.voicePicker])
         if #available(iOS 17.0, *) {
-            // Don't show the row if the device doesn't support the feature
-            if AVSpeechSynthesizer.personalVoiceAuthorizationStatus != .unsupported {
-                snapshot.appendSections([.personalVoice])
-                snapshot.appendItems([.personalVoice])
-            }
+            // Always show the row on iOS 17+ so users can open the screen and see the compatibility message when unsupported (same pattern as Listening Mode)
+            snapshot.appendSections([.personalVoice])
+            snapshot.appendItems([.personalVoice])
         }
         dataSource.apply(snapshot, animatingDifferences: false)
     }

--- a/Vocable/Supporting Files/Localizable.xcstrings
+++ b/Vocable/Supporting Files/Localizable.xcstrings
@@ -4234,28 +4234,6 @@
         }
       }
     },
-    "personal_voices.empty_state.unsupported.description" : {
-      "comment" : "Empty state description when the device or OS does not support Personal Voice. Placeholders: device model (e.g. iPhone), system name (e.g. iOS), system version (e.g. 17.0).",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This %1$@ on %2$@ %3$@ does not support Personal Voice.\n\nPersonal Voice is available on iPhone 12 and later with iOS 17 or later."
-          }
-        }
-      }
-    },
-    "personal_voices.empty_state.unsupported.title" : {
-      "comment" : "Title of the Personal Voices screen empty state when the device or OS does not support Personal Voice.",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personal Voice Unsupported"
-          }
-        }
-      }
-    },
     "personal_voices.empty_state.not_authorized.button.title" : {
       "comment" : "Action button for the personal voices screen that will display a system prompt allowing access to their Personal Voice profiles stored on their device.",
       "localizations" : {
@@ -4501,6 +4479,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "個人語音訪問"
+          }
+        }
+      }
+    },
+    "personal_voices.empty_state.unsupported.description" : {
+      "comment" : "Empty state description when the device or OS does not support Personal Voice. Placeholders: device model (e.g. iPhone), system name (e.g. iOS), system version (e.g. 17.0).",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This %1$@ on %2$@ %3$@ does not support Personal Voice.\n\nPersonal Voice is available on iPhone 12/iPad Air (5th gen) and later with iOS 17 or later."
+          }
+        }
+      }
+    },
+    "personal_voices.empty_state.unsupported.title" : {
+      "comment" : "Title of the Personal Voices screen empty state when the device or OS does not support Personal Voice.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personal Voice Unsupported"
           }
         }
       }

--- a/Vocable/Supporting Files/Localizable.xcstrings
+++ b/Vocable/Supporting Files/Localizable.xcstrings
@@ -3907,79 +3907,79 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "يحتاج Vocable إلى إذن للوصول إلى الأصوات الشخصية على هذا الجهاز.\n\nيمكنك تمكين الوصول في إعدادات %1$@."
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable har brug for tilladelse til at tilgå personlige stemmer på denne enhed.\n\nDu kan aktivere adgang i %1$@ Indstillinger."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable benötigt die Berechtigung, um auf persönliche Stimmen auf diesem Gerät zuzugreifen.\n\nSie können den Zugriff in %1$@ Einstellungen aktivieren."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocable needs permission to access Personal Voices on this device.\n\nYou can enable access in %1$@ Settings."
+            "value" : "Vocable needs permission to access Personal Voices on this device.\n\nYou can enable access in %1$@ Settings.  NOTE: Personal Voice is only available on iPhone 12 or later,  iPads with M1 chip or later, and with iOS 17 or later.   "
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable necesita permiso para acceder a Voces Personales en este dispositivo.\n\nPuede habilitar el acceso en Ajustes %1$@."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable a besoin d'une autorisation pour accéder aux voix personnelles sur cet appareil.\n\nVous pouvez activer l'accès dans les paramètres de %1$@."
           }
         },
         "hi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "वोकेबल को इस डिवाइस पर व्यक्तिगत आवाज़ों तक पहुंचने के लिए अनुमति की आवश्यकता है।\n\nआप %1$@ सेटिंग्स में पहुंच सक्षम कर सकते हैं।"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable ha bisogno di permessi per accedere alle Voci Personali su questo dispositivo.\n\nPuoi abilitare l'accesso nelle Impostazioni di %1$@."
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable이 이 기기에서 개인 음성에 액세스하려면 권한이 필요합니다.\n\n%1$@ 설정에서 액세스를 활성화할 수 있습니다."
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable требуется разрешение на доступ к Personal Voices на этом устройстве.\n\nВы можете включить доступ в настройках %1$@."
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable cần có quyền truy cập Giọng nói cá nhân trên thiết bị này.\n\nBạn có thể kích hoạt quyền truy cập trong Cài đặt %1$@."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable 需要获得访问此设备上的个人语音的权限。\n\n您可以在%1$@ 设置中启用访问。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vocable 需要獲得存取此裝置上的個人語音的權限。\n\n您可以在%1$@ 設定中啟用存取。"
           }
         }
@@ -4489,7 +4489,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This %1$@ on %2$@ %3$@ does not support Personal Voice.\n\nPersonal Voice is available on iPhone 12/iPad Air (5th gen) and later with iOS 17 or later."
+            "value" : "This %1$@ on %2$@ %3$@ does not support Personal Voice.\n\nPersonal Voice is available on iPhone 12 or iPads with M1 or later, or with iOS 17 or later."
           }
         }
       }

--- a/Vocable/Supporting Files/Localizable.xcstrings
+++ b/Vocable/Supporting Files/Localizable.xcstrings
@@ -3926,7 +3926,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vocable needs permission to access Personal Voices on this device.\n\nYou can enable access in %1$@ Settings.  NOTE: Personal Voice is only available on iPhone 12 or later,  iPads with M1 chip or later, and with iOS 17 or later.   "
+            "value" : "Vocable needs permission to access Personal Voices on this device.\n\nYou can enable access in %1$@ Settings.  \n\nPersonal Voice is available on iOS 17+ on iPhone 12+ or iPad (M1 or later)."
           }
         },
         "es" : {
@@ -4489,7 +4489,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This %1$@ on %2$@ %3$@ does not support Personal Voice.\n\nPersonal Voice is available on iPhone 12 or iPads with M1 or later, or with iOS 17 or later."
+            "value" : "This %1$@ on %2$@ %3$@ does not support Personal Voice.\n\nPersonal Voice is available on iOS 17+ on iPhone 12+ or iPad (M1 or later).\n"
           }
         }
       }

--- a/Vocable/Supporting Files/Localizable.xcstrings
+++ b/Vocable/Supporting Files/Localizable.xcstrings
@@ -4234,6 +4234,28 @@
         }
       }
     },
+    "personal_voices.empty_state.unsupported.description" : {
+      "comment" : "Empty state description when the device or OS does not support Personal Voice. Placeholders: device model (e.g. iPhone), system name (e.g. iOS), system version (e.g. 17.0).",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This %1$@ on %2$@ %3$@ does not support Personal Voice.\n\nPersonal Voice is available on iPhone 12 and later with iOS 17 or later."
+          }
+        }
+      }
+    },
+    "personal_voices.empty_state.unsupported.title" : {
+      "comment" : "Title of the Personal Voices screen empty state when the device or OS does not support Personal Voice.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personal Voice Unsupported"
+          }
+        }
+      }
+    },
     "personal_voices.empty_state.not_authorized.button.title" : {
       "comment" : "Action button for the personal voices screen that will display a system prompt allowing access to their Personal Voice profiles stored on their device.",
       "localizations" : {


### PR DESCRIPTION
https://github.com/willowtreeapps/vocable-ios/issues/826

closes 826

# Description of Work
Add a compatibility error for personal voice on devices < iOS 17 and < iphone 12.  Also removed teh pagination footer.

| Before | After |
|--------|--------|
| <img width="1242" height="2688" alt="IMG_0144" src="https://github.com/user-attachments/assets/573e26e4-f8e0-4615-a0c6-43a35229bdb9" />| ![Screenshot 2026-02-20 at 8 22 03 AM](https://github.com/user-attachments/assets/81604543-de07-4025-860f-90d3c927e0cf)|


## Notes to Test (Optional)
Notes

---
