### PR TITLE
Add Foundation Model (on-device LLM) smart assist integration

### DIFF
--- a/Vocable.xcodeproj/project.pbxproj
+++ b/Vocable.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		2745402B2460DD490056EF98 /* Presets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2745402A2460DD490056EF98 /* Presets.swift */; };
 		2745402E2460DD760056EF98 /* presets.json in Resources */ = {isa = PBXBuildFile; fileRef = 2745402D2460DD760056EF98 /* presets.json */; };
 		30B979A524254CBC00309D7C /* WarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B979A424254CBC00309D7C /* WarningView.swift */; };
+		3D5803A381815281A67BF385 /* FoundationModelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F13099E92C28936DCFBF906 /* FoundationModelService.swift */; };
+		4CA05DA9B1B5CF42118BC059 /* SmartAssistServiceCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10EF9924A54CD798EC58EBEE /* SmartAssistServiceCoordinator.swift */; };
 		4E014DAA27EA53BC00561FC8 /* NSRange+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E014DA927EA53BC00561FC8 /* NSRange+.swift */; };
 		4E095237284E67770079381D /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E095236284E67770079381D /* View+.swift */; };
 		4E18DBF027FF49420043A019 /* DefaultGazeButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E18DBEF27FF49420043A019 /* DefaultGazeButtonStyle.swift */; };
@@ -45,6 +47,7 @@
 		4EB382A0284160AB00320E10 /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = 4EB3829F284160AB00320E10 /* Documentation.docc */; };
 		4EB6A59427FBF84B00F2BFB3 /* VocableGazeButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB6A59327FBF84B00F2BFB3 /* VocableGazeButtonStyle.swift */; };
 		4EE2D2EC27FE2FCA00299A1A /* ContentHuggingHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE2D2EB27FE2FCA00299A1A /* ContentHuggingHostingController.swift */; };
+		57905A1AAD5E8B8CCD67AF08 /* SmartAssistService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC87D24471EDBA0AD04028D5 /* SmartAssistService.swift */; };
 		622A6BFE283EB15200F75011 /* AccessibilityID+Settings+EditCategoryDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622A6BFD283EB15200F75011 /* AccessibilityID+Settings+EditCategoryDetails.swift */; };
 		622A6BFF283EB15200F75011 /* AccessibilityID+Settings+EditCategoryDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622A6BFD283EB15200F75011 /* AccessibilityID+Settings+EditCategoryDetails.swift */; };
 		622A6C00283EB15200F75011 /* AccessibilityID+Settings+EditCategoryDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622A6BFD283EB15200F75011 /* AccessibilityID+Settings+EditCategoryDetails.swift */; };
@@ -318,6 +321,7 @@
 		B8DA9DF223F30BAF00FEBE19 /* Cell+NibLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA9DF123F30BAF00FEBE19 /* Cell+NibLoading.swift */; };
 		B8DA9DF423F30BD200FEBE19 /* VectorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DA9DF323F30BD200FEBE19 /* VectorUtils.swift */; };
 		B8EB51D12409860A00F425A6 /* GazeableAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EB51CF2409860A00F425A6 /* GazeableAlertViewController.swift */; };
+		C49CE39628EB7EB098DA1903 /* SmartAssistResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD7E0265BC9AF9AA585A6DB /* SmartAssistResponse.swift */; };
 		CE12277624F586CB008F7866 /* CustomPhraseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12277524F586CB008F7866 /* CustomPhraseTests.swift */; };
 		CE12277824F58706008F7866 /* CustomCategoriesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12277724F58706008F7866 /* CustomCategoriesScreen.swift */; };
 		CE1406A224F3E8AD00C26225 /* SettingsScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1406A124F3E8AD00C26225 /* SettingsScreenTests.swift */; };
@@ -352,6 +356,7 @@
 
 /* Begin PBXFileReference section */
 		0E969127281C5F520097A3CC /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
+		10EF9924A54CD798EC58EBEE /* SmartAssistServiceCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SmartAssistServiceCoordinator.swift; sourceTree = "<group>"; };
 		130C00B420D2AD2A007C3163 /* Vocable.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Vocable.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		130C00B720D2AD2A007C3163 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		130C00C020D2AD2C007C3163 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -516,6 +521,7 @@
 		71B856432416CEB600CB163B /* ToastView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ToastView.xib; sourceTree = "<group>"; };
 		71DBE5EA240DE4D000BA8D01 /* WarningView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WarningView.xib; sourceTree = "<group>"; };
 		71FA2854242406540051498A /* SelectionModeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionModeViewController.swift; sourceTree = "<group>"; };
+		8F13099E92C28936DCFBF906 /* FoundationModelService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FoundationModelService.swift; sourceTree = "<group>"; };
 		9D15E0542271F0DC0058DF57 /* CursorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorView.swift; sourceTree = "<group>"; };
 		9DB58D4822666BC200E99C3B /* UIColor+AppExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+AppExtensions.swift"; sourceTree = "<group>"; };
 		A90D790427F205E90032254E /* VocableListCellPrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocableListCellPrimaryButton.swift; sourceTree = "<group>"; };
@@ -564,6 +570,7 @@
 		A9E665A6241A785F00FE577A /* CarouselGridCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselGridCollectionViewController.swift; sourceTree = "<group>"; };
 		A9FD68A428008AD3006ABA3F /* AddPhraseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhraseCollectionViewCell.swift; sourceTree = "<group>"; };
 		A9FD68A628009646006ABA3F /* NSAttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Helpers.swift"; sourceTree = "<group>"; };
+		AAD7E0265BC9AF9AA585A6DB /* SmartAssistResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SmartAssistResponse.swift; sourceTree = "<group>"; };
 		B225D67B2C29B8110007D003 /* KeyboardLayoutEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayoutEnvironment.swift; sourceTree = "<group>"; };
 		B2458E5F2BFE4C35007AF53D /* HighlightableContentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightableContentCell.swift; sourceTree = "<group>"; };
 		B24F02332BEBEF4E003C6BF9 /* mul */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = mul; path = mul.lproj/LaunchScreen.xcstrings; sourceTree = "<group>"; };
@@ -642,6 +649,7 @@
 		DCAF41472864B6F400502D7D /* Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		DCDF7E122832A3190009E75E /* PresetCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetCategoryTests.swift; sourceTree = "<group>"; };
 		DCF25CD42811AD2000DF766F /* PresetPhraseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetPhraseTests.swift; sourceTree = "<group>"; };
+		FC87D24471EDBA0AD04028D5 /* SmartAssistService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SmartAssistService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -786,6 +794,9 @@
 			children = (
 				220DDD4A2A53CAC30058C7A9 /* Models */,
 				220DDD542A53CAC30058C7A9 /* ListenAPIClient.swift */,
+				FC87D24471EDBA0AD04028D5 /* SmartAssistService.swift */,
+				10EF9924A54CD798EC58EBEE /* SmartAssistServiceCoordinator.swift */,
+				8F13099E92C28936DCFBF906 /* FoundationModelService.swift */,
 			);
 			path = APIClient;
 			sourceTree = "<group>";
@@ -796,6 +807,7 @@
 				220A558A2A8DD8E600612581 /* Reply.swift */,
 				220A558C2A8DD90900612581 /* Query.swift */,
 				220A558E2A8DDA2100612581 /* Exchange.swift */,
+				AAD7E0265BC9AF9AA585A6DB /* SmartAssistResponse.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1810,6 +1822,10 @@
 				622A6BFE283EB15200F75011 /* AccessibilityID+Settings+EditCategoryDetails.swift in Sources */,
 				30B979A524254CBC00309D7C /* WarningView.swift in Sources */,
 				B291D1102C5AC894006E9FA6 /* KeyboardLayoutMode.swift in Sources */,
+				57905A1AAD5E8B8CCD67AF08 /* SmartAssistService.swift in Sources */,
+				4CA05DA9B1B5CF42118BC059 /* SmartAssistServiceCoordinator.swift in Sources */,
+				3D5803A381815281A67BF385 /* FoundationModelService.swift in Sources */,
+				C49CE39628EB7EB098DA1903 /* SmartAssistResponse.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1916,7 +1932,7 @@
 		};
 		B277CDC32BFBDD68003BFACE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = B277CDC22BFBDD68003BFACE /* SwiftLintBuildToolPlugin */;
+			productRef = B277CDC22BFBDD68003BFACE /* plugin:SwiftLintBuildToolPlugin */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2490,7 +2506,7 @@
 			package = 6B8D3B712821C09200DDB9B7 /* XCRemoteSwiftPackageReference "mixpanel-swift" */;
 			productName = Mixpanel;
 		};
-		B277CDC22BFBDD68003BFACE /* SwiftLintBuildToolPlugin */ = {
+		B277CDC22BFBDD68003BFACE /* plugin:SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B277CDBA2BF502F2003BFACE /* XCRemoteSwiftPackageReference "SwiftLint" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";

--- a/Vocable/APIClient/FoundationModelService.swift
+++ b/Vocable/APIClient/FoundationModelService.swift
@@ -24,14 +24,17 @@ final class FoundationModelService: SmartAssistService {
     private let maxTurnsBeforeReset = 8
 
     private static let instructions = """
-        You are an assistant for an AAC (Augmentative and Alternative Communication) app. \
-        A person nearby is speaking to the user. The user cannot speak verbally and will \
-        select one of the responses you suggest.
+        You are helping someone with communication assistance needs have a conversation.
 
-        Given what was said, suggest 3 to 5 short, natural responses the user might want \
-        to say. Keep responses concise (under 10 words each). Include a mix of: \
-        direct answers to questions, conversational acknowledgments, and follow-up questions \
-        when appropriate.
+        You will be given a transcribed prompt from a speaker the user is talking to.
+        Respond with suggested replies the user might want to say.
+
+        - The maximum number of responses is 14. Prefer as few as possible. Do not always use 14.
+        - Prefer responses that do not reflect opinions.
+        - If an opinionated response is needed, include varying opinions.
+        - Responses should be short. Prefer 1-3 words if possible.
+        - If the prompt isn't clear, include one option that requests the speaker to reword the prompt.
+        - If a response can be 'yes' or 'no', include a simple 'yes' and 'no' in addition to the others.
         """
 
     // MARK: - SmartAssistService

--- a/Vocable/APIClient/FoundationModelService.swift
+++ b/Vocable/APIClient/FoundationModelService.swift
@@ -1,0 +1,109 @@
+//
+//  FoundationModelService.swift
+//  Vocable
+//
+//  Created on 3/31/26.
+//  Copyright © 2026 WillowTree. All rights reserved.
+//
+
+#if canImport(FoundationModels)
+import Foundation
+import FoundationModels
+
+@available(iOS 26, *)
+final class FoundationModelService: SmartAssistService {
+
+    // MARK: - Properties
+
+    private let model = SystemLanguageModel.default
+    private var session: LanguageModelSession?
+    private var turnCount = 0
+    private var lastUserResponse: (prompt: String, response: String)?
+
+    /// Proactively reset the session after this many turns to avoid context window exhaustion.
+    private let maxTurnsBeforeReset = 8
+
+    private static let instructions = """
+        You are an assistant for an AAC (Augmentative and Alternative Communication) app. \
+        A person nearby is speaking to the user. The user cannot speak verbally and will \
+        select one of the responses you suggest.
+
+        Given what was said, suggest 3 to 5 short, natural responses the user might want \
+        to say. Keep responses concise (under 10 words each). Include a mix of: \
+        direct answers to questions, conversational acknowledgments, and follow-up questions \
+        when appropriate.
+        """
+
+    // MARK: - SmartAssistService
+
+    func checkAvailability() async -> Bool {
+        guard model.isAvailable else {
+            return false
+        }
+        return model.supportsLocale()
+    }
+
+    func query(_ prompt: String) async throws -> [String] {
+        // Reset session proactively if we've had many turns
+        if turnCount >= maxTurnsBeforeReset {
+            resetConversation()
+        }
+
+        let session = getOrCreateSession()
+
+        // Build the prompt with conversation context
+        let fullPrompt: String
+        if let lastUserResponse {
+            fullPrompt = "The user selected the response: \"\(lastUserResponse.response)\". Now someone said: \"\(prompt)\""
+            self.lastUserResponse = nil
+        } else {
+            fullPrompt = "Someone said: \"\(prompt)\""
+        }
+
+        do {
+            let response = try await session.respond(
+                to: fullPrompt,
+                generating: SmartAssistResponse.self
+            )
+            turnCount += 1
+            return response.content.responses
+        } catch let error as LanguageModelSession.GenerationError {
+            switch error {
+            case .exceededContextWindowSize:
+                // Reset and retry once
+                resetConversation()
+                let freshSession = getOrCreateSession()
+                let retryResponse = try await freshSession.respond(
+                    to: "Someone said: \"\(prompt)\"",
+                    generating: SmartAssistResponse.self
+                )
+                turnCount = 1
+                return retryResponse.content.responses
+            default:
+                throw SmartAssistServiceError.internalError(underlying: error)
+            }
+        }
+    }
+
+    func userResponded(to prompt: String, with response: String) {
+        lastUserResponse = (prompt: prompt, response: response)
+    }
+
+    func resetConversation() {
+        session = nil
+        turnCount = 0
+        lastUserResponse = nil
+    }
+
+    // MARK: - Private
+
+    private func getOrCreateSession() -> LanguageModelSession {
+        if let session {
+            return session
+        }
+        let newSession = LanguageModelSession(instructions: Self.instructions)
+        self.session = newSession
+        return newSession
+    }
+}
+#endif

--- a/Vocable/APIClient/ListenAPIClient.swift
+++ b/Vocable/APIClient/ListenAPIClient.swift
@@ -33,12 +33,12 @@ enum ListenAPIClientError: Error {
     case unavailable
 }
 
-class ListenAPIClient {
+class ListenAPIClient: SmartAssistService {
     
     // MARK: - Properties
     
     private let session = URLSession(configuration: .default)
-    private var history: [Exchange] = []
+    private(set) var history: [Exchange] = []
     
     /// Storage for caching the availability check for the query API
     ///
@@ -138,6 +138,16 @@ class ListenAPIClient {
         }
     }
     
+    // MARK: - SmartAssistService
+
+    func checkAvailability() async -> Bool {
+        return await isAvailable()
+    }
+
+    func resetConversation() {
+        history = []
+    }
+
     func query(_ prompt: String) async throws -> [String] {
         guard await isAvailable() else {
             throw ListenAPIClientError.unavailable

--- a/Vocable/APIClient/Models/SmartAssistResponse.swift
+++ b/Vocable/APIClient/Models/SmartAssistResponse.swift
@@ -12,8 +12,8 @@ import FoundationModels
 @available(iOS 26, *)
 @Generable(description: "Suggested responses for an AAC user")
 struct SmartAssistResponse {
-    @Guide(description: "Short response phrases the user can select, under 10 words each",
-           .minimumCount(2), .maximumCount(5))
+    @Guide(description: "Short response phrases the user can select, preferring 1-3 words each",
+           .minimumCount(1), .maximumCount(14))
     var responses: [String]
 }
 #endif

--- a/Vocable/APIClient/Models/SmartAssistResponse.swift
+++ b/Vocable/APIClient/Models/SmartAssistResponse.swift
@@ -1,0 +1,19 @@
+//
+//  SmartAssistResponse.swift
+//  Vocable
+//
+//  Created on 3/31/26.
+//  Copyright © 2026 WillowTree. All rights reserved.
+//
+
+#if canImport(FoundationModels)
+import FoundationModels
+
+@available(iOS 26, *)
+@Generable(description: "Suggested responses for an AAC user")
+struct SmartAssistResponse {
+    @Guide(description: "Short response phrases the user can select, under 10 words each",
+           .minimumCount(2), .maximumCount(5))
+    var responses: [String]
+}
+#endif

--- a/Vocable/APIClient/SmartAssistService.swift
+++ b/Vocable/APIClient/SmartAssistService.swift
@@ -1,0 +1,31 @@
+//
+//  SmartAssistService.swift
+//  Vocable
+//
+//  Created on 3/31/26.
+//  Copyright © 2026 WillowTree. All rights reserved.
+//
+
+import Foundation
+
+/// A service that produces suggested response phrases for an AAC user
+/// given a transcribed speech prompt.
+protocol SmartAssistService: AnyObject {
+    /// Checks whether this service is currently available.
+    func checkAvailability() async -> Bool
+
+    /// Queries the service with a transcribed prompt and returns suggested responses.
+    func query(_ prompt: String) async throws -> [String]
+
+    /// Informs the service that the user selected a response, for conversation history tracking.
+    func userResponded(to prompt: String, with response: String)
+
+    /// Resets any accumulated conversation history.
+    func resetConversation()
+}
+
+enum SmartAssistServiceError: Error {
+    case unavailable
+    case contextWindowExceeded
+    case internalError(underlying: Error)
+}

--- a/Vocable/APIClient/SmartAssistServiceCoordinator.swift
+++ b/Vocable/APIClient/SmartAssistServiceCoordinator.swift
@@ -1,0 +1,87 @@
+//
+//  SmartAssistServiceCoordinator.swift
+//  Vocable
+//
+//  Created on 3/31/26.
+//  Copyright © 2026 WillowTree. All rights reserved.
+//
+
+import Foundation
+
+enum SmartAssistServiceType {
+    case foundationModels
+    case cloudAPI
+    case none
+}
+
+final class SmartAssistServiceCoordinator {
+
+    // MARK: - Properties
+
+    private let apiClient: ListenAPIClient
+
+    #if canImport(FoundationModels)
+    private var foundationModelService: (any SmartAssistService)?
+    #endif
+
+    private(set) var activeServiceType: SmartAssistServiceType = .none
+
+    // MARK: - Init
+
+    init(apiClient: ListenAPIClient) {
+        self.apiClient = apiClient
+
+        #if canImport(FoundationModels)
+        if #available(iOS 26, *) {
+            self.foundationModelService = FoundationModelService()
+        }
+        #endif
+    }
+
+    // MARK: - Public Methods
+
+    func query(_ prompt: String) async throws -> [String] {
+        // Try Foundation Models first
+        #if canImport(FoundationModels)
+        if #available(iOS 26, *), let fmService = foundationModelService {
+            if await fmService.checkAvailability() {
+                do {
+                    let responses = try await fmService.query(prompt)
+                    activeServiceType = .foundationModels
+                    return responses
+                } catch {
+                    // Foundation Models failed; fall through to API
+                }
+            }
+        }
+        #endif
+
+        // Fall back to Cloud API
+        guard await apiClient.checkAvailability() else {
+            activeServiceType = .none
+            throw SmartAssistServiceError.unavailable
+        }
+
+        let responses = try await apiClient.query(prompt)
+        activeServiceType = .cloudAPI
+        return responses
+    }
+
+    func userResponded(to prompt: String, with response: String) {
+        #if canImport(FoundationModels)
+        if #available(iOS 26, *) {
+            foundationModelService?.userResponded(to: prompt, with: response)
+        }
+        #endif
+        apiClient.userResponded(to: prompt, with: response)
+    }
+
+    func resetConversation() {
+        #if canImport(FoundationModels)
+        if #available(iOS 26, *) {
+            foundationModelService?.resetConversation()
+        }
+        #endif
+        apiClient.resetConversation()
+    }
+}

--- a/Vocable/AppConfig/ListenModeFeatureConfiguration.swift
+++ b/Vocable/AppConfig/ListenModeFeatureConfiguration.swift
@@ -10,6 +10,10 @@ import Foundation
 import Combine
 import CoreData
 
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
 final class ListenModeFeatureConfiguration: ObservableObject {
     
     static let shared = ListenModeFeatureConfiguration()
@@ -48,6 +52,15 @@ final class ListenModeFeatureConfiguration: ObservableObject {
     
     var smartAssistAvailable: Bool {
         true
+    }
+
+    var foundationModelsSupported: Bool {
+        #if canImport(FoundationModels)
+        if #available(iOS 26, *) {
+            return SystemLanguageModel.default.isAvailable
+        }
+        #endif
+        return false
     }
     
     private var cancellables = Set<AnyCancellable>()

--- a/Vocable/Features/Voice/ListeningResponseContentViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseContentViewController.swift
@@ -41,7 +41,7 @@ final class ListeningResponseContentViewController: PagingCarouselViewController
 
     var disposables = Set<AnyCancellable>()
     var synthesizedSpeechQueue: DispatchQueue!
-    var apiClient: ListenAPIClient?
+    var serviceCoordinator: SmartAssistServiceCoordinator?
     
     /// When listening mode was used to generate the `Content` displayed, set this to the prompt used to query the API.
     ///
@@ -91,9 +91,9 @@ final class ListeningResponseContentViewController: PagingCarouselViewController
         guard let utterance = diffableDataSource.itemIdentifier(for: indexPath) else { return }
         lastUtterance = utterance
 
-        if let apiClient,
+        if let serviceCoordinator,
            let trackingPrompt {
-            apiClient.userResponded(to: trackingPrompt, with: utterance)
+            serviceCoordinator.userResponded(to: trackingPrompt, with: utterance)
         }
         
         synthesizedSpeechQueue.async { [weak self] in

--- a/Vocable/Features/Voice/ListeningResponseViewController.swift
+++ b/Vocable/Features/Voice/ListeningResponseViewController.swift
@@ -89,7 +89,7 @@ final class ListeningResponseViewController: VocableViewController {
 
     private let synthesizedSpeechQueue = DispatchQueue(label: "speech_synthesis_queue", qos: .userInitiated)
     let classifier = VLClassifier()
-    let apiClient = ListenAPIClient()
+    let serviceCoordinator = SmartAssistServiceCoordinator(apiClient: ListenAPIClient())
 
     @PublishedValue private(set) var lastUtterance: String?
 
@@ -153,7 +153,7 @@ final class ListeningResponseViewController: VocableViewController {
 
         case .choices(let choices):
             let responseContentController = ListeningResponseContentViewController()
-            responseContentController.apiClient = apiClient
+            responseContentController.serviceCoordinator = serviceCoordinator
             responseContentController.content = choices
             responseContentController.trackingPrompt = trackingPrompt
             responseContentController.synthesizedSpeechQueue = synthesizedSpeechQueue
@@ -225,23 +225,15 @@ final class ListeningResponseViewController: VocableViewController {
                     self.delegate?.didUpdateSpeechResponse(transcription)
                 case .finalTranscription(let transcription):
                     self.delegate?.didUpdateSpeechResponse(transcription)
-                    
+
                     guard AppConfig.listeningMode.smartAssistAvailable,
-                          AppConfig.listeningMode.smartAssistEnabledPreference,
-                          apiClient.isAvailable != false
+                          AppConfig.listeningMode.smartAssistEnabledPreference
                     else {
                         self.classifier.classify(transcription)
                         return
                     }
-                    
-                    Task {
-                        let isAvailable = await self.apiClient.isAvailable()
-                        if isAvailable {
-                            self.fetchResponses(for: transcription)
-                        } else {
-                            self.classifier.classify(transcription)
-                        }
-                    }
+
+                    self.fetchResponses(for: transcription)
                     
                 default:
                     if self.speechRecognizerController.isListening {
@@ -254,10 +246,10 @@ final class ListeningResponseViewController: VocableViewController {
     private func fetchResponses(for prompt: String) {
         Task { @MainActor in
             do {
-                let responses = try await apiClient.query(prompt)
+                let responses = try await serviceCoordinator.query(prompt)
                 self.setContent(.choices(responses), trackingPrompt: prompt)
             } catch {
-                self.setContent(.empty(.vocableAPIFailure, action: .none))
+                self.classifier.classify(prompt)
             }
         }
     }


### PR DESCRIPTION
## Summary

### Changes by Chris Stroud
- Adds `FoundationModelService` — a new `SmartAssistService` implementation backed by Apple's on-device `FoundationModels` framework (iOS 26+)
- Adds `SmartAssistService` protocol and `SmartAssistServiceError` to unify the local and cloud backends behind a common interface
- Adds `SmartAssistServiceCoordinator` which implements a priority waterfall: try Foundation Models first, fall back to the cloud API, then fall back to the existing CoreML classifier if both fail
- Adds `SmartAssistResponse` — a `@Generable` struct used for structured output from the local model
- Wires the coordinator into `ListeningResponseViewController` and `ListeningResponseContentViewController`
- Adds `foundationModelsSupported` property to `ListenModeFeatureConfiguration`

### Changes by Andrew Carter
- Aligned the `FoundationModelService` system prompt and `SmartAssistResponse` generation guides to match the instructions used by the existing cloud API, so both backends produce consistent responses.

The cloud API uses the following system prompt:

```
You are helping someone with communication assistance needs have a conversation.

* You will be given a transcribed prompt from a speaker the user is talking to.
* You will call the show_responses function with responses to the speaker's prompt.
* The maximum number of responses is 14. Prefer as few as possible. Do not always use 14.
* Prefer responses that do not reflect opinions.
* If a opinionated response is needed, include varying opinions.
* Responses should be short. Prefer 1-3 words is possible.
* If the prompt isn't clear give one option in the responses that requests the speaker to reword the prompt.
* If a response can be 'yes' or 'no', include a simple 'yes' and 'no' responses in addition to the others.
```

The original `FoundationModelService` instructions diverged from this — it capped responses at 3–5, allowed up to 10 words per response, and had no guidance on opinions, yes/no responses, or unclear prompts. The `@Guide` on `SmartAssistResponse.responses` also enforced `.maximumCount(5)` at the schema level, which would have overridden the instructions. Both have been updated to match the API's behaviour.

## Test plan

- [ ] Build and run on an iOS 26 device/simulator with Foundation Models available — verify smart assist produces responses consistent with the cloud API (short, non-opinionated, yes/no included where appropriate, up to 14 responses)
- [ ] Verify fallback to cloud API when Foundation Models are unavailable
- [ ] Verify fallback to CoreML classifier when both Foundation Models and cloud API are unavailable
- [ ] Verify smart assist disabled path still routes directly to the CoreML classifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)